### PR TITLE
Configure planet bash to be more user-friendly

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -1,6 +1,7 @@
 FROM planet/os
 
 RUN apt-get update && apt-get install -q -y bridge-utils \
+        bash-completion \
         kmod \
         iptables \
         libdevmapper1.02.1 \

--- a/build.assets/docker/bashrc
+++ b/build.assets/docker/bashrc
@@ -1,0 +1,35 @@
+
+if [[ -f /etc/bash_completion ]]; then
+    source /etc/bash_completion
+fi
+
+_kubectl_completion() {
+    source <(kubectl completion bash)
+}
+
+_start() {
+    _kubectl_completion
+}
+
+HISTCONTROL=ignoreboth
+HISTSIZE=1000
+HISTFILESIZE=2000
+PROMPT_DIRTRIM=3
+
+shopt -s histappend
+shopt -s checkwinsize
+shopt -s autocd
+shopt -s nocaseglob
+shopt -s cdspell
+shopt -s cmdhist
+shopt -s dirspell
+
+export PS1='\t \u@\h:\w\$ '
+export EDITOR="/usr/bin/vim"
+export VIEWER="less"
+export PAGER="less"
+export SELECTED_EDITOR=$EDITOR
+export HISTTIMEFORMAT="%y.%m.%d %T "
+
+_start
+

--- a/build.assets/docker/os.dockerfile
+++ b/build.assets/docker/os.dockerfile
@@ -19,6 +19,7 @@ RUN (apt-get clean \
 	&& apt-get install -q -y less \
 	&& apt-get install -q -y locales \
 	&& apt-get -t jessie-backports install -q -y systemd)
+ADD bashrc /etc/bash.bashrc
 
 # Set locale to en_US.UTF-8
 RUN (locale-gen \


### PR DESCRIPTION
Enabled bash and kubectl (no more copy-pasting and typing all the `j6fd6a`s) completion. Also properly set some environment vars. Some cd and history tuning.

Tested it, looks like convenient and works fine.