### PR TITLE
Add tool to make filesystem usage metrics work for devicemapper

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -q -y bridge-utils \
         kmod \
         iptables \
         libdevmapper1.02.1 \
+        thin-provisioning-tools \
         libsqlite3-0 \
         e2fsprogs \
         libncurses5 \


### PR DESCRIPTION
Cadvisor can collect filesystem usage metrics from docker with devicemapper backend only when on system installed `thin_ls` command line tool.
related PR -> https://github.com/google/cadvisor/pull/1204