### PR TITLE
Kevin/master/3898 service route

### DIFF
--- a/build.assets/makefiles/base/network/flanneld.service
+++ b/build.assets/makefiles/base/network/flanneld.service
@@ -32,7 +32,4 @@ ExecStart=/usr/bin/flanneld -v 2 \
     --kube-key=/var/state/kubelet.key \
     --kube-ca=/var/state/root.cert \
     --iface=${PLANET_PUBLIC_IP}
-# https://github.com/gravitational/gravity.e/issues/3898
-# Some nodes may be configured in a way that do not include a route for the service subnet (nodes without defualt gateways).
-# This leads to no route to host errors, because the initial route table lookup failure occurs before NAT is triggered in netfilter.
-ExecStartPost=-/bin/bash -c "until [ -e /run/flannel/subnet.env ]; do echo \"waiting for write.\"; sleep 3; done; ip route add ${KUBE_SERVICE_SUBNET} dev flannel.1"
+ExecStartPost=-/usr/bin/scripts/wait-for-flannel.sh

--- a/build.assets/makefiles/base/network/flanneld.service
+++ b/build.assets/makefiles/base/network/flanneld.service
@@ -32,4 +32,7 @@ ExecStart=/usr/bin/flanneld -v 2 \
     --kube-key=/var/state/kubelet.key \
     --kube-ca=/var/state/root.cert \
     --iface=${PLANET_PUBLIC_IP}
-ExecStartPost=-/bin/bash -c "until [ -e /run/flannel/subnet.env ]; do echo \"waiting for write.\"; sleep 3; done"
+# https://github.com/gravitational/gravity.e/issues/3898
+# Some nodes may be configured in a way that do not include a route for the service subnet (nodes without defualt gateways).
+# This leads to no route to host errors, because the initial route table lookup failure occurs before NAT is triggered in netfilter.
+ExecStartPost=-/bin/bash -c "until [ -e /run/flannel/subnet.env ]; do echo \"waiting for write.\"; sleep 3; done; ip route add ${KUBE_SERVICE_SUBNET} dev flannel.1"

--- a/build.assets/makefiles/base/network/network.mk
+++ b/build.assets/makefiles/base/network/network.mk
@@ -21,6 +21,7 @@ all: $(BINARIES) network.mk
 # script that allows waiting for etcd to come up
 	mkdir -p $(ROOTFS)/usr/bin/scripts
 	install -m 0755 ./wait-for-etcd.sh $(ROOTFS)/usr/bin/scripts
+	install -m 0755 ./wait-for-flannel.sh $(ROOTFS)/usr/bin/scripts
 
 # script that sets up /etc/hosts and symlinks resolv.conf
 	install -m 0755 ./setup-etc.sh $(ROOTFS)/usr/bin/scripts

--- a/build.assets/makefiles/base/network/wait-for-flannel.sh
+++ b/build.assets/makefiles/base/network/wait-for-flannel.sh
@@ -10,7 +10,7 @@ done;
 # The node may not have a default gateway or routes that cover the service subnet
 # This prevents "no route to host" errors when trying to reach the service subnet
 # by creating a dummy interface, and routing the service subnet to this interface
-# we can guarentee that the route exists, and can be NAT to the correct destination
+# we can guarantee that the route exists, and can be NAT to the correct destination
 ip link add flannel.null type dummy
 ip link set flannel.null up
 ip route add ${KUBE_SERVICE_SUBNET} dev flannel.null

--- a/build.assets/makefiles/base/network/wait-for-flannel.sh
+++ b/build.assets/makefiles/base/network/wait-for-flannel.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+source /etc/container-environment
+
+until [ -e /run/flannel/subnet.env ]; 
+  do echo \"waiting for flannel to start.\"; 
+  sleep 3; 
+done; 
+
+# https://github.com/gravitational/gravity.e/issues/3898
+# The node may not have a default gateway or routes that cover the service subnet
+# This prevents "no route to host" errors when trying to reach the service subnet
+# by creating a dummy interface, and routing the service subnet to this interface
+# we can guarentee that the route exists, and can be NAT to the correct destination
+ip link add flannel.null type dummy
+ip link set flannel.null up
+ip route add ${KUBE_SERVICE_SUBNET} dev flannel.null
+exit 0


### PR DESCRIPTION
Updates: https://github.com/gravitational/planet/pull/new/kevin/master/3898-service-route

I'm not sure if there is a better way to tackle this. Create a dummy interface, and use it to null route the service subnet IP range. I tried to route towards the existing flannel interface, but this appears to block the traffic before netfilter applies the NAT for some reason.

Risk - On some customer networks the service subnet might overlap with customer network ranges. Adding this route, should act as a blackhole for the entire service subnet, which means the entire range will no long route within the customers network. This should be acceptable, as this is always a risk since services will be randomly assigned in this range anyways.


Thoughts?