### PR TITLE
Dmitri/3021 stop timeout

### DIFF
--- a/build.assets/orbit.manifest.json
+++ b/build.assets/orbit.manifest.json
@@ -22,7 +22,7 @@
         "StartPreCommand": "-/bin/rm /var/run/planet.socket",
         "StopPostCommand": "-/bin/rm /var/run/planet.socket",
         "StopCommand": "stop",
-        "TimeoutStopSec": "20min",
+        "TimeoutStopSec": "5min",
         "Dependencies": {
             "Requires": "network-online.target",
             "After": "network.target network-online.target"

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -212,7 +212,7 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 		Mounts:       config.Mounts,
 		DataDir:      "/var/run/planet",
 		InitUser:     "root",
-		InitArgs:     []string{"/bin/systemd", "--log-level=debug"},
+		InitArgs:     []string{"/bin/systemd"},
 		InitEnv:      []string{"container=docker", "LC_ALL=en_US.UTF-8"},
 		Capabilities: allCaps,
 	}


### PR DESCRIPTION
  - Bump stop timeout to `5min` as on some distributions the default (`DefaultTimeoutStopSec=90s`) is not enough during tests (`ubuntu` / `redhat 7.4`)
  - change "container" to "docker" as "libcontainer" does not seem to be a valid virtualization environment for systemd
