### PR TITLE
planet: correct exit code propagation broken with the latest few ...

### DIFF
--- a/tool/planet/enter.go
+++ b/tool/planet/enter.go
@@ -3,9 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"os"
-	"strconv"
 
 	"github.com/gravitational/planet/Godeps/_workspace/src/github.com/docker/docker/pkg/term"
 	"github.com/gravitational/planet/Godeps/_workspace/src/github.com/gravitational/log"
@@ -14,25 +12,10 @@ import (
 	"github.com/gravitational/planet/lib/monitoring"
 )
 
-// commandOutput is a io.Writer that decodes structured process output and delegates
-// the plain text to w
-type commandOutput struct {
-	w        io.Writer
-	exitCode int
-}
-
-// exitError is an error that describes the event of a process exiting with a non-zero value
-type exitError struct {
-	trace.Traces
-	exitCode int
-}
-
 func enterConsole(rootfs, cmd, user string, tty bool, args []string) (err error) {
-	cmdOut := &commandOutput{w: os.Stdout}
-
 	cfg := box.ProcessConfig{
 		In:   os.Stdin,
-		Out:  cmdOut,
+		Out:  os.Stdout,
 		Args: append([]string{cmd}, args...),
 	}
 
@@ -45,9 +28,6 @@ func enterConsole(rootfs, cmd, user string, tty bool, args []string) (err error)
 	}
 
 	err = enter(rootfs, cfg)
-	if err == nil && cmdOut.exitCode != 0 {
-		err = &exitError{exitCode: cmdOut.exitCode}
-	}
 	return err
 }
 
@@ -126,32 +106,12 @@ func containerStatus() (ok bool, err error) {
 // if command failed, or command standard output otherwise
 func enterCommand(rootfs string, args []string) ([]byte, error) {
 	buf := &bytes.Buffer{}
-	cmdOut := &commandOutput{w: buf}
 	cfg := box.ProcessConfig{
 		User: "root",
 		Args: args,
 		In:   os.Stdin,
-		Out:  cmdOut,
+		Out:  buf,
 	}
 	err := enter(rootfs, cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if cmdOut.exitCode != 0 {
-		err = &exitError{exitCode: cmdOut.exitCode}
-	}
-	return buf.Bytes(), err
-}
-
-func (r *commandOutput) Write(p []byte) (n int, err error) {
-	var msg box.Message
-
-	err = json.Unmarshal(p, &msg)
-	r.w.Write([]byte(msg.Payload))
-	r.exitCode = msg.ExitCode
-	return len(p), err
-}
-
-func (err exitError) Error() string {
-	return "exit status " + strconv.FormatInt(int64(err.exitCode), 10)
+	return buf.Bytes(), trace.Wrap(err)
 }

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -24,8 +24,8 @@ func main() {
 	var err error
 
 	if err = run(); err != nil {
-		if errExit, ok := err.(*exitError); ok {
-			exitCode = errExit.exitCode
+		if errExit, ok := err.(*box.ExitError); ok {
+			exitCode = errExit.Code
 		}
 	}
 	os.Exit(exitCode)
@@ -153,7 +153,7 @@ func run() error {
 			var ok bool
 			ok, err = containerStatus()
 			if err == nil && !ok {
-				err = &exitError{exitCode: 1}
+				err = &box.ExitError{Code: 1}
 			}
 		} else {
 			rootfs, err = findRootfs()


### PR DESCRIPTION
... commits.

Previous attempt at propagating exit values from sub-commands used JSON
over websocket without considering websocket frames which, given certain
payload size will send a partial json leading to a decoding error and a
client closing its side with `broken pipe` error.
This change makes use of websocket's native JSON support which
understands (websocket) frames and works properly.
In doing so, the code was reduced to pretty much the original sans a few additions. The exit code error is now (properly) part of lib/box.
