### PR TITLE
Add socat to enable port-forwarding.

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install -q -y bridge-utils \
         coreutils \
         lsof \
         socat \
+        nmap \
+        netcat \
         dnsmasq ; \
     apt-get -y autoclean; apt-get -y clean
 


### PR DESCRIPTION
 It's an essential function for Helm to Tiller communication.

Because Helm using gRPC (not HTTP) we can't use proxying like for Bandwagon: it requires TCP port-forwarding, which requires socat to present on all of k8s nodes.