### PR TITLE
etcd promotion: restart apiserver after restarting etcd as it has etcd

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -56,4 +56,9 @@ const (
 
 	// LocalDNSIP is the IP of the local DNS server
 	LocalDNSIP = "127.0.0.1"
+
+	// ETCDServiceName names the service unit for etcd
+	ETCDServiceName = "etcd.service"
+	// APIServerServiceName names the service unit for k8s apiserver
+	APIServerServiceName = "kube-apiserver.service"
 )

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -59,7 +59,13 @@ func etcdPromote(name, initialCluster, initialClusterState string) error {
 		return trace.Wrap(err)
 	}
 
-	out, err = exec.Command("/bin/systemctl", "start", "etcd").CombinedOutput()
+	out, err = exec.Command("/bin/systemctl", "start", ETCDServiceName).CombinedOutput()
+	log.Infof("starting etcd: %v", string(out))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	out, err = exec.Command("/bin/systemctl", "start", APIServerServiceName).CombinedOutput()
 	log.Infof("starting etcd: %v", string(out))
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -652,7 +652,6 @@ var masterUnits = []string{
 	"docker",
 	"kube-apiserver",
 	"kube-controller-manager",
-	"kube-scheduler",
 }
 
 var nodeUnits = []string{


### PR DESCRIPTION
set as a dependency and systemd will not automatically restart apiserver in this case.
Remove `kube-scheduler` from the list of master units to monitor during startup as it has been removed from the list of automatically starting services.
