### PR TITLE
Fix a few uncommon problems

### DIFF
--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -122,7 +122,7 @@ func Start(cfg Config) (*Box, error) {
 
 	devices, err := enum.Devices()
 	if err != nil {
-		log.Fatalln(err)
+		return nil, trace.Wrap(err, "failed to enumerate available devices")
 	}
 
 	var disks []*configs.Device

--- a/tool/planet/secrets.go
+++ b/tool/planet/secrets.go
@@ -55,7 +55,7 @@ func initCA(hosts []string, dir string) (configCA *keyPairConfig, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	w := &fileWriter{perms: 06444, dir: dir, baseName: CertificateAuthorityKeyPair}
+	w := &fileWriter{perms: 0644, dir: dir, baseName: CertificateAuthorityKeyPair}
 	w.write("cert", string(cert))
 	w.write("key", string(key))
 	configCA = &keyPairConfig{


### PR DESCRIPTION
- swapped accidental `log.Fatalln` via `trace.Wrap`
- corrected the file mode for `root.cert` from `06444` (which resulted in `0444`) to `0644` so that the file is writable
