### PR TITLE
Remove obviously obsolete environment variable.

### DIFF
--- a/build.assets/makefiles/base/network/flanneld.service
+++ b/build.assets/makefiles/base/network/flanneld.service
@@ -7,7 +7,6 @@ Wants=etcd.service
 Restart=always
 RestartSec=5
 Environment="TMPDIR=/var/tmp/"
-Environment="FLANNEL_VER=0.5.1"
 EnvironmentFile=/etc/container-environment
 LimitNOFILE=40000
 LimitNPROC=1048576

--- a/build.assets/makefiles/base/network/network.mk
+++ b/build.assets/makefiles/base/network/network.mk
@@ -4,7 +4,7 @@ ARCH := amd64
 NAME := flannel
 TARGET := $(NAME)-$(FLANNEL_VER)
 TARGET_TAR := $(TARGET)-linux-$(ARCH).tar.gz
-BINARIES := $(ASSETDIR)/flanneld
+BINARIES := $(ASSETDIR)/flanneld-$(FLANNEL_VER)
 
 all: $(BINARIES) network.mk
 	@echo "\\n---> Installing Flannel and preparing network stack for Kubernetes:\\n"


### PR DESCRIPTION
* Remove obviously obsolete environment variable.
* Build flannel to a versioned binary - just like we do with other just-binary assets.