### PR TITLE
update manifest with new arguments and fix the required argument

### DIFF
--- a/build.assets/orbit.manifest.json
+++ b/build.assets/orbit.manifest.json
@@ -14,17 +14,44 @@
             {
                 "type": "String",
                 "name": "masterip",
-                "env": "PLANET_MASTER_IP"
+                "env": "PLANET_MASTER_IP",
+                "cli": {"name": "master-ip"}
             },
             {
                 "type": "String",
+                "name": "publicip",
+                "env": "PLANET_PUBLIC_IP",
+                "cli": {"name": "public-ip"}
+            },            
+            {
+                "type": "String",
                 "name": "cloudprovider",
-                "env": "PLANET_CLOUD_PROVIDER"
+                "env": "PLANET_CLOUD_PROVIDER",
+                "cli": {"name": "cloud-provider"}
             },
             {
                 "type": "String",
                 "name": "clusterid",
-                "env": "PLANET_CLUSTER_ID"
+                "env": "PLANET_CLUSTER_ID",
+                "cli": {"name": "cluster-id"}
+            },
+            {
+                "type": "String",
+                "name": "statedir",
+                "env": "PLANET_STATE_DIR",
+                "cli": {"name": "state-dir"}
+            },
+            {
+                "type": "String",
+                "name": "podsubnet",
+                "env": "PLANET_POD_SUBNET",
+                "cli": {"name": "pod-subnet"}
+            },
+            {
+                "type": "String",
+                "name": "servicesubnet",
+                "env": "PLANET_SERVICE_SUBNET",
+                "cli": {"name": "service-subnet"}
             },
             {
                 "type": "Bool",

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -41,7 +41,7 @@ func run() error {
 		// start the container with planet
 		cstart = app.Command("start", "Start Planet container")
 
-		cstartPublicIP           = cstart.Flag("public-ip", "IP accessible by other nodes for inter-host communication").OverrideDefaultFromEnvar("PLANET_PUBLIC_IP").Required().IP()
+		cstartPublicIP           = cstart.Flag("public-ip", "IP accessible by other nodes for inter-host communication").OverrideDefaultFromEnvar("PLANET_PUBLIC_IP").IP()
 		cstartMasterIP           = cstart.Flag("master-ip", "IP of the master POD (defaults to public-ip)").OverrideDefaultFromEnvar("PLANET_MASTER_IP").IP()
 		cstartCloudProvider      = cstart.Flag("cloud-provider", "cloud provider name, e.g. 'aws' or 'gce'").OverrideDefaultFromEnvar("PLANET_CLOUD_PROVIDER").String()
 		cstartClusterID          = cstart.Flag("cluster-id", "id of the cluster").OverrideDefaultFromEnvar("PLANET_CLUSTER_ID").String()


### PR DESCRIPTION
This PR:
- Updates orbit manifest with new arguments for package manager
- Lifts `required` flag that conflicts with environment variables (in this library `OverrideDefaultFromEnvVar` is not compatible with `Required` flag
