### PR TITLE
Do not set apiserver entry to self in /etc/hosts on start

### DIFF
--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -177,6 +177,8 @@ func run() error {
 		cleaderEtcdEndpoints = List(cleader.Flag("etcd-endpoints", "List of comma-separated etcd endpoints").Default(DefaultEtcdEndpoints))
 		cleaderPause         = cleader.Command("pause", "Pause leader election participation for this node")
 		cleaderResume        = cleader.Command("resume", "Resume leader election participation for this node")
+		cleaderView          = cleader.Command("view", "Dislpay the IP address of the active master")
+		cleaderViewKey       = cleaderView.Flag("leader-key", "Etcd key holding the new leader").Required().String()
 	)
 
 	cmd, err := app.Parse(args[1:])
@@ -271,6 +273,14 @@ func run() error {
 		} else {
 			err = leaderResume(cleaderPublicIP.String(), memberKey, etcdConf)
 		}
+	case cleaderView.FullCommand():
+		etcdConf := &etcdconf.Config{
+			Endpoints: *cleaderEtcdEndpoints,
+			CAFile:    *cleaderEtcdCAFile,
+			CertFile:  *cleaderEtcdCertFile,
+			KeyFile:   *cleaderEtcdKeyFile,
+		}
+		err = leaderView(*cleaderViewKey, etcdConf)
 
 	// "start" command
 	case cstart.FullCommand():

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -173,6 +173,7 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 	if err = setHosts(config, []utils.HostEntry{
 		{IP: "127.0.0.1", Hostnames: "localhost localhost.localdomain localhost4 localhost4.localdomain4"},
 		{IP: "::1", Hostnames: "localhost localhost.localdomain localhost6 localhost6.localdomain6"},
+		{IP: config.MasterIP, Hostnames: APIServerDNSName},
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Instead, have passive planet master nodes receive the IP of the active master on command line.

Adds a new command `planet leader view` to retrieve the IP address of the currently active master.
