### PR TITLE
update to golang 1.10.7 to avoid cve-2018-16875

### DIFF
--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -3,7 +3,7 @@ FROM planet/base
 ENV GOPATH /gopath
 ENV GOROOT /opt/go
 ENV PATH $PATH:$GOPATH/bin:$GOROOT/bin
-ENV GOVERSION 1.8.3
+ENV GOVERSION 1.10.7
 
 # Have our own /etc/passwd with users populated from 990 to 1000
 COPY passwd /etc/passwd


### PR DESCRIPTION
@a-palchikov Are there any concerns with going from 1.8.3 -> 1.10.7 on 5.0.x planet? Golang upstream didn't backport the fixes, so I would rather avoid having to mess with old builds if possible.