### PR TITLE
Instead of relying on explicit systemd dependency chain which breaks

### DIFF
--- a/build.assets/makefiles/base/agent/planet-agent.service
+++ b/build.assets/makefiles/base/agent/planet-agent.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Planet Agent service
 Documentation=https://github.com/gravitational/planet
-After=etcd.service serf.service
-Requires=etcd.service serf.service
+Wants=etcd.service serf.service
 
 [Service]
 Restart=always
@@ -10,6 +9,8 @@ RestartSec=5
 EnvironmentFile=/etc/container-environment
 LimitNOFILE=40000
 LimitNPROC=1048576
+ExecStartPre=/bin/systemctl is-active etcd.service
+ExecStartPre=/bin/systemctl is-active serf.service
 ExecStart=/usr/bin/planet --debug agent \
         --name=${PLANET_AGENT_NAME} \
         --rpc-addr=${PLANET_PUBLIC_IP}:7575 \

--- a/build.assets/makefiles/base/docker/docker.service
+++ b/build.assets/makefiles/base/docker/docker.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Docker
 Documentation=https://docs.docker.com
-After=flanneld.service docker.socket
-Requires=docker.socket
+Wants=flanneld.service docker.socket
 
 [Service]
 Type=notify
@@ -15,6 +14,8 @@ Environment="DOCKER_PIDFILE=/var/run/docker.pid"
 ExecStartPre=-/sbin/ip link set dev docker0 down
 ExecStartPre=-/sbin/brctl delbr docker0
 ExecStartPre=-/bin/rm -f /var/run/docker.pid
+ExecStartPre=/bin/systemctl is-active flanneld.service
+ExecStartPre=/bin/systemctl is-active docker.socket
 ExecStart=/usr/bin/docker daemon -H fd:// --mtu=${FLANNEL_MTU} --iptables=false --ip-masq=false --bip=${FLANNEL_SUBNET} --graph=/ext/docker $DOCKER_OPTS
 Restart=always
 RestartSec=5

--- a/build.assets/makefiles/base/docker/registry.service
+++ b/build.assets/makefiles/base/docker/registry.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Local Docker Registry
-Requires=docker.service
-After=docker.service
+Wants=docker.service
 
 [Service]
+ExecStartPre=/bin/systemctl is-active docker.service
 ExecStart=/usr/bin/registry serve /etc/docker/registry/config.yml
 Restart=always
 RestartSec=10

--- a/build.assets/makefiles/base/network/flanneld.service
+++ b/build.assets/makefiles/base/network/flanneld.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Flannel
 Documentation=https://github.com/coreos/flannel
-After=etcd.service
+Wants=etcd.service
 
 [Service]
 Restart=always
@@ -20,6 +20,7 @@ ExecStartPre=/usr/bin/etcdctl \
     --key-file=/var/state/etcd.key \
     --ca-file=/var/state/root.cert \
     --peers https://127.0.0.1:4001 set /coreos.com/network/config '{"Network":"${KUBE_POD_SUBNET}", "Backend": {"Type": "${FLANNEL_BACKEND}"}}'
+ExecStartPre=/bin/systemctl is-active etcd.service
 ExecStart=/usr/bin/flanneld \
     --ip-masq=true \
     --etcd-endpoints https://127.0.0.1:4001,https://127.0.0.1:2379 \

--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Kubernetes API Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-Requires=etcd.service
-After=etcd.service
+Wants=etcd.service
 
 [Service]
 EnvironmentFile=/etc/container-environment
 ExecStartPre=/usr/bin/scripts/wait-for-etcd.sh
+ExecStartPre=/bin/systemctl is-active etcd.service
 ExecStart=/usr/bin/kube-apiserver \
         --insecure-bind-address=127.0.0.1 \
         --insecure-port=8080 \

--- a/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
+++ b/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-Requires=kube-apiserver.service
+Wants=kube-apiserver.service
 
 [Service]
 EnvironmentFile=/etc/container-environment
+ExecStartPre=/bin/systemctl is-active kube-apiserver.service
 ExecStart=/usr/bin/kube-controller-manager \
         --service-account-private-key-file=/var/state/apiserver.key \
         --root-ca-file=/var/state/root.cert \

--- a/build.assets/makefiles/master/k8s-master/kube-kubelet.service
+++ b/build.assets/makefiles/master/k8s-master/kube-kubelet.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/kubernetes/kubernetes
-Requires=docker.service
-After=docker.service
+Wants=docker.service
 
 [Service]
 EnvironmentFile=/etc/container-environment
+ExecStartPre=/bin/systemctl is-active docker.service
 ExecStart=/usr/bin/kubelet \
         --address=0.0.0.0 \
         --port=10250 \

--- a/build.assets/makefiles/master/k8s-master/kube-scheduler.service
+++ b/build.assets/makefiles/master/k8s-master/kube-scheduler.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Kubernetes Scheduler
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-Requires=kube-apiserver.service
+Wants=kube-apiserver.service
 
 [Service]
+ExecStartPre=/bin/systemctl is-active kube-apiserver.service
 ExecStart=/usr/bin/kube-scheduler --master=https://apiserver:6443 --kubeconfig=/etc/kubernetes/scheduler.kubeconfig
 Restart=always
 RestartSec=10

--- a/build.assets/makefiles/master/k8s-master/offline-container-import.service
+++ b/build.assets/makefiles/master/k8s-master/offline-container-import.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Prepackaged Kubernetes container images
-Requires=docker.service
+Wants=docker.service
 
 [Service]
 EnvironmentFile=/etc/container-environment
 Restart=on-failure
+RestartSec=5
+ExecStartPre=/bin/systemctl is-active docker.service
 ExecStart=/usr/bin/docker-import --dir=/etc/docker/offline/ --registry-addr=${KUBE_APISERVER}:5000
 
 [Install]


### PR DESCRIPTION
with a dependency failing multiple times, use "Wants/ExecStartPre=systemctl is-active dependency" to build a resilient dependency chain.
Reference: http://unix.stackexchange.com/questions/213185/restarting-systemd-service-on-dependency-failure/216254#216254

Updates #https://github.com/gravitational/gravity/issues/1160
