### PR TITLE
Add curl to planet

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -q -y bridge-utils \
         e2fsprogs \
         libncurses5 \
         net-tools \
+        curl \
         iproute2 \
         lsb-base \
         dash \
@@ -18,4 +19,3 @@ RUN apt-get update && apt-get install -q -y bridge-utils \
 
 RUN groupadd --system --non-unique --gid 1000 planet ;\
     useradd --system --non-unique --no-create-home -g 1000 -u 1000 planet
-


### PR DESCRIPTION
Planet is lacking basic Linux utilities which makes it very inconvenient sometimes when you need to test something. Like, the other day I was trying to debug a failing pod healthcheck and could not find an easy way to make an HTTP request from within a planet.
