### PR TITLE
Dmitri/deploy to s3

### DIFF
--- a/build.assets/makefiles/deploy/Makefile
+++ b/build.assets/makefiles/deploy/Makefile
@@ -15,6 +15,5 @@ deploy:
 	@echo "Deploying $(BUILD_TAG) to Amazon S3"
 	$(foreach target,\
 		$(TARGETS),\
-		AWS_CONFIG_FILE=./deploy_artifacts.ini aws s3 cp \
-		$(BUILDDIR)/$(target)/planet-$(target).tar.gz \
-		$(BUILD_BUCKET_URL)/$(BUILD_TAG)/ --profile artifacts;)
+		aws s3 cp $(BUILDDIR)/$(target)/planet-$(target).tar.gz \
+		$(BUILD_BUCKET_URL)/$(BUILD_TAG)/;)

--- a/build.assets/makefiles/deploy/deploy_artifacts.ini
+++ b/build.assets/makefiles/deploy/deploy_artifacts.ini
@@ -1,4 +1,0 @@
-[profile artifacts]
-aws_access_key_id = AKIAJDZXWXLMXZUGWDHQ
-aws_secret_access_key = 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
-region = us-east-1


### PR DESCRIPTION
This PR adds a (basic) way to deploy and share build artifacts via Amazon S3.
I've created a bucket for this: s3://builds.gravitational.io
The other relevant parts are (neighbor PRs):
- gravity: pulling artifacts before trying to build them
- teleport: building and packaging a teleport-app.tar.gz
