### PR TITLE
Faster build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export
 # Builds 'planet' binary
 planet: remove-temp-files
 	go install github.com/gravitational/planet/tool/planet
-	go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
+	@ln -sf $$GOPATH/bin/planet $(BUILDDIR)/rootfs/usr/bin/planet
 
 remove-temp-files:
 	@mkdir -p $(BUILDDIR)


### PR DESCRIPTION
Instead of `go build` Planet now uses `go install` for development builds. Then it symlinks `planet` executable into the temporary extracted RootFS.
