### PR TITLE
Update the schema type for envar items to be String

### DIFF
--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -134,13 +134,7 @@
                 "spec": {
                     "name": "env",
                     "env": "PLANET_ENV",
-                    "type": "KeyVal",
-                    "spec": {
-                        "keys": [
-                            {"name": "key", "type":"String"},
-                            {"name": "val", "type":"String"}
-                        ]
-                    }
+                    "type": "String"
                 }
             },
             {


### PR DESCRIPTION
Otherwise the installer fails to install a profile with custom environment options (i.e. `--env`) to planet.