### PR TITLE
Use old apiserver domain name.

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -53,10 +53,10 @@ const (
 	// OverlayInterfaceName is the name of the linux network interface connected to the overlay network
 	OverlayInterfaceName = "docker0"
 
-	// APIServerDNSNameLegacy is the legacy domain name of the current leader server.
-	APIServerDNSNameLegacy = "leader.telekube.local"
 	// APIServerDNSName is the domain name of the current leader server.
-	APIServerDNSName = "leader.gravity.local"
+	APIServerDNSName = "leader.telekube.local"
+	// APIServerDNSNameGravity is the domain name of the current leader server.
+	APIServerDNSNameGravity = "leader.gravity.local"
 	// RegistryDNSName is the domain name of the cluster local registry.
 	RegistryDNSName = "registry.local"
 )

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -196,7 +196,7 @@ func startLeaderClient(conf *LeaderConfig, errorC chan error) (leaderClient io.C
 func writeLocalLeader(target string, masterIP string) error {
 	contents := fmt.Sprint(masterIP, " ",
 		constants.APIServerDNSName, " ",
-		constants.APIServerDNSNameLegacy, " ",
+		constants.APIServerDNSNameGravity, " ",
 		constants.RegistryDNSName, " ",
 		LegacyAPIServerDNSName, "\n")
 	err := ioutil.WriteFile(


### PR DESCRIPTION
When adding a new leader alias, `leader.gravity.local`, I inadvertently made it the "main" one while only intending to keep it as an alias for now.