### PR TITLE
Ignore expected errors when handling devices

### DIFF
--- a/tool/planet/devices.go
+++ b/tool/planet/devices.go
@@ -25,7 +25,7 @@ func createDevice(device *configs.Device) error {
 func removeDevice(node string) (err error) {
 	if err = os.Remove(node); err != nil && os.IsNotExist(err) {
 		// Ignore `file not found` errors
-		err = nil
+		return nil
 	}
 	return trace.Wrap(err)
 }


### PR DESCRIPTION
- `file not found` errors when removing device nodes
- `file already exists` errors when creating device nodes
