### PR TITLE
Make etcdctl work in planet out-of-the-box

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -15,6 +15,10 @@ const (
 	EnvEtcdMemberName          = "ETCD_MEMBER_NAME"
 	EnvEtcdInitialCluster      = "ETCD_INITIAL_CLUSTER"
 	EnvEtcdInitialClusterState = "ETCD_INITIAL_CLUSTER_STATE"
+	EnvEtcdctlCertFile         = "ETCDCTL_CERT_FILE"
+	EnvEtcdctlKeyFile          = "ETCDCTL_KEY_FILE"
+	EnvEtcdctlCAFile           = "ETCDCTL_CA_FILE"
+	EnvEtcdctlPeers            = "ETCDCTL_PEERS"
 	EnvLeaderKey               = "KUBE_LEADER_KEY"
 	EnvRole                    = "PLANET_ROLE"
 	EnvClusterID               = "KUBE_CLUSTER_ID"
@@ -27,6 +31,11 @@ const (
 
 	DefaultLeaderTerm    = 10 * time.Second
 	DefaultEtcdEndpoints = "https://127.0.0.1:2379"
+
+	DefaultSecretsMountDir = "/var/state"
+	DefaultEtcdctlCertFile = DefaultSecretsMountDir + "/etcd.cert"
+	DefaultEtcdctlKeyFile  = DefaultSecretsMountDir + "/etcd.key"
+	DefaultEtcdctlCAFile   = DefaultSecretsMountDir + "/root.cert"
 
 	// APIServerDNSName defines the DNS entry name of the master node
 	APIServerDNSName = "apiserver"

--- a/tool/planet/enter.go
+++ b/tool/planet/enter.go
@@ -44,6 +44,10 @@ func enter(rootfs, socketPath string, cfg *box.ProcessConfig) error {
 	// tell bash to use environment we've created
 	cfg.Env.Upsert("ENV", ContainerEnvironmentFile)
 	cfg.Env.Upsert("BASH_ENV", ContainerEnvironmentFile)
+	cfg.Env.Upsert(EnvEtcdctlCertFile, DefaultEtcdctlCertFile)
+	cfg.Env.Upsert(EnvEtcdctlKeyFile, DefaultEtcdctlKeyFile)
+	cfg.Env.Upsert(EnvEtcdctlCAFile, DefaultEtcdctlCAFile)
+	cfg.Env.Upsert(EnvEtcdctlPeers, DefaultEtcdEndpoints)
 	s, err := box.Connect(&box.ClientConfig{
 		Rootfs:     rootfs,
 		SocketPath: socketPath,

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -463,7 +463,7 @@ func mountSecrets(config *Config) {
 	config.Mounts = append(config.Mounts, []box.Mount{
 		{
 			Src:      config.SecretsDir,
-			Dst:      "/var/state",
+			Dst:      DefaultSecretsMountDir,
 			Readonly: true,
 		},
 	}...)


### PR DESCRIPTION
With this update `etcdctl` works as soon as you enter the planet, without needing to specify multiple flags or export env vars:

``` bash
[root@196ee2de23d844d298f4d7b897122dbf ~]# gravity planet enter
root@196ee2de23d844d298f4d7b897122dbf:/# etcdctl ls /
/coreos.com
/planet
/registry
/teleport
```
