### PR TITLE
Update kubernetes to address CVE-2018-1002105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BUILD_ASSETS := $(PWD)/build/assets
 BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 
-KUBE_VER := v1.9.6
+KUBE_VER := v1.9.12-gravitational.0
 SECCOMP_VER :=  2.3.1-2.1
 DOCKER_VER := 17.03.2
 # we currently use our own flannel fork: gravitational/flannel

--- a/build.assets/makefiles/kubernetes/kubernetes.mk
+++ b/build.assets/makefiles/kubernetes/kubernetes.mk
@@ -1,7 +1,7 @@
 .PHONY: all
 
 CURL_OPTS := -s
-DOWNLOAD_URL := https://storage.googleapis.com/kubernetes-release/release/$(KUBE_VER)/bin/linux/amd64
+DOWNLOAD_URL := https://s3-us-west-2.amazonaws.com/dev.gravitational.io/kubernetes-release/release/$(KUBE_VER)/linux/amd64
 REPODIR := $(GOPATH)/src/github.com/kubernetes/kubernetes
 OUTPUTDIR := $(ASSETDIR)/k8s-$(KUBE_VER)
 BINARIES := kube-apiserver \


### PR DESCRIPTION
Switch to using a gravitational backport to kubernetes 1.9
Bump Kubernetes to address CVE-2018-1002105 kubernetes/kubernetes#71411