### PR TITLE
Add some users to buildbox

### DIFF
--- a/build.assets/docker/passwd
+++ b/build.assets/docker/passwd
@@ -21,14 +21,23 @@ systemd-network:x:101:104:systemd Network Management,,,:/run/systemd/netif:/bin/
 systemd-resolve:x:102:105:systemd Resolver,,,:/run/systemd/resolve:/bin/false
 systemd-bus-proxy:x:103:106:systemd Bus Proxy,,,:/run/systemd:/bin/false
 messagebus:x:104:107::/var/run/dbus:/bin/false
+planet1:x:991:991::/home/planet:/bin/sh
+planet2:x:992:992::/home/planet:/bin/sh
+planet3:x:993:993::/home/planet:/bin/sh
+planet4:x:994:994::/home/planet:/bin/sh
+planet5:x:995:995::/home/planet:/bin/sh
+planet6:x:996:996::/home/planet:/bin/sh
+planet7:x:997:997::/home/planet:/bin/sh
+planet8:x:998:998::/home/planet:/bin/sh
+planet9:x:999:999::/home/planet:/bin/sh
 planet:x:1000:1000::/home/planet:/bin/sh
-planet1:x:999:1000::/home/planet:/bin/sh
-planet2:x:998:1000::/home/planet:/bin/sh
-planet3:x:997:1000::/home/planet:/bin/sh
-planet4:x:996:1000::/home/planet:/bin/sh
-planet5:x:995:1000::/home/planet:/bin/sh
-planet6:x:994:1000::/home/planet:/bin/sh
-planet7:x:993:1000::/home/planet:/bin/sh
-planet8:x:992:1000::/home/planet:/bin/sh
-planet8:x:991:1000::/home/planet:/bin/sh
-planet8:x:990:1000::/home/planet:/bin/sh
+planet11:x:1001:1001::/home/planet:/bin/sh
+planet12:x:1002:1002::/home/planet:/bin/sh
+planet13:x:1003:1003::/home/planet:/bin/sh
+planet14:x:1004:1004::/home/planet:/bin/sh
+planet15:x:1005:1005::/home/planet:/bin/sh
+planet16:x:1006:1006::/home/planet:/bin/sh
+planet17:x:1007:1007::/home/planet:/bin/sh
+planet18:x:1008:1008::/home/planet:/bin/sh
+planet19:x:1009:1009::/home/planet:/bin/sh
+planet20:x:1010:1010::/home/planet:/bin/sh


### PR DESCRIPTION
We need to add users with uids higher than 1000, because all distros of Linux using 1000+ uids for normal users, not 1000- ones.

fix https://github.com/gravitational/gravity/issues/728
