### PR TITLE
planet: dns-bootstrap

### DIFF
--- a/build.assets/makefiles/master/dns/bootstrap.sh
+++ b/build.assets/makefiles/master/dns/bootstrap.sh
@@ -62,6 +62,21 @@ spec:
 EOM
 `
 
+function wait-k8s-apiserver {
+  echo "waiting for k8s api-server"
+
+  local n=30
+  while [ -n "$(kubectl version 2>&1 >/dev/null)" ] && [ "$n" -gt 0 ]; do
+    echo "failed to query k8s api-server version"
+    n=$(($n-1))
+    sleep 1
+  done
+
+  return 1
+}
+
+wait-k8s-apiserver
+
 # create kube-system namespace
 kubectl get namespace kube-system
 if [ "$?" != "0" ]; then


### PR DESCRIPTION
Added a check for apiserver to become available prior to communicating with it in the bootstrap script.
