### PR TITLE
Use kubectl cert in kubectl config

### DIFF
--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -157,8 +157,8 @@ clusters:
 users:
 - name: default
   user:
-    client-certificate: /var/lib/gravity/secrets/scheduler.cert
-    client-key: /var/lib/gravity/secrets/kubelet.key
+    client-certificate: /var/lib/gravity/secrets/kubectl.cert
+    client-key: /var/lib/gravity/secrets/kubectl.key
 contexts:
 - name: default
   context:

--- a/tool/planet/enter.go
+++ b/tool/planet/enter.go
@@ -49,7 +49,7 @@ func enter(rootfs, socketPath string, cfg *box.ProcessConfig) error {
 	cfg.Env.Upsert(EnvEtcdctlKeyFile, DefaultEtcdctlKeyFile)
 	cfg.Env.Upsert(EnvEtcdctlCAFile, DefaultEtcdctlCAFile)
 	cfg.Env.Upsert(EnvEtcdctlPeers, DefaultEtcdEndpoints)
-	cfg.Env.Upsert(EnvKubeConfig, constants.KubeConfigPath)
+	cfg.Env.Upsert(EnvKubeConfig, constants.KubectlConfigPath)
 	s, err := box.Connect(&box.ClientConfig{
 		Rootfs:     rootfs,
 		SocketPath: socketPath,


### PR DESCRIPTION
Make kubectl use its own cert. This cleans up confusion b/w scheduler/kubelet certs and kubect works both on host and in planet.

Supplements https://github.com/gravitational/gravity/pull/1998.