### PR TITLE
agent: stop the master service units unconditionally as soon as the node

### DIFF
--- a/build.assets/makefiles/master/k8s-master/k8s-master.mk
+++ b/build.assets/makefiles/master/k8s-master/k8s-master.mk
@@ -5,14 +5,13 @@ BINDIR:=$(ASSETDIR)/k8s-$(KUBE_VER)
 all: k8s-master.mk
 	@echo "\n---> Building master k8s components\n"
 	cp -af ./kube-apiserver.service $(ROOTFS)/lib/systemd/system
-	ln -sf /lib/systemd/system/kube-apiserver.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	cp -af ./kube-controller-manager.service $(ROOTFS)/lib/systemd/system
-	ln -sf /lib/systemd/system/kube-controller-manager.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	cp -af ./kube-scheduler.service $(ROOTFS)/lib/systemd/system
-	ln -sf /lib/systemd/system/kube-scheduler.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	cp -af ./kube-kubelet.service $(ROOTFS)/lib/systemd/system
-	ln -sf /lib/systemd/system/kube-kubelet.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	cp -af ./kube-proxy.service $(ROOTFS)/lib/systemd/system
+	ln -sf /lib/systemd/system/kube-apiserver.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
+	ln -sf /lib/systemd/system/kube-controller-manager.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
+	ln -sf /lib/systemd/system/kube-kubelet.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	ln -sf /lib/systemd/system/kube-proxy.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	install -m 0755 $(BINDIR)/kube-apiserver $(ROOTFS)/usr/bin
 	install -m 0755 $(BINDIR)/kube-controller-manager $(ROOTFS)/usr/bin

--- a/build.assets/makefiles/node/k8s-node/k8s-node.mk
+++ b/build.assets/makefiles/node/k8s-node/k8s-node.mk
@@ -5,8 +5,8 @@ BINDIR:=$(ASSETDIR)/k8s-$(KUBE_VER)
 all: 
 	@echo "\n---> Building Kubernets-node components (kubelet, kube-proxy)\n"
 	cp -af ./kube-kubelet.service $(ROOTFS)/lib/systemd/system
-	ln -sf /lib/systemd/system/kube-kubelet.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	cp -af ./kube-proxy.service $(ROOTFS)/lib/systemd/system
+	ln -sf /lib/systemd/system/kube-kubelet.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	ln -sf /lib/systemd/system/kube-proxy.service  $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 	install -m 0755 $(BINDIR)/kube-proxy $(ROOTFS)/usr/bin
 	install -m 0755 $(BINDIR)/kubelet $(ROOTFS)/usr/bin


### PR DESCRIPTION
loses the leader status.
build: do not enable the kube-scheduler service by default when creating the rootfs.
