### PR TITLE
Reset search suffixes and disable rotate.

### DIFF
--- a/lib/utils/dns.go
+++ b/lib/utils/dns.go
@@ -50,26 +50,6 @@ func (d *DNSConfig) rotate() string {
 	return ""
 }
 
-// UpsertServer adds server if it's not here, adds it to the begining
-func (d *DNSConfig) UpsertServer(ip string) {
-	for _, server := range d.Servers {
-		if server == ip {
-			return
-		}
-	}
-	d.Servers = append([]string{ip}, d.Servers...)
-}
-
-// UpsertSearchDomain adds a search domain suffix to search list
-func (d *DNSConfig) UpsertSearchDomain(domain string) {
-	for _, name := range d.Search {
-		if name == domain {
-			return
-		}
-	}
-	d.Search = append(d.Search, domain)
-}
-
 // String returns resolv.conf serialized version of config
 func (d *DNSConfig) String() string {
 	buf := &bytes.Buffer{}

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -491,9 +491,13 @@ func copyResolvFile(destination string, nameservers []string) error {
 	outNameservers = append(outNameservers, cfg.Servers...)
 	cfg.Servers = outNameservers
 
-	cfg.UpsertSearchDomain(DefaultSearchDomain)
+	// Limit search to local cluster domain
+	cfg.Search = []string{DefaultSearchDomain}
 	cfg.Ndots = DNSNdots
 	cfg.Timeout = DNSTimeout
+	// See: https://github.com/gravitational/gravity/issues/1861
+	// Do not use rotate to allow proper cluster-local name resolution.
+	cfg.Rotate = false
 
 	resolv, err := os.OpenFile(
 		destination,


### PR DESCRIPTION
Reset search suffixes to include only cluster-local suffix.
Disable rotate in `resolv.conf`.

Fixes https://github.com/gravitational/gravity/issues/1861.