### PR TITLE
Quote env vars in container environment

### DIFF
--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -333,8 +334,13 @@ func ReadEnvironment(path string) (vars EnvVars, err error) {
 		if len(keyVal) != 2 {
 			continue
 		}
-		vars.Upsert(keyVal[0], strings.TrimSuffix(strings.TrimPrefix(
-			keyVal[1], `"`), `"`)) // strip quotes from value
+		// the value may be quoted (if the file was previously written by WriteEnvironment above)
+		val, err := strconv.Unquote(keyVal[1])
+		if err != nil {
+			vars.Upsert(keyVal[0], keyVal[1])
+		} else {
+			vars.Upsert(keyVal[0], val)
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/box/srv_test.go
+++ b/lib/box/srv_test.go
@@ -29,6 +29,10 @@ func (s *SrvSuite) TestWriteReadEnvironment(c *check.C) {
 			Name: "EMPTY_VAR",
 			Val:  "",
 		},
+		{
+			Name: "WITH_QUOTES",
+			Val:  `blah "blah" blah`,
+		},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -38,4 +42,5 @@ func (s *SrvSuite) TestWriteReadEnvironment(c *check.C) {
 	c.Assert(env.Get("DOCKER_OPTS"), check.Equals,
 		"--storage-driver=devicemapper --exec-opt native.cgroupdriver=cgroupfs")
 	c.Assert(env.Get("EMPTY_VAR"), check.Equals, "")
+	c.Assert(env.Get("WITH_QUOTES"), check.Equals, `blah "blah" blah`)
 }


### PR DESCRIPTION
Our `/etc/container-environment` file does not enclose env var values in quotes, but they may contain spaces and so it leads to all sorts of issues when sourcing it, e.g. https://github.com/gravitational/gravity/issues/1574.

This PR makes sure all vars in container environment file are quoted which seems appropriate. For example, standard `/etc/environment` on my box also quotes `PATH` in it.