### PR TITLE
Update kubernetes to address CVE-2018-1002105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.12.1
+KUBE_VER ?= v1.12.3
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 18.06.1
 # we currently use our own flannel fork: gravitational/flannel


### PR DESCRIPTION
Bump Kubernetes to address CVE-2018-1002105 https://github.com/kubernetes/kubernetes/issues/71411