### PR TITLE
allow specifying search domains

### DIFF
--- a/lib/utils/dns.go
+++ b/lib/utils/dns.go
@@ -60,6 +60,16 @@ func (d *DNSConfig) UpsertServer(ip string) {
 	d.Servers = append([]string{ip}, d.Servers...)
 }
 
+// UpsertSearchDomain adds a search domain suffix to search list
+func (d *DNSConfig) UpsertSearchDomain(domain string) {
+	for _, name := range d.Search {
+		if name == domain {
+			return
+		}
+	}
+	d.Search = append(d.Search, domain)
+}
+
 // String returns resolv.conf serialized version of config
 func (d *DNSConfig) String() string {
 	buf := &bytes.Buffer{}

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -20,6 +20,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer"
 )
 
+const DefaultSearchDomain = "cluster.local"
+
 const MinKernelVersion = 310
 const (
 	CheckKernel          = true
@@ -422,6 +424,7 @@ func addResolv(config *Config) error {
 		return trace.Wrap(err)
 	}
 	cfg.UpsertServer(config.PublicIP)
+	cfg.UpsertSearchDomain(DefaultSearchDomain)
 	cfg.Ndots = DNSNdots
 	cfg.Timeout = DNSTimeout
 


### PR DESCRIPTION
I don't think there's a more clever way to 'read' in 'cluster.local', but this will specify it as a default search domain.
