### PR TITLE
Increase k8s events ttl to 1 day

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/kube-apiserver \
         --etcd-cafile=/var/state/root.cert \
         --etcd-certfile=/var/state/etcd.cert \
         --etcd-keyfile=/var/state/etcd.key \
+        --event-ttl=24h0m0s \
         --bind-address=${PLANET_PUBLIC_IP} \
         --logtostderr=true $KUBE_CLOUD_FLAGS
 Restart=always


### PR DESCRIPTION
Otherwise they disappear too quickly (the default is 1 hour).
