### PR TITLE
Few changes

### DIFF
--- a/lib/box/clt.go
+++ b/lib/box/clt.go
@@ -26,7 +26,7 @@ func Connect(path string) (ContainerServer, error) {
 }
 
 func (c *client) Enter(cfg ProcessConfig) error {
-	u := url.URL{Host: "cube", Scheme: "ws", Path: "/v1/enter"}
+	u := url.URL{Host: "planet", Scheme: "ws", Path: "/v1/enter"}
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return trace.Wrap(err)
@@ -42,7 +42,7 @@ func (c *client) Enter(cfg ProcessConfig) error {
 	conn, err := net.Dial("unix", c.path)
 	if err != nil {
 		return checkError(
-			trace.Wrap(err, "failed to connect to cube socket"))
+			trace.Wrap(err, "failed to connect to planet socket"))
 	}
 	clt, err := websocket.NewClient(wscfg, conn)
 	if err != nil {
@@ -51,6 +51,7 @@ func (c *client) Enter(cfg ProcessConfig) error {
 	defer clt.Close()
 
 	exitC := make(chan error, 2)
+
 	go func() {
 		_, err := io.Copy(cfg.Out, clt)
 		exitC <- err
@@ -64,6 +65,7 @@ func (c *client) Enter(cfg ProcessConfig) error {
 	log.Infof("connected to container namespace")
 
 	for i := 0; i < 2; i++ {
+		<-exitC
 		<-exitC
 	}
 	return nil

--- a/tool/planet/enter.go
+++ b/tool/planet/enter.go
@@ -14,7 +14,7 @@ import (
 )
 
 // enter initiates the process in the namespaces of the container
-// managed by the cube master process and mantains websocket connection
+// managed by the planet master process and mantains websocket connection
 // to proxy input and output
 func enter(rootfs string, cfg box.ProcessConfig) error {
 	log.Infof("enter: %v %#v", rootfs, cfg)

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -45,10 +45,10 @@ func run() error {
 		cstartInsecureRegistries = List(cstart.Flag("insecure-registry", "Optional insecure registries").OverrideDefaultFromEnvar("PLANET_INSECURE_REGISTRY"))
 
 		// stop a running container
-		cstop = app.Command("stop", "Stop cube container")
+		cstop = app.Command("stop", "Stop planet container")
 
 		// enter a running container
-		center      = app.Command("enter", "Enter running cube container")
+		center      = app.Command("enter", "Enter running planet container")
 		centerArgs  = center.Arg("cmd", "command to execute").Default("/bin/bash").String()
 		centerNoTTY = center.Flag("not-tty", "do not attach TTY to this process").Bool()
 		centerUser  = center.Flag("user", "user to execute the command").Default("root").String()
@@ -77,7 +77,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		setupSignalHanlders()
+		setupSignalHanlders(rootfs)
 		err = start(Config{
 			Rootfs:             rootfs,
 			Env:                *cstartEnv,
@@ -194,17 +194,12 @@ func findRootfs() (string, error) {
 
 // setupSignalHanlders sets up a handler to interrupt SIGTERM and SIGINT
 // allowing for a graceful shutdown via executing "stop" command
-func setupSignalHanlders() {
+func setupSignalHanlders(rootfs string) {
 	c := make(chan os.Signal, 1)
 	go func() {
 		sig := <-c
 		log.Infof("received a signal %v. stopping...\n", sig)
-		rootfs, err := findRootfs()
-		if err != nil {
-			log.Errorf("error: %v", err)
-			return
-		}
-		err = stop(rootfs)
+		err := stop(rootfs)
 		if err != nil {
 			log.Errorf("error: %v", err)
 		}

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -70,7 +70,7 @@ func start(conf Config) error {
 		},
 		Files:        conf.Files,
 		Mounts:       conf.Mounts,
-		DataDir:      "/var/run/cube",
+		DataDir:      "/var/run/planet",
 		InitUser:     "root",
 		InitArgs:     []string{"/bin/systemd"},
 		InitEnv:      []string{"container=libcontainer"},


### PR DESCRIPTION
1. Fixed #17 It was sitting trying to read from stdin in box/clt.go:61, I fixed that
   by passing null instead of stdin and replacing a "magic constant" of 2
   with len(channel)
2. Renamed "cube" -> "planet" in a few remaining places.
