### PR TITLE
Add dependencies on network target

### DIFF
--- a/build.assets/orbit.manifest.json
+++ b/build.assets/orbit.manifest.json
@@ -21,7 +21,11 @@
         "KillSignal": "SIGRTMIN+13",
         "StartPreCommand": "-/bin/rm /var/run/planet.socket",
         "StopPostCommand": "-/bin/rm /var/run/planet.socket",
-        "StopCommand": "stop"
+        "StopCommand": "stop",
+        "Dependencies": {
+            "Requires": "network-online.target",
+            "After": "network.target network-online.target"
+        }
     },
     "config": {
         "params": [


### PR DESCRIPTION
Add dependencies on network target to avoid issues with host's `resolv.conf` not containing the node's IP