### PR TITLE
[5.3]: bump system resource limits for coredns

### DIFF
--- a/build.assets/makefiles/base/dns/coredns.service
+++ b/build.assets/makefiles/base/dns/coredns.service
@@ -6,7 +6,8 @@ After=network.target
 [Service]
 PermissionsStartOnly=true
 LimitNOFILE=1048576
-LimitNPROC=512
+LimitNPROC=infinity
+LimitCORE=infinity
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true


### PR DESCRIPTION
Bump file/processe limits for `CoreDNS` to avoid issues with lower system resource settings.

Updates https://github.com/gravitational/gravity.e/issues/3896.