### PR TITLE
re-election fix and error propagation

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -352,11 +352,11 @@
 		},
 		{
 			"ImportPath": "github.com/gravitational/coordinate/config",
-			"Rev": "8a4be2c6a0a3d395180ef69f160a726f930e17ea"
+			"Rev": "19eb5792cfb46f415a7bd8c27e3cbe33a1fa1bcb"
 		},
 		{
 			"ImportPath": "github.com/gravitational/coordinate/leader",
-			"Rev": "8a4be2c6a0a3d395180ef69f160a726f930e17ea"
+			"Rev": "19eb5792cfb46f415a7bd8c27e3cbe33a1fa1bcb"
 		},
 		{
 			"ImportPath": "github.com/gravitational/go-udev",

--- a/vendor/github.com/gravitational/coordinate/leader/leader.go
+++ b/vendor/github.com/gravitational/coordinate/leader/leader.go
@@ -152,6 +152,15 @@ func (l *Client) AddWatch(key string, retry time.Duration, valuesC chan string) 
 			return
 		}
 
+		// make sure we always send the first actual value
+		if resp != nil && resp.Node != nil {
+			select {
+			case valuesC <- resp.Node.Value:
+			case <-l.closeC:
+				return
+			}
+		}
+
 		var sentAnything bool
 		for {
 			resp, err = watcher.Next(ctx)


### PR DESCRIPTION
Make sure planet agent receives current value of the election var,
otherwise it fails to start voter.

Propagate errors in case if we failed to register voter to the process
