### PR TITLE
Update use proper CA certificate for status command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,7 +231,7 @@
 [[projects]]
   name = "github.com/gravitational/satellite"
   packages = ["agent","agent/backend/inmemory","agent/cache","agent/health","agent/proto/agentpb","monitoring","monitoring/collector","utils"]
-  revision = "35606a9baaa87fe4175c43f8d0f2e9379e2271a5"
+  revision = "bb94380a0533c1f6ea7d0e3b49a6380e0f003f53"
   version = "0.0.10"
 
 [[projects]]
@@ -461,6 +461,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "249435921d064db205504b31da9653c3807171a18b3050fd69165aba9b557acc"
+  inputs-digest = "1b9c3e6849c330ce2da0d218673902eb83e91fb91eab866c0fe1793fd3c15ac3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -3,7 +3,7 @@ FROM planet/base
 ENV GOPATH /gopath
 ENV GOROOT /opt/go
 ENV PATH $PATH:$GOPATH/bin:$GOROOT/bin
-ENV GOVERSION 1.8.3
+ENV GOVERSION 1.9
 
 # Have our own /etc/passwd with users populated from 990 to 1000
 COPY passwd /etc/passwd

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -120,8 +120,8 @@ const (
 	// AgentStatusTimeout specifies the default status query timeout
 	AgentStatusTimeout = 5 * time.Second
 
-	// ClientRPCCertPath specifies the path to the client certificate for agent RPC
-	ClientRPCCertPath = "/var/state/etcd.cert"
+	// ClientRPCCertPath specifies the path to the CA certificate for agent RPC
+	ClientRPCCertPath = "/var/state/root.cert"
 )
 
 // K8sSearchDomains are default k8s search domain settings

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -135,7 +135,7 @@ func run() error {
 		cstatusRPCPort     = cstatus.Flag("rpc-port", "Local agent RPC port.").Default("7575").Int()
 		cstatusPrettyPrint = cstatus.Flag("pretty", "Pretty-print the output").Default("false").Bool()
 		cstatusTimeout     = cstatus.Flag("timeout", "Status timeout").Default(AgentStatusTimeout.String()).Duration()
-		cstatusCertFile    = cstatus.Flag("cert-file", "Client certificate to use for RPC call").
+		cstatusCertFile    = cstatus.Flag("cert-file", "Client CA certificate to use for RPC call").
 					Default(ClientRPCCertPath).OverrideDefaultFromEnvar(EnvPlanetAgentCertFile).String()
 
 		// test command
@@ -223,6 +223,7 @@ func run() error {
 			SerfRPCAddr: *cagentSerfRPCAddr,
 			MetricsAddr: *cagentMetricsAddr,
 			Cache:       cache,
+			CAFile:      *cagentEtcdCAFile,
 			CertFile:    *cagentEtcdCertFile,
 			KeyFile:     *cagentEtcdKeyFile,
 		}

--- a/vendor/github.com/gravitational/satellite/agent/client.go
+++ b/vendor/github.com/gravitational/satellite/agent/client.go
@@ -38,20 +38,9 @@ type client struct {
 	conn *grpc.ClientConn
 }
 
-// NewClient creates a agent RPC client to the given address
-// using the specified client certificate certFile
-func NewClient(addr, certFile string) (*client, error) {
-	creds, err := credentials.NewClientTLSFromFile(certFile, "")
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to read certificate")
-	}
-
-	return NewClientWithCreds(addr, creds)
-}
-
-// NewClientWithCreds creates a new agent RPC client to the given address
+// NewClient creates a new agent RPC client to the given address
 // using specified credentials creds
-func NewClientWithCreds(addr string, creds credentials.TransportCredentials) (*client, error) {
+func NewClient(addr string, creds credentials.TransportCredentials) (*client, error) {
 	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to dial")


### PR DESCRIPTION
Update agent code to use proper CA certificate for status command.
Had to bump to Go1.9 for http.Server.ServeTLS (see https://github.com/golang/go/issues/13228 and https://github.com/golang/go/commit/0b77d3eb009335aaa72205c6642409a5e4a408d6)