### PR TITLE
version 5.0.x: do not display error message for exit code errors

### DIFF
--- a/lib/box/client.go
+++ b/lib/box/client.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/websocket"
 )
 
@@ -74,7 +75,9 @@ func (c *client) Enter(cfg ProcessConfig) error {
 	// a user hits "Enter" (which causes it to exit io.Copy() loop because it will
 	// fail writing to container's closed handle).
 	go func() {
-		io.Copy(clt, cfg.In)
+		if _, err := io.Copy(clt, cfg.In); err != nil {
+			log.Warnf("Failed to copy input to container: %v.", err)
+		}
 	}()
 
 	// only wait for output handle to be closed

--- a/lib/box/enter.go
+++ b/lib/box/enter.go
@@ -75,7 +75,7 @@ func StartProcessTTY(c libcontainer.Container, cfg ProcessConfig) error {
 		return trace.Wrap(err)
 	}
 
-	log.Infof("process started")
+	log.Debugf("Process %#v started.", p)
 
 	// wait for the process to finish.
 	_, err = p.Wait()

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -393,11 +393,11 @@ func startWebServer(listener net.Listener, c libcontainer.Container) error {
 	go func() {
 		defer func() {
 			if err := listener.Close(); err != nil {
-				log.Warningf("failed to remove socket file: %v", err)
+				log.Warnf("Failed to remove socket file: %v.", err)
 			}
 		}()
 		if err := srv.Serve(listener); err != nil {
-			log.Infof("server stopped with: %v", err)
+			log.Warnf("Server finished with %v.", err)
 		}
 	}()
 	return nil

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -36,10 +36,10 @@ func main() {
 	var err error
 
 	if err = run(); err != nil {
-		log.Errorf("Failed to run: '%v'\n", trace.DebugReport(err))
 		if errExit, ok := trace.Unwrap(err).(*box.ExitError); ok {
 			exitCode = errExit.Code
 		} else {
+			log.Errorf("Failed to run: %v.", trace.DebugReport(err))
 			exitCode = 1
 		}
 	}


### PR DESCRIPTION
I will follow up with forward-ports for other versions if the change is accepted.

Updates https://github.com/gravitational/telekube/issues/3513.