### PR TITLE
Enable multizone for GCE.

### DIFF
--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -679,6 +679,9 @@ KubernetesClusterTag=%v
 ; list of network tags on instances which will be used
 ; when creating firewall rules for load balancers
 node-tags=%v
+; enable multi-zone setting, otherwise kube-controller-manager
+; will not recognize nodes running in different zones
+multizone=true
 `
 )
 


### PR DESCRIPTION
This setting is required so when deploying on GCE and nodes are in different zones, kube-controller-manager recognizes them all properly. Otherwise, it will be dropping nodes that are not in the zone it's running in.
