### PR TITLE
fix situation when client is closed right after first election

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -56,7 +56,6 @@ func startLeaderClient(conf *LeaderConfig) (io.Closer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer client.Close()
 	if conf.Role == RoleMaster {
 		if err := client.AddVoter(conf.LeaderKey, conf.PublicIP, conf.Term); err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
this probably occured as a result of a port - we've been closing the client right after it was created, turning off leader election
