### PR TITLE
The k8s systemd services do not properly respond to termination requests

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
+++ b/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
@@ -16,3 +16,4 @@ Restart=always
 RestartSec=10
 User=planet
 Group=planet
+SuccessExitStatus=2

--- a/build.assets/makefiles/master/k8s-master/kube-scheduler.service
+++ b/build.assets/makefiles/master/k8s-master/kube-scheduler.service
@@ -10,3 +10,4 @@ Restart=always
 RestartSec=10
 User=planet
 Group=planet
+SuccessExitStatus=2


### PR DESCRIPTION
from systemd and are marked as failed once stopped (they exit with code
2 - `INVALIDARGUMENT`).
When systemd monitoring checker runs, it reports such units as failed
although they have been manually stopped.
This change define the exit code 2 (`INVALIDARGUMENT`) to be the success code
for both `kube-controller-manager`/`kube-scheduler` service units as they are supposed
to be inactive on a standby master.
