### PR TITLE
Add support for mounting host devices.

### DIFF
--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -159,6 +159,15 @@
                 }
             },
             {
+                "type": "List",
+                "name": "devices",
+                "spec": {
+                    "name": "device",
+                    "env": "PLANET_DEVICE",
+                    "type": "String"
+                }
+            },
+            {
                 "type": "String",
                 "name": "initialcluster",
                 "env": "PLANET_INITIAL_CLUSTER",

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -43,6 +43,8 @@ type Config struct {
 	Env box.EnvVars
 	// Mounts specifies the list of additional mounts
 	Mounts box.Mounts
+	// Devices is the list of devices to create inside container
+	Devices box.Devices
 	// Files are files to be shared inside the container
 	Files []box.File
 	// IgnoreChecks disables kernel checks during start up

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -70,6 +70,7 @@ func run() error {
 		cstartIgnoreChecks            = cstart.Flag("ignore-checks", "Force start ignoring some failed host checks (e.g. kernel version)").OverrideDefaultFromEnvar("PLANET_FORCE").Bool()
 		cstartEnv                     = EnvVars(cstart.Flag("env", "Set environment variable").OverrideDefaultFromEnvar("PLANET_ENV"))
 		cstartMounts                  = Mounts(cstart.Flag("volume", "External volume to mount").OverrideDefaultFromEnvar("PLANET_VOLUME"))
+		cstartDevices                 = Devices(cstart.Flag("device", "Device to create inside container").OverrideDefaultFromEnvar("PLANET_DEVICE"))
 		cstartRoles                   = List(cstart.Flag("role", "Roles such as 'master' or 'node'").OverrideDefaultFromEnvar("PLANET_ROLE"))
 		cstartSecretsDir              = cstart.Flag("secrets-dir", "Directory with master secrets - certificate authority and certificates").OverrideDefaultFromEnvar("PLANET_SECRETS_DIR").ExistingDir()
 		cstartServiceSubnet           = kv.CIDRFlag(cstart.Flag("service-subnet", "subnet dedicated to the services in cluster").Default(DefaultServiceSubnet).OverrideDefaultFromEnvar("PLANET_SERVICE_SUBNET"))
@@ -312,6 +313,7 @@ func run() error {
 			SocketPath:     *socketPath,
 			Env:            *cstartEnv,
 			Mounts:         *cstartMounts,
+			Devices:        *cstartDevices,
 			IgnoreChecks:   *cstartIgnoreChecks,
 			Roles:          *cstartRoles,
 			MasterIP:       cstartMasterIP.String(),
@@ -448,6 +450,12 @@ func EnvVars(s kingpin.Settings) *box.EnvVars {
 
 func Mounts(s kingpin.Settings) *box.Mounts {
 	vars := new(box.Mounts)
+	s.SetValue(vars)
+	return vars
+}
+
+func Devices(s kingpin.Settings) *box.Devices {
+	vars := new(box.Devices)
 	s.SetValue(vars)
 	return vars
 }

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -196,6 +196,7 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 		},
 		Files:        config.Files,
 		Mounts:       config.Mounts,
+		Devices:      config.Devices,
 		DataDir:      "/var/run/planet",
 		InitUser:     "root",
 		InitArgs:     []string{"/bin/systemd"},


### PR DESCRIPTION
This PR adds ability to create device nodes for host's devices inside planet. Gravity uses this when a customer specified "devices" in their app manifest (similar to "volumes").

Used by https://github.com/gravitational/telekube/pull/3466. Updates https://github.com/gravitational/telekube/issues/3390.
