### PR TITLE
Dmitri/1430 overlayfs2

### DIFF
--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -159,7 +159,7 @@ users:
 - name: default
   user:
     client-certificate: /var/lib/gravity/secrets/scheduler.cert
-    client-key: /var/lib/gravity/secrets/scheduler.key
+    client-key: /var/lib/gravity/secrets/kubelet.key
 contexts:
 - name: default
   context:


### PR DESCRIPTION
Use scheduler's certificate for `kubectl` configuration to be able to use the config for `gravity sh`