### PR TITLE
Add kubectl script.

### DIFF
--- a/build.assets/docker/os-rootfs/usr/local/bin/kubectl
+++ b/build.assets/docker/os-rootfs/usr/local/bin/kubectl
@@ -11,7 +11,7 @@ else
 fi
 
 # determine the absolute path to the planet rootfs
-PLANET_ROOT=${DIR}/../../../
+PLANET_ROOT=$(realpath ${DIR}/../../../)
 
-# invoke the real kubectl binary with a proper config and propagating all arguments as-is
+# invoke the real kubectl binary with a proper config and propage all arguments as-is
 ${PLANET_ROOT}/usr/bin/kubectl --kubeconfig=${PLANET_ROOT}/etc/kubernetes/kubectl.kubeconfig $@


### PR DESCRIPTION
This kubectl alias script invokes planet's kubectl with a correct kubeconfig. Its purpose is host's kubectl is symlinked to it so it works on host right after installation w/o needing any env vars in session. Gravity PR: https://github.com/gravitational/telekube/pull/3677.