### PR TITLE
Improved compatibility checks

### DIFF
--- a/Godeps/_workspace/src/github.com/gravitational/orbit/lib/check/check.go
+++ b/Godeps/_workspace/src/github.com/gravitational/orbit/lib/check/check.go
@@ -23,7 +23,7 @@ func SupportsAufs() (bool, error) {
 	// proc/filesystems for when aufs is supported
 	err := exec.Command("modprobe", "aufs").Run()
 	if err != nil {
-		return false, trace.Wrap(err)
+		return false, nil
 	}
 
 	f, err := os.Open("/proc/filesystems")

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILDDIR := $(shell realpath $(BUILDDIR))
 PLANETVER:=0.01
 export
 
-build: 
+build: $(BUILDDIR)/current
 	go install github.com/gravitational/planet/tool/planet
 	@ln -sf $$GOPATH/bin/planet $(BUILDDIR)/current/rootfs/usr/bin/planet
 
@@ -61,6 +61,7 @@ master-clean:
 
 dev-start: prepare-to-run
 	cd $(BUILDDIR)/current && sudo rootfs/usr/bin/planet start\
+		--debug \
 		--role=master\
 		--role=node\
 		--volume=/var/planet/etcd:/ext/etcd\
@@ -109,3 +110,5 @@ clean-docker-images: clean-containers
 		docker rmi -f $(DIRTY) ;\
 	fi
 
+$(BUILDDIR)/current:
+	@echo "You need to build the full image first. Run \"make dev\""

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ you will be running planet directly.
 
 ### Building (installing from source)
 
-You must have `Docker > 1.8.0` installed (and its daemon running) to build Planet. This means you
+You must have `Docker > 1.8.2` installed (and its daemon running) to build Planet. This means you
 should be in `docker` group and being able to run typical Docker commands like `docker run` without 
 using `sudo`.
 
@@ -126,8 +126,9 @@ make dev-start
 ```
 
 You will need another terminal to interact with it. To enter into a running Planet container, 
-you'll need to execute `make enter`. You will see Kubernetes components running, 
-with `ps -e` showing something like:
+you'll need to execute `make enter`. 
+
+You will see Kubernetes components running, with `ps -e` showing something like:
 
 ```
   PID TTY          TIME CMD

--- a/build.assets/makefiles/base/docker/docker.mk
+++ b/build.assets/makefiles/base/docker/docker.mk
@@ -6,7 +6,7 @@
 
 ARCH := x86_64
 OS := Linux
-VER := 1.6.2
+VER := 1.8.2
 
 $(ROOTFS)/usr/bin/docker: $(TARGETDIR)/docker
 # install socket-activated metadata service

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -35,7 +35,7 @@ $(ROOTFS)/bin/bash: clean-rootfs
 	@echo -e "\\n---> Creating RootFS for Planet image:\\n"
 # create rootfs based in RAM:
 	@mkdir -p $(ROOTFS)
-	sudo mount -t tmpfs -o size=400m tmpfs $(ROOTFS)
+	sudo mount -t tmpfs -o size=600m tmpfs $(ROOTFS)
 # populate Rootfs using docker image 'planet/base'
 	docker create --name=$(CONTAINERNAME) planet/base
 	@echo "Exporting base Docker image into a fresh RootFS into $(ROOTFS)...."

--- a/build.assets/makefiles/kubernetes/kubernetes.mk
+++ b/build.assets/makefiles/kubernetes/kubernetes.mk
@@ -1,6 +1,6 @@
 .PHONY: all
 
-VER := 92f21b3fe3399ae6e1c29979649ba7e64d6d096e
+VER := e3188f6ee7007000c5daf525c8cc32b4c5bf4ba8
 BINARIES := $(TARGETDIR)/kube-apiserver $(TARGETDIR)/kube-controller-manager $(TARGETDIR)/kube-scheduler $(TARGETDIR)/kubectl $(TARGETDIR)/kube-proxy $(TARGETDIR)/kubelet
 
 all: kubernetes.mk $(BINARIES)

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -33,9 +33,10 @@ func start(conf Config) error {
 		log.Infof("warning: %v", err)
 	}
 
+	// must ensure that AuFS is supported on the host:
 	ok, err := check.SupportsAufs()
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	if !ok {
 		return trace.Errorf("need aufs support on the machine")
@@ -43,7 +44,7 @@ func start(conf Config) error {
 
 	if conf.hasRole("master") {
 		if err := checkMounts(conf); err != nil {
-			return err
+			return trace.Wrap(err)
 		}
 	}
 


### PR DESCRIPTION
- Planet does not start if certain required cgroups, like `memory` are
  not enabled in the kernel
- Bumped Kubernetes to the latest master
- Bumped Docker from 1.6.2 to 1.8.2

This closes https://github.com/gravitational/wiki/issues/26
