### PR TITLE
Use cluster-local search suffix to avoid undesired DNS resolution behavior

### DIFF
--- a/lib/utils/dns.go
+++ b/lib/utils/dns.go
@@ -50,26 +50,6 @@ func (d *DNSConfig) rotate() string {
 	return ""
 }
 
-// UpsertServer adds server if it's not here, adds it to the begining
-func (d *DNSConfig) UpsertServer(ip string) {
-	for _, server := range d.Servers {
-		if server == ip {
-			return
-		}
-	}
-	d.Servers = append([]string{ip}, d.Servers...)
-}
-
-// UpsertSearchDomain adds a search domain suffix to search list
-func (d *DNSConfig) UpsertSearchDomain(domain string) {
-	for _, name := range d.Search {
-		if name == domain {
-			return
-		}
-	}
-	d.Search = append(d.Search, domain)
-}
-
 // String returns resolv.conf serialized version of config
 func (d *DNSConfig) String() string {
 	buf := &bytes.Buffer{}
@@ -121,7 +101,7 @@ func DNSReadConfig(rdr io.Reader) (*DNSConfig, error) {
 		}
 		switch f[0] {
 		case nameserverParam: // add one name server
-			if len(f) > 1 && len(conf.Servers) < 3 { // small, but the standard limit
+			if len(f) > 1 && len(conf.Servers) < 3 { // system limit
 				conf.Servers = append(conf.Servers, f[1])
 			}
 

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -54,9 +54,13 @@ const (
 	// setup AWS integration in kubernetes
 	CloudProviderAWS = "aws"
 
-	// DNSNdots is the amount of NDOTS we set before doing initial global query
+	// See resolv.conf(5) on a Linux machine
+	//
+	// DNSNdots defines the threshold for amount of dots that must appear in a name
+	// before an initial absolute query will be made
 	DNSNdots = 2
-	// DNSTimeout is the amount of seconds to wait
+	// DNSTimeout is the amount time resolver will wait for response before retrying
+	// the query with a different name server. Measured in seconds
 	DNSTimeout = 1
 
 	// LocalDNSIP is the IP of the local DNS server


### PR DESCRIPTION
Set search domain to cluster-local suffix to avoid undesired DNS resolution hiccups.
I left the search suffix reading code intact, but it could potentially be stripped entirely.

Updates #1381.