### PR TITLE
Bump to k8s v1.5.3 to fix the regression in "kubectl logs" not printi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ASSETS := $(PWD)/build.assets
 BUILD_ASSETS := $(PWD)/build/assets
 BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
-KUBE_VER := v1.5.2
+KUBE_VER := v1.5.3
 DOCKER_VER := 1.12.6-0~debian-jessie
 PUBLIC_IP := 127.0.0.1
 export


### PR DESCRIPTION
Bump to k8s v1.5.3 to fix the regression in "kubectl logs" not printing the list of containers (among other improvements and bug-fixes). See: https://github.com/kubernetes/kubernetes/issues/38774