### PR TITLE
Remove "etcd promote" command and add "etcd wipe" command

### DIFF
--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -296,12 +296,12 @@ func etcdRestore(file string) error {
 }
 
 // etcdWipe wipes out all local etcd data
-func etcdWipe(autoConfirm bool) error {
+func etcdWipe(confirmed bool) error {
 	dataDir, err := getEtcdDataDir()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if !autoConfirm {
+	if !confirmed {
 		err := getConfirmation(fmt.Sprintf(wipeoutPrompt, dataDir),
 			wipeoutConfirmation)
 		if err != nil {

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -190,8 +190,8 @@ func run() error {
 		cetcdRestore     = cetcd.Command("restore", "Restore etcd backup as part of the upgrade")
 		cetcdRestoreFile = cetcdRestore.Arg("file", "A previously taken backup file to use during upgrade").Required().ExistingFile()
 
-		cetcdWipe        = cetcd.Command("wipe", "Wipe out all local etcd data").Hidden()
-		cetcdWipeConfirm = cetcdWipe.Flag("confirm", "Auto-confirm the action").Bool()
+		cetcdWipe          = cetcd.Command("wipe", "Wipe out all local etcd data").Hidden()
+		cetcdWipeConfirmed = cetcdWipe.Flag("confirm", "Auto-confirm the action").Bool()
 
 		// leader election commands
 		cleader              = app.Command("leader", "Leader election control")
@@ -479,7 +479,7 @@ func run() error {
 		err = etcdRestore(*cetcdRestoreFile)
 
 	case cetcdWipe.FullCommand():
-		err = etcdWipe(*cetcdWipeConfirm)
+		err = etcdWipe(*cetcdWipeConfirmed)
 
 	default:
 		err = trace.Errorf("unsupported command: %v", cmd)


### PR DESCRIPTION
These changes are required by new fsm-based join operation.

* The `etcd promote` subcommand is deleted because it is no longer used. Master nodes always come up with etcd configured as full members.
* The new `etcd wipe` command wipes out all etcd data on the node where it is run. It is used in a rollback procedure when 1->2 expand scenario fails. The command is dangerous so it is hidden and requires confirmation.
