### PR TITLE
4.x cve-2018-1002105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 
 KUBE_VER := v1.7.18-gravitational.0
-SECCOMP_VER :=  2.3.1-2.1
+SECCOMP_VER :=  2.3.1-2.1+deb9u1
 DOCKER_VER := 1.12.6
 FLANNEL_VER := amed/awsvpc-multi-routing-table-backend
 ETCD_VER := v2.3.8

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BUILD_ASSETS := $(PWD)/build/assets
 BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 
-KUBE_VER := v1.7.15
+KUBE_VER := v1.7.18-gravitational.0
 SECCOMP_VER :=  2.3.1-2.1
 DOCKER_VER := 1.12.6
 FLANNEL_VER := amed/awsvpc-multi-routing-table-backend

--- a/build.assets/makefiles/kubernetes/kubernetes.mk
+++ b/build.assets/makefiles/kubernetes/kubernetes.mk
@@ -1,7 +1,7 @@
 .PHONY: all
 
 CURL_OPTS := -s
-DOWNLOAD_URL := https://storage.googleapis.com/kubernetes-release/release/$(KUBE_VER)/bin/linux/amd64
+DOWNLOAD_URL := https://s3-us-west-2.amazonaws.com/dev.gravitational.io/kubernetes-release/release/$(KUBE_VER)/linux/amd64
 REPODIR := $(GOPATH)/src/github.com/kubernetes/kubernetes
 OUTPUTDIR := $(ASSETDIR)/k8s-$(KUBE_VER)
 BINARIES := kube-apiserver \


### PR DESCRIPTION
version/4.x appears to be a tag, so I put together a branch kevin/version/4.x to show the changes.

This is the same as the other CVE fixes, there is no upstream backport of the fix, so I backported and built on a fork.