### PR TITLE
bump docker to address CVE-2019-5736

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ OUTPUTDIR := $(BUILDDIR)/planet
 
 KUBE_VER ?= v1.13.2
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
-DOCKER_VER ?= 18.06.1
+DOCKER_VER ?= 18.06.2
 # we currently use our own flannel fork: gravitational/flannel
 FLANNEL_VER := v0.10.0-gravitational
 HELM_VER := v2.8.1


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/260

