### PR TITLE
More offline-container-import fixes

### DIFF
--- a/build.assets/makefiles/master/k8s-master/offline-container-import.service
+++ b/build.assets/makefiles/master/k8s-master/offline-container-import.service
@@ -4,7 +4,6 @@ Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/container-environment
-Type=oneshot
 Restart=on-failure
 ExecStart=/usr/bin/docker-import --dir=/etc/docker/offline/ --registry-addr=${KUBE_APISERVER}:5000
 

--- a/tool/docker-import/main.go
+++ b/tool/docker-import/main.go
@@ -130,7 +130,7 @@ func importWithRepo(repo Repo, path, registryAddr string) error {
 		return trace.Wrap(err, "failed to load image into docker:\n%s", out)
 	}
 	repoTag := fmt.Sprintf("%v/%v", registryAddr, repo.Tag())
-	out, err = dockerCommand("tag", repo.ImageURL(), repoTag)
+	out, err = dockerCommand("tag", "-f", repo.ImageURL(), repoTag)
 	if err != nil {
 		return trace.Wrap(err, "failed to tag image in registry:\n%s", out)
 	}


### PR DESCRIPTION
Turns out it is illegal to use `Type=oneshot` with `Restart=on-failure`.

Also, add force flag to `docker tag` so it does not fail on subsequent runs.
