### PR TITLE
Add more leader/registry aliases.

### DIFF
--- a/build.assets/makefiles/base/docker/docker.mk
+++ b/build.assets/makefiles/base/docker/docker.mk
@@ -1,10 +1,12 @@
 # This makefile installs Kubernetes-friendly docker inside of planet
-# images. 
-# 
+# images.
+#
 # This makefile is executed inside the docker's buildbox image.
 
-LEGACY_REGISTRY := apiserver:5000
-REGISTRY := leader.telekube.local:5000
+REGISTRY_ALIASES := apiserver:5000 \
+		leader.telekube.local:5000 \
+		leader.gravity.local:5000 \
+		registry.local:5000
 
 .PHONY: all
 all: service scripts certs
@@ -25,14 +27,11 @@ scripts:
 
 .PHONY: certs
 certs:
-# client and server certificate directory
-	mkdir -p $(ROOTFS)/etc/docker/certs.d/$(REGISTRY)
+# create client and server certificate directories
 # notice .crt for roots, and .cert for certificates, this is not a typo, but docker expected format
-	ln -sf /var/state/root.cert $(ROOTFS)/etc/docker/certs.d/$(REGISTRY)/$(REGISTRY).crt
-	ln -sf /var/state/kubelet.cert $(ROOTFS)/etc/docker/certs.d/$(REGISTRY)/client.cert
-	ln -sf /var/state/kubelet.key $(ROOTFS)/etc/docker/certs.d/$(REGISTRY)/client.key
-# notice .crt for roots, and .cert for certificates, this is not a typo, but docker expected format
-	mkdir -p $(ROOTFS)/etc/docker/certs.d/$(LEGACY_REGISTRY)
-	ln -sf /var/state/root.cert $(ROOTFS)/etc/docker/certs.d/$(LEGACY_REGISTRY)/$(LEGACY_REGISTRY).crt
-	ln -sf /var/state/kubelet.cert $(ROOTFS)/etc/docker/certs.d/$(LEGACY_REGISTRY)/client.cert
-	ln -sf /var/state/kubelet.key $(ROOTFS)/etc/docker/certs.d/$(LEGACY_REGISTRY)/client.key
+	for r in $(REGISTRY_ALIASES); do \
+		mkdir -p $(ROOTFS)/etc/docker/certs.d/$$r; \
+		ln -sf /var/state/root.cert $(ROOTFS)/etc/docker/certs.d/$$r/$$r.crt; \
+		ln -sf /var/state/kubelet.cert $(ROOTFS)/etc/docker/certs.d/$$r/client.cert; \
+		ln -sf /var/state/kubelet.key $(ROOTFS)/etc/docker/certs.d/$$r/client.key; \
+	done

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -53,14 +53,12 @@ const (
 	// OverlayInterfaceName is the name of the linux network interface connected to the overlay network
 	OverlayInterfaceName = "docker0"
 
-	// APIServerDNSNameLegacy is the legacy domain name of a current leader server.
+	// APIServerDNSNameLegacy is the legacy domain name of the current leader server.
 	APIServerDNSNameLegacy = "leader.telekube.local"
-	// APIServerDNSName is the domain name of a current leader server.
+	// APIServerDNSName is the domain name of the current leader server.
 	APIServerDNSName = "leader.gravity.local"
-	// RegistryDNSName is the domain name of a cluster local registry.
+	// RegistryDNSName is the domain name of the cluster local registry.
 	RegistryDNSName = "registry.local"
-	// TelekubeDomain is the domain for local telekube cluster.
-	TelekubeDomain = "telekube.local"
 )
 
 var (

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -53,9 +53,13 @@ const (
 	// OverlayInterfaceName is the name of the linux network interface connected to the overlay network
 	OverlayInterfaceName = "docker0"
 
-	// APIServerDNSName is the domain name of a current leader server
-	APIServerDNSName = "leader.telekube.local"
-	// TelekubeDomain is the domain for local telekube cluster
+	// APIServerDNSNameLegacy is the legacy domain name of a current leader server.
+	APIServerDNSNameLegacy = "leader.telekube.local"
+	// APIServerDNSName is the domain name of a current leader server.
+	APIServerDNSName = "leader.gravity.local"
+	// RegistryDNSName is the domain name of a cluster local registry.
+	RegistryDNSName = "registry.local"
+	// TelekubeDomain is the domain for local telekube cluster.
 	TelekubeDomain = "telekube.local"
 )
 

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -194,7 +194,11 @@ func startLeaderClient(conf *LeaderConfig, errorC chan error) (leaderClient io.C
 }
 
 func writeLocalLeader(target string, masterIP string) error {
-	contents := fmt.Sprint(masterIP, " ", constants.APIServerDNSName, " ", LegacyAPIServerDNSName, "\n")
+	contents := fmt.Sprint(masterIP, " ",
+		constants.APIServerDNSName, " ",
+		constants.APIServerDNSNameLegacy, " ",
+		constants.RegistryDNSName, " ",
+		LegacyAPIServerDNSName, "\n")
 	err := ioutil.WriteFile(
 		target,
 		[]byte(contents),


### PR DESCRIPTION
Add a couple of new DNS aliases for leader node:

- `leader.gravity.local` which will eventually supersede `leader.telekube.local`
- `registry.local` for easier use in app images (part of the upcoming catalog work)
