### PR TITLE
Dmitri/signals - Backport to 1.x

### DIFF
--- a/build.assets/orbit.manifest.json
+++ b/build.assets/orbit.manifest.json
@@ -17,7 +17,8 @@
         "User": "0",
         "Type": "simple",
         "Restart": "always",
-        "KillMode": "none",
+        "KillMode": "mixed",
+        "KillSignal": "SIGRTMIN+13",
         "StartPreCommand": "-/bin/rm /var/run/planet.socket",
         "StopPostCommand": "-/bin/rm /var/run/planet.socket",
         "StopCommand": "stop"

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -224,12 +224,6 @@ func Start(cfg Config) (*Box, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	st, err := container.Status()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	log.Infof("container status: %v %v", st, err)
-
 	// start the API webserver (the sooner the better, so if it can't start we can
 	// fail sooner)
 	socketPath := serverSockPath(cfg.Rootfs, cfg.SocketPath)
@@ -259,6 +253,12 @@ func Start(cfg Config) (*Box, error) {
 		listener.Close()
 		return nil, trace.Wrap(err)
 	}
+
+	status, err := container.Status()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	log.Infof("container status: %v (err=%v)", status, err)
 
 	return &Box{
 		Process:     process,


### PR DESCRIPTION
 * Extend list of signal traps to handle otherwise terminal signals (e.g. SIGUSRx or SIGALRM)
 * Configure `mixed` KillMode for planet with custom KillSignal (SIGRTMIN+13) which immediately terminates the systemd (equivalent of `systemd halt`)

Combination of these measures will allow planet to avoid running into situation with multiple systemd hierarchies active as as the case previously if planet was either killed or received an unexpected signal.