### PR TITLE
Update kubernetes to address CVE-2018-1002105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.11.2
+KUBE_VER ?= v1.11.5
 SECCOMP_VER ?=  2.3.1-2.1
 DOCKER_VER ?= 17.03.2
 # we currently use our own flannel fork: gravitational/flannel


### PR DESCRIPTION
Bump Kubernetes to address CVE-2018-1002105 https://github.com/kubernetes/kubernetes/issues/71411