### PR TITLE
Kevin/experimental/cgroups3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -558,7 +558,7 @@
   revision = "7d4729fb36185a7c1719923406c9d40e54fb93c7"
 
 [[projects]]
-  digest = "1:c8c1cb86074527519ceb2290cff4a78545cfa71844acaea9e670a7dc1354a01c"
+  digest = "1:3a7b076f85f7786b280e7b06017cfa7f9379dfde983ac5280eb471d0f8a14baa"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer",
@@ -581,8 +581,8 @@
     "libcontainer/utils",
   ]
   pruneopts = "UT"
-  revision = "4fc53a81fb7c994640722ac585fa9ca548971871"
-  version = "v1.0.0-rc5"
+  revision = "ccb5efd37fb7c86364786e9137e22948751de7ed"
+  version = "v1.0.0-rc6"
 
 [[projects]]
   digest = "1:57234a321bf1f8f98a8a9a5122a2404cc60d0800516f4ab7a7b2375e4b2d19ea"
@@ -1122,6 +1122,7 @@
     "github.com/julienschmidt/httprouter",
     "github.com/mitchellh/go-ps",
     "github.com/opencontainers/runc/libcontainer",
+    "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
     "github.com/opencontainers/runc/libcontainer/configs",
     "github.com/opencontainers/runc/libcontainer/devices",
     "github.com/opencontainers/runc/libcontainer/nsenter",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,7 +100,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/opencontainers/runc"
-  version = "v1.0.0-rc5"
+  version = "v1.0.0-rc6"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -333,13 +333,13 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 				Destination: "/dev/disk",
 				Flags:       syscall.MS_BIND,
 			},
-			// Mount the cgroup filesystem into the container
-			/*{
-				Source:      "cgroup",
+			// create a tmpfs filesystem for the cgroup controllers to be mounted onto
+			{
+				Source:      "tmpfs",
 				Destination: "/sys/fs/cgroup",
-				Device:      "cgroup",
+				Device:      "tmpfs",
 				Flags:       defaultMountFlags,
-			},*/
+			},
 		},
 		Cgroups: &configs.Cgroup{
 			Name: fmt.Sprintf("planet-%v", containerID),

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -193,6 +193,8 @@ func Start(cfg Config) (*Box, error) {
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
+		Init:   true,
+		Cwd:    "/",
 	}
 
 	// Run the container by starting the init process.

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -330,8 +331,7 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 			},
 		},
 		Cgroups: &configs.Cgroup{
-			Name:   containerID,
-			Parent: "system",
+			Path: path.Join("/gravity/planet/", containerID),
 			Resources: &configs.Resources{
 				AllowAllDevices:  &allowAllDevices,
 				AllowedDevices:   configs.DefaultAllowedDevices,

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -38,6 +37,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pborman/uuid"
 )
@@ -91,6 +91,10 @@ func (b *Box) Wait() (*os.ProcessState, error) {
 func Start(cfg Config) (*Box, error) {
 	log.Infof("[BOX] starting with config: %#v", cfg)
 
+	if !systemd.UseSystemd() {
+		return nil, trace.BadParameter("unable to use systemd for container creation")
+	}
+
 	rootfs, err := checkPath(cfg.Rootfs, false)
 	if err != nil {
 		return nil, err
@@ -129,7 +133,7 @@ func Start(cfg Config) (*Box, error) {
 	}
 
 	root, err := libcontainer.New(cfg.DataDir,
-		libcontainer.Cgroupfs,
+		libcontainer.SystemdCgroups,
 		libcontainer.NewuidmapPath(newuidmap),
 		libcontainer.NewgidmapPath(newgidmap),
 	)
@@ -326,7 +330,7 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 			},
 		},
 		Cgroups: &configs.Cgroup{
-			Path: path.Join("/gravity/planet/", containerID),
+			Name: containerID,
 			Resources: &configs.Resources{
 				AllowAllDevices:  &allowAllDevices,
 				AllowedDevices:   configs.DefaultAllowedDevices,

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -288,7 +288,7 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 			{Type: configs.NEWUTS},
 			{Type: configs.NEWIPC},
 			{Type: configs.NEWPID},
-			{Type: configs.NEWCGROUP}
+			{Type: configs.NEWCGROUP},
 		}),
 		Mounts: []*configs.Mount{
 			{

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -142,6 +142,10 @@ func Start(cfg Config) (*Box, error) {
 	}
 
 	containerID := uuid.New()
+	// https://github.com/systemd/systemd/blob/9ed6a1d2c6fd60ea666a30f815ab4c776e5d5c7c/src/core/machine-id-setup.c#L54-L58
+	// Pass the container uuid to systemd init
+	cfg.InitEnv = append(cfg.InitEnv, fmt.Sprintf("container_uuid=%v", containerID))
+
 	config, err := getLibcontainerConfig(containerID, rootfs, cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -335,12 +335,6 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 				Device:      "cgroup",
 				Flags:       defaultMountFlags,
 			},
-			{
-				Device:      "bind",
-				Source:      "/sys/fs/cgroup/systemd",
-				Destination: "/sys/fs/cgroup/systemd",
-				Flags:       syscall.MS_BIND,
-			},
 		},
 		Cgroups: &configs.Cgroup{
 			Path: path.Join("/gravity/planet", containerID),

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -38,7 +38,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/runc/libcontainer"
-	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pborman/uuid"
 )
@@ -92,10 +91,6 @@ func (b *Box) Wait() (*os.ProcessState, error) {
 func Start(cfg Config) (*Box, error) {
 	log.Infof("[BOX] starting with config: %#v", cfg)
 
-	if !systemd.UseSystemd() {
-		return nil, trace.BadParameter("unable to use systemd for container creation")
-	}
-
 	rootfs, err := checkPath(cfg.Rootfs, false)
 	if err != nil {
 		return nil, err
@@ -134,7 +129,7 @@ func Start(cfg Config) (*Box, error) {
 	}
 
 	root, err := libcontainer.New(cfg.DataDir,
-		libcontainer.SystemdCgroups,
+		libcontainer.Cgroupfs,
 		libcontainer.NewuidmapPath(newuidmap),
 		libcontainer.NewgidmapPath(newgidmap),
 	)

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -332,6 +332,19 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 				Destination: "/dev/disk",
 				Flags:       syscall.MS_BIND,
 			},
+			// Mount the cgroup filesystem into the container
+			{
+				Source:      "cgroup",
+				Destination: "/sys/fs/cgroup",
+				Device:      "cgroup",
+				Flags:       defaultMountFlags,
+			},
+			{
+				Device:      "bind",
+				Source:      "/sys/fs/cgroup/systemd",
+				Destination: "/sys/fs/cgroup/systemd",
+				Flags:       syscall.MS_BIND,
+			},
 		},
 		Cgroups: &configs.Cgroup{
 			Name: containerID,

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -33,10 +33,11 @@ import (
 
 	"github.com/gravitational/go-udev"
 	"github.com/gravitational/trace"
-	"github.com/runc/libcontainer/cgroups/systemd"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pborman/uuid"
 )

--- a/vendor/github.com/docker/docker/pkg/term/term_windows.go
+++ b/vendor/github.com/docker/docker/pkg/term/term_windows.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 
 	"github.com/Azure/go-ansiterm/winterm"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/term/windows"
 )
 

--- a/vendor/github.com/docker/docker/pkg/term/windows/ansi_writer.go
+++ b/vendor/github.com/docker/docker/pkg/term/windows/ansi_writer.go
@@ -8,7 +8,7 @@ import (
 
 	ansiterm "github.com/Azure/go-ansiterm"
 	"github.com/Azure/go-ansiterm/winterm"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 var logger *logrus.Logger

--- a/vendor/github.com/opencontainers/runc/libcontainer/README.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/README.md
@@ -148,6 +148,7 @@ config := &configs.Config{
 		{Type: configs.NEWPID},
 		{Type: configs.NEWUSER},
 		{Type: configs.NEWNET},
+		{Type: configs.NEWCGROUP},
 	}),
 	Cgroups: &configs.Cgroup{
 		Name:   "test-container",
@@ -323,6 +324,7 @@ generated when building libcontainer with docker.
 
 ## Copyright and license
 
-Code and documentation copyright 2014 Docker, inc. Code released under the Apache 2.0 license.
-Docs released under Creative commons.
-
+Code and documentation copyright 2014 Docker, inc.
+The code and documentation are released under the [Apache 2.0 license](../LICENSE).
+The documentation is also released under Creative Commons Attribution 4.0 International License.
+You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/vendor/github.com/opencontainers/runc/libcontainer/SPEC.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/SPEC.md
@@ -21,16 +21,17 @@ Minimum requirements:
 
 ### Namespaces
 
-|     Flag      | Enabled | 
-| ------------  | ------- |
-| CLONE_NEWPID  |    1    |
-| CLONE_NEWUTS  |    1    |
-| CLONE_NEWIPC  |    1    |
-| CLONE_NEWNET  |    1    |
-| CLONE_NEWNS   |    1    |
-| CLONE_NEWUSER |    1    |
+|     Flag        | Enabled |
+| --------------- | ------- |
+| CLONE_NEWPID    |    1    |
+| CLONE_NEWUTS    |    1    |
+| CLONE_NEWIPC    |    1    |
+| CLONE_NEWNET    |    1    |
+| CLONE_NEWNS     |    1    |
+| CLONE_NEWUSER   |    1    |
+| CLONE_NEWCGROUP |    1    |
 
-Namespaces are created for the container via the `clone` syscall.  
+Namespaces are created for the container via the `unshare` syscall.
 
 
 ### Filesystem
@@ -156,17 +157,21 @@ init process will block waiting for the parent to finish setup.
 
 ### IntelRdt
 
-Intel platforms with new Xeon CPU support Intel Resource Director Technology
-(RDT). Cache Allocation Technology (CAT) is a sub-feature of RDT, which
-currently supports L3 cache resource allocation.
+Intel platforms with new Xeon CPU support Resource Director Technology (RDT).
+Cache Allocation Technology (CAT) and Memory Bandwidth Allocation (MBA) are
+two sub-features of RDT.
 
-This feature provides a way for the software to restrict cache allocation to a
-defined 'subset' of L3 cache which may be overlapping with other 'subsets'.
-The different subsets are identified by class of service (CLOS) and each CLOS
-has a capacity bitmask (CBM).
+Cache Allocation Technology (CAT) provides a way for the software to restrict
+cache allocation to a defined 'subset' of L3 cache which may be overlapping
+with other 'subsets'. The different subsets are identified by class of
+service (CLOS) and each CLOS has a capacity bitmask (CBM).
 
-It can be used to handle L3 cache resource allocation for containers if
-hardware and kernel support Intel RDT/CAT.
+Memory Bandwidth Allocation (MBA) provides indirect and approximate throttle
+over memory bandwidth for the software. A user controls the resource by
+indicating the percentage of maximum memory bandwidth.
+
+It can be used to handle L3 cache and memory bandwidth resources allocation
+for containers if hardware and kernel support Intel RDT CAT and MBA features.
 
 In Linux 4.10 kernel or newer, the interface is defined and exposed via
 "resource control" filesystem, which is a "cgroup-like" interface.
@@ -175,6 +180,9 @@ Comparing with cgroups, it has similar process management lifecycle and
 interfaces in a container. But unlike cgroups' hierarchy, it has single level
 filesystem layout.
 
+CAT and MBA features are introduced in Linux 4.10 and 4.12 kernel via
+"resource control" filesystem.
+
 Intel RDT "resource control" filesystem hierarchy:
 ```
 mount -t resctrl resctrl /sys/fs/resctrl
@@ -182,59 +190,85 @@ tree /sys/fs/resctrl
 /sys/fs/resctrl/
 |-- info
 |   |-- L3
-|       |-- cbm_mask
-|       |-- min_cbm_bits
+|   |   |-- cbm_mask
+|   |   |-- min_cbm_bits
+|   |   |-- num_closids
+|   |-- MB
+|       |-- bandwidth_gran
+|       |-- delay_linear
+|       |-- min_bandwidth
 |       |-- num_closids
-|-- cpus
+|-- ...
 |-- schemata
 |-- tasks
 |-- <container_id>
-    |-- cpus
+    |-- ...
     |-- schemata
     |-- tasks
-
 ```
 
-For runc, we can make use of `tasks` and `schemata` configuration for L3 cache
-resource constraints.
+For runc, we can make use of `tasks` and `schemata` configuration for L3
+cache and memory bandwidth resources constraints.
 
 The file `tasks` has a list of tasks that belongs to this group (e.g.,
 <container_id>" group). Tasks can be added to a group by writing the task ID
-to the "tasks" file  (which will automatically remove them from the previous
+to the "tasks" file (which will automatically remove them from the previous
 group to which they belonged). New tasks created by fork(2) and clone(2) are
-added to the same group as their parent. If a pid is not in any sub group, it
-is in root group.
+added to the same group as their parent.
 
-The file `schemata` has allocation masks/values for L3 cache on each socket,
-which contains L3 cache id and capacity bitmask (CBM).
+The file `schemata` has a list of all the resources available to this group.
+Each resource (L3 cache, memory bandwidth) has its own line and format.
+
+L3 cache schema:
+It has allocation bitmasks/values for L3 cache on each socket, which
+contains L3 cache id and capacity bitmask (CBM).
 ```
 	Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 ```
-For example, on a two-socket machine, L3's schema line could be `L3:0=ff;1=c0`
-Which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.
+For example, on a two-socket machine, the schema line could be "L3:0=ff;1=c0"
+which means L3 cache id 0's CBM is 0xff, and L3 cache id 1's CBM is 0xc0.
 
 The valid L3 cache CBM is a *contiguous bits set* and number of bits that can
 be set is less than the max bit. The max bits in the CBM is varied among
-supported Intel Xeon platforms. In Intel RDT "resource control" filesystem
-layout, the CBM in a group should be a subset of the CBM in root. Kernel will
-check if it is valid when writing. e.g., 0xfffff in root indicates the max bits
-of CBM is 20 bits, which mapping to entire L3 cache capacity. Some valid CBM
-values to set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
+supported Intel CPU models. Kernel will check if it is valid when writing.
+e.g., default value 0xfffff in root indicates the max bits of CBM is 20
+bits, which mapping to entire L3 cache capacity. Some valid CBM values to
+set in a group: 0xf, 0xf0, 0x3ff, 0x1f00 and etc.
 
-For more information about Intel RDT/CAT kernel interface:  
+Memory bandwidth schema:
+It has allocation values for memory bandwidth on each socket, which contains
+L3 cache id and memory bandwidth percentage.
+```
+	Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+```
+For example, on a two-socket machine, the schema line could be "MB:0=20;1=70"
+
+The minimum bandwidth percentage value for each CPU model is predefined and
+can be looked up through "info/MB/min_bandwidth". The bandwidth granularity
+that is allocated is also dependent on the CPU model and can be looked up at
+"info/MB/bandwidth_gran". The available bandwidth control steps are:
+min_bw + N * bw_gran. Intermediate values are rounded to the next control
+step available on the hardware.
+
+For more information about Intel RDT kernel interface:  
 https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt
 
-An example for runc:
 ```
+An example for runc:
 Consider a two-socket machine with two L3 caches where the default CBM is
-0xfffff and the max CBM length is 20 bits. With this configuration, tasks
-inside the container only have access to the "upper" 80% of L3 cache id 0 and
-the "lower" 50% L3 cache id 1:
+0x7ff and the max CBM length is 11 bits, and minimum memory bandwidth of 10%
+with a memory bandwidth granularity of 10%.
+
+Tasks inside the container only have access to the "upper" 7/11 of L3 cache
+on socket 0 and the "lower" 5/11 L3 cache on socket 1, and may use a
+maximum memory bandwidth of 20% on socket 0 and 70% on socket 1.
 
 "linux": {
-	"intelRdt": {
-		"l3CacheSchema": "L3:0=ffff0;1=3ff"
-	}
+    "intelRdt": {
+        "closID": "guaranteed_group",
+        "l3CacheSchema": "L3:0=7f0;1=1f",
+        "memBwSchema": "MB:0=20;1=70"
+    }
 }
 ```
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
@@ -3,7 +3,6 @@
 package fs
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,6 +13,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -35,7 +36,7 @@ var (
 	HugePageSizes, _ = cgroups.GetHugePageSize()
 )
 
-var errSubsystemDoesNotExist = errors.New("cgroup: subsystem does not exist")
+var errSubsystemDoesNotExist = fmt.Errorf("cgroup: subsystem does not exist")
 
 type subsystemSet []subsystem
 
@@ -62,9 +63,10 @@ type subsystem interface {
 }
 
 type Manager struct {
-	mu      sync.Mutex
-	Cgroups *configs.Cgroup
-	Paths   map[string]string
+	mu       sync.Mutex
+	Cgroups  *configs.Cgroup
+	Rootless bool // ignore permission-related errors
+	Paths    map[string]string
 }
 
 // The absolute path to the root of the cgroup hierarchies.
@@ -98,6 +100,33 @@ type cgroupData struct {
 	innerPath string
 	config    *configs.Cgroup
 	pid       int
+}
+
+// isIgnorableError returns whether err is a permission error (in the loose
+// sense of the word). This includes EROFS (which for an unprivileged user is
+// basically a permission error) and EACCES (for similar reasons) as well as
+// the normal EPERM.
+func isIgnorableError(rootless bool, err error) bool {
+	// We do not ignore errors if we are root.
+	if !rootless {
+		return false
+	}
+	// Is it an ordinary EPERM?
+	if os.IsPermission(errors.Cause(err)) {
+		return true
+	}
+
+	// Try to handle other errnos.
+	var errno error
+	switch err := errors.Cause(err).(type) {
+	case *os.PathError:
+		errno = err.Err
+	case *os.LinkError:
+		errno = err.Err
+	case *os.SyscallError:
+		errno = err.Err
+	}
+	return errno == unix.EROFS || errno == unix.EPERM || errno == unix.EACCES
 }
 
 func (m *Manager) Apply(pid int) (err error) {
@@ -145,11 +174,11 @@ func (m *Manager) Apply(pid int) (err error) {
 		m.Paths[sys.Name()] = p
 
 		if err := sys.Apply(d); err != nil {
-			if os.IsPermission(err) && m.Cgroups.Path == "" {
-				// If we didn't set a cgroup path, then let's defer the error here
-				// until we know whether we have set limits or not.
-				// If we hadn't set limits, then it's ok that we couldn't join this cgroup, because
-				// it will have the same limits as its parent.
+			// In the case of rootless (including euid=0 in userns), where an explicit cgroup path hasn't
+			// been set, we don't bail on error in case of permission problems.
+			// Cases where limits have been set (and we couldn't create our own
+			// cgroup) are handled by Set.
+			if isIgnorableError(m.Rootless, err) && m.Cgroups.Path == "" {
 				delete(m.Paths, sys.Name())
 				continue
 			}
@@ -161,7 +190,7 @@ func (m *Manager) Apply(pid int) (err error) {
 }
 
 func (m *Manager) Destroy() error {
-	if m.Cgroups.Paths != nil {
+	if m.Cgroups == nil || m.Cgroups.Paths != nil {
 		return nil
 	}
 	m.mu.Lock()
@@ -207,9 +236,16 @@ func (m *Manager) Set(container *configs.Config) error {
 	for _, sys := range subsystems {
 		path := paths[sys.Name()]
 		if err := sys.Set(path, container.Cgroups); err != nil {
+			if m.Rootless && sys.Name() == "devices" {
+				continue
+			}
+			// When m.Rootless is true, errors from the device subsystem are ignored because it is really not expected to work.
+			// However, errors from other subsystems are not ignored.
+			// see @test "runc create (rootless + limits + no cgrouppath + no permission) fails with informative error"
 			if path == "" {
-				// cgroup never applied
-				return fmt.Errorf("cannot set limits on the %s cgroup, as the container has not joined it", sys.Name())
+				// We never created a path for this cgroup, so we cannot set
+				// limits for it (though we have already tried at this point).
+				return fmt.Errorf("cannot set %s limit: container could not join or create cgroup", sys.Name())
 			}
 			return err
 		}
@@ -281,7 +317,7 @@ func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
 }
 
 func (raw *cgroupData) path(subsystem string) (string, error) {
-	mnt, err := cgroups.FindCgroupMountpoint(subsystem)
+	mnt, err := cgroups.FindCgroupMountpoint(raw.root, subsystem)
 	// If we didn't mount the subsystem, there is no point we make the path.
 	if err != nil {
 		return "", err

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpu.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpu.go
@@ -46,11 +46,7 @@ func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error 
 	}
 	// because we are not using d.join we need to place the pid into the procs file
 	// unlike the other subsystems
-	if err := cgroups.WriteCgroupProc(path, pid); err != nil {
-		return err
-	}
-
-	return nil
+	return cgroups.WriteCgroupProc(path, pid)
 }
 
 func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {
@@ -83,11 +79,7 @@ func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 			return err
 		}
 	}
-	if err := s.SetRtSched(path, cgroup); err != nil {
-		return err
-	}
-
-	return nil
+	return s.SetRtSched(path, cgroup)
 }
 
 func (s *CpuGroup) Remove(d *cgroupData) error {

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpuset.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpuset.go
@@ -77,18 +77,14 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	// The logic is, if user specified cpuset configs, use these
 	// specified configs, otherwise, inherit from parent. This makes
 	// cpuset configs work correctly with 'cpuset.cpu_exclusive', and
-	// keep backward compatbility.
+	// keep backward compatibility.
 	if err := s.ensureCpusAndMems(dir, cgroup); err != nil {
 		return err
 	}
 
 	// because we are not using d.join we need to place the pid into the procs file
 	// unlike the other subsystems
-	if err := cgroups.WriteCgroupProc(dir, pid); err != nil {
-		return err
-	}
-
-	return nil
+	return cgroups.WriteCgroupProc(dir, pid)
 }
 
 func (s *CpusetGroup) getSubsystemSettings(parent string) (cpus []byte, mems []byte, err error) {

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/kmem.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/kmem.go
@@ -1,0 +1,55 @@
+// +build linux,!nokmem
+
+package fs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall" // for Errno type only
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"golang.org/x/sys/unix"
+)
+
+const cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
+
+func EnableKernelMemoryAccounting(path string) error {
+	// Check if kernel memory is enabled
+	// We have to limit the kernel memory here as it won't be accounted at all
+	// until a limit is set on the cgroup and limit cannot be set once the
+	// cgroup has children, or if there are already tasks in the cgroup.
+	for _, i := range []int64{1, -1} {
+		if err := setKernelMemory(path, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setKernelMemory(path string, kernelMemoryLimit int64) error {
+	if path == "" {
+		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
+	}
+	if !cgroups.PathExists(filepath.Join(path, cgroupKernelMemoryLimit)) {
+		// kernel memory is not enabled on the system so we should do nothing
+		return nil
+	}
+	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
+		// Check if the error number returned by the syscall is "EBUSY"
+		// The EBUSY signal is returned on attempts to write to the
+		// memory.kmem.limit_in_bytes file if the cgroup has children or
+		// once tasks have been attached to the cgroup
+		if pathErr, ok := err.(*os.PathError); ok {
+			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
+				if errNo == unix.EBUSY {
+					return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
+				}
+			}
+		}
+		return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/kmem_disabled.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/kmem_disabled.go
@@ -1,0 +1,11 @@
+// +build linux,nokmem
+
+package fs
+
+func EnableKernelMemoryAccounting(path string) error {
+	return nil
+}
+
+func setKernelMemory(path string, kernelMemoryLimit int64) error {
+	return nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
@@ -5,23 +5,18 @@ package fs
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall" // only for Errno
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
-	cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
-	cgroupMemorySwapLimit   = "memory.memsw.limit_in_bytes"
-	cgroupMemoryLimit       = "memory.limit_in_bytes"
+	cgroupMemorySwapLimit = "memory.memsw.limit_in_bytes"
+	cgroupMemoryLimit     = "memory.limit_in_bytes"
 )
 
 type MemoryGroup struct {
@@ -63,44 +58,6 @@ func (s *MemoryGroup) Apply(d *cgroupData) (err error) {
 	_, err = d.join("memory")
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
-	}
-	return nil
-}
-
-func EnableKernelMemoryAccounting(path string) error {
-	// Check if kernel memory is enabled
-	// We have to limit the kernel memory here as it won't be accounted at all
-	// until a limit is set on the cgroup and limit cannot be set once the
-	// cgroup has children, or if there are already tasks in the cgroup.
-	for _, i := range []int64{1, -1} {
-		if err := setKernelMemory(path, i); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func setKernelMemory(path string, kernelMemoryLimit int64) error {
-	if path == "" {
-		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
-	}
-	if !cgroups.PathExists(filepath.Join(path, cgroupKernelMemoryLimit)) {
-		// kernel memory is not enabled on the system so we should do nothing
-		return nil
-	}
-	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
-		// Check if the error number returned by the syscall is "EBUSY"
-		// The EBUSY signal is returned on attempts to write to the
-		// memory.kmem.limit_in_bytes file if the cgroup has children or
-		// once tasks have been attached to the cgroup
-		if pathErr, ok := err.(*os.PathError); ok {
-			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
-				if errNo == unix.EBUSY {
-					return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
-				}
-			}
-		}
-		return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
 	}
 	return nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -5,6 +5,7 @@ package systemd
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
 )
 
 type Manager struct {
@@ -74,7 +76,8 @@ var (
 	hasStartTransientUnit           bool
 	hasStartTransientSliceUnit      bool
 	hasTransientDefaultDependencies bool
-	hasDelegate                     bool
+	hasDelegateScope                bool
+	hasDelegateSlice                bool
 )
 
 func newProp(name string, units interface{}) systemdDbus.Property {
@@ -149,12 +152,12 @@ func UseSystemd() bool {
 		theConn.StopUnit(scope, "replace", nil)
 
 		// Assume StartTransientUnit on a scope allows Delegate
-		hasDelegate = true
-		dl := newProp("Delegate", true)
-		if _, err := theConn.StartTransientUnit(scope, "replace", []systemdDbus.Property{dl}, nil); err != nil {
+		hasDelegateScope = true
+		dlScope := newProp("Delegate", true)
+		if _, err := theConn.StartTransientUnit(scope, "replace", []systemdDbus.Property{dlScope}, nil); err != nil {
 			if dbusError, ok := err.(dbus.Error); ok {
 				if strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.PropertyReadOnly") {
-					hasDelegate = false
+					hasDelegateScope = false
 				}
 			}
 		}
@@ -184,6 +187,22 @@ func UseSystemd() bool {
 				break
 			}
 			time.Sleep(time.Millisecond)
+		}
+
+		// Not critical because of the stop unit logic above.
+		theConn.StopUnit(slice, "replace", nil)
+
+		// Assume StartTransientUnit on a slice allows Delegate
+		hasDelegateSlice = true
+		dlSlice := newProp("Delegate", true)
+		if _, err := theConn.StartTransientUnit(slice, "replace", []systemdDbus.Property{dlSlice}, nil); err != nil {
+			if dbusError, ok := err.(dbus.Error); ok {
+				// Starting with systemd v237, Delegate is not even a property of slices anymore,
+				// so the D-Bus call fails with "InvalidArgs" error.
+				if strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.PropertyReadOnly") || strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.InvalidArgs") {
+					hasDelegateSlice = false
+				}
+			}
 		}
 
 		// Not critical because of the stop unit logic above.
@@ -241,9 +260,16 @@ func (m *Manager) Apply(pid int) error {
 		properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	}
 
-	if hasDelegate {
-		// This is only supported on systemd versions 218 and above.
-		properties = append(properties, newProp("Delegate", true))
+	// Check if we can delegate. This is only supported on systemd versions 218 and above.
+	if strings.HasSuffix(unitName, ".slice") {
+		if hasDelegateSlice {
+			// systemd 237 and above no longer allows delegation on a slice
+			properties = append(properties, newProp("Delegate", true))
+		}
+	} else {
+		if hasDelegateScope {
+			properties = append(properties, newProp("Delegate", true))
+		}
 	}
 
 	// Always enable accounting, this gets us the same behaviour as the fs implementation,
@@ -270,13 +296,19 @@ func (m *Manager) Apply(pid int) error {
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
 	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
-		cpuQuotaPerSecUSec := uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
-		// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
-		// (integer percentage of CPU) internally.  This means that if a fractional percent of
-		// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
-		// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
-		if cpuQuotaPerSecUSec%10000 != 0 {
-			cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
+		// corresponds to USEC_INFINITY in systemd
+		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
+		// always setting a property value ensures we can apply a quota and remove it later
+		cpuQuotaPerSecUSec := uint64(math.MaxUint64)
+		if c.Resources.CpuQuota > 0 {
+			// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
+			// (integer percentage of CPU) internally.  This means that if a fractional percent of
+			// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest
+			// 10ms (1% of a second) such that child cgroups can set the cpu.cfs_quota_us they expect.
+			cpuQuotaPerSecUSec = uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
+			if cpuQuotaPerSecUSec%10000 != 0 {
+				cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
+			}
 		}
 		properties = append(properties,
 			newProp("CPUQuotaPerSecUSec", cpuQuotaPerSecUSec))
@@ -287,6 +319,12 @@ func (m *Manager) Apply(pid int) error {
 			newProp("BlockIOWeight", uint64(c.Resources.BlkioWeight)))
 	}
 
+	if c.Resources.PidsLimit > 0 {
+		properties = append(properties,
+			newProp("TasksAccounting", true),
+			newProp("TasksMax", uint64(c.Resources.PidsLimit)))
+	}
+
 	// We have to set kernel memory here, as we can't change it once
 	// processes have been attached to the cgroup.
 	if c.Resources.KernelMemory != 0 {
@@ -295,12 +333,16 @@ func (m *Manager) Apply(pid int) error {
 		}
 	}
 
-	statusChan := make(chan string)
-	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, statusChan); err != nil && !isUnitExists(err) {
+	statusChan := make(chan string, 1)
+	if _, err := theConn.StartTransientUnit(unitName, "replace", properties, statusChan); err == nil {
+		select {
+		case <-statusChan:
+		case <-time.After(time.Second):
+			logrus.Warnf("Timed out while waiting for StartTransientUnit(%s) completion signal from dbus. Continuing...", unitName)
+		}
+	} else if !isUnitExists(err) {
 		return err
 	}
-
-	<-statusChan
 
 	if err := joinCgroups(c, pid); err != nil {
 		return err
@@ -428,7 +470,7 @@ func ExpandSlice(slice string) (string, error) {
 }
 
 func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
-	mountpoint, err := cgroups.FindCgroupMountpoint(subsystem)
+	mountpoint, err := cgroups.FindCgroupMountpoint(c.Path, subsystem)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/utils.go
@@ -13,40 +13,50 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 )
 
 const (
-	cgroupNamePrefix = "name="
+	CgroupNamePrefix = "name="
 	CgroupProcesses  = "cgroup.procs"
 )
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
-func FindCgroupMountpoint(subsystem string) (string, error) {
-	mnt, _, err := FindCgroupMountpointAndRoot(subsystem)
+func FindCgroupMountpoint(cgroupPath, subsystem string) (string, error) {
+	mnt, _, err := FindCgroupMountpointAndRoot(cgroupPath, subsystem)
 	return mnt, err
 }
 
-func FindCgroupMountpointAndRoot(subsystem string) (string, string, error) {
+func FindCgroupMountpointAndRoot(cgroupPath, subsystem string) (string, string, error) {
 	// We are not using mount.GetMounts() because it's super-inefficient,
 	// parsing it directly sped up x10 times because of not using Sscanf.
 	// It was one of two major performance drawbacks in container start.
 	if !isSubsystemAvailable(subsystem) {
 		return "", "", NewNotFoundError(subsystem)
 	}
+
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return "", "", err
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
+	return findCgroupMountpointAndRootFromReader(f, cgroupPath, subsystem)
+}
+
+func findCgroupMountpointAndRootFromReader(reader io.Reader, cgroupPath, subsystem string) (string, string, error) {
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		txt := scanner.Text()
-		fields := strings.Split(txt, " ")
-		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
-			if opt == subsystem {
-				return fields[4], fields[3], nil
+		fields := strings.Fields(txt)
+		if len(fields) < 5 {
+			continue
+		}
+		if strings.HasPrefix(fields[4], cgroupPath) {
+			for _, opt := range strings.Split(fields[len(fields)-1], ",") {
+				if opt == subsystem {
+					return fields[4], fields[3], nil
+				}
 			}
 		}
 	}
@@ -103,7 +113,7 @@ func FindCgroupMountpointDir() (string, error) {
 		}
 
 		if postSeparatorFields[0] == "cgroup" {
-			// Check that the mount is properly formated.
+			// Check that the mount is properly formatted.
 			if numPostFields < 3 {
 				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
 			}
@@ -151,19 +161,20 @@ func getCgroupMountsHelper(ss map[string]bool, mi io.Reader, all bool) ([]Mount,
 			Root:       fields[3],
 		}
 		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
-			if !ss[opt] {
+			seen, known := ss[opt]
+			if !known || (!all && seen) {
 				continue
 			}
-			if strings.HasPrefix(opt, cgroupNamePrefix) {
-				m.Subsystems = append(m.Subsystems, opt[len(cgroupNamePrefix):])
-			} else {
-				m.Subsystems = append(m.Subsystems, opt)
+			ss[opt] = true
+			if strings.HasPrefix(opt, CgroupNamePrefix) {
+				opt = opt[len(CgroupNamePrefix):]
 			}
-			if !all {
-				numFound++
-			}
+			m.Subsystems = append(m.Subsystems, opt)
+			numFound++
 		}
-		res = append(res, m)
+		if len(m.Subsystems) > 0 || all {
+			res = append(res, m)
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
@@ -187,7 +198,7 @@ func GetCgroupMounts(all bool) ([]Mount, error) {
 
 	allMap := make(map[string]bool)
 	for s := range allSubsystems {
-		allMap[s] = true
+		allMap[s] = false
 	}
 	return getCgroupMountsHelper(allMap, f, all)
 }
@@ -256,13 +267,13 @@ func GetInitCgroupPath(subsystem string) (string, error) {
 }
 
 func getCgroupPathHelper(subsystem, cgroup string) (string, error) {
-	mnt, root, err := FindCgroupMountpointAndRoot(subsystem)
+	mnt, root, err := FindCgroupMountpointAndRoot("", subsystem)
 	if err != nil {
 		return "", err
 	}
 
 	// This is needed for nested containers, because in /proc/self/cgroup we
-	// see pathes from host, which don't exist in container.
+	// see paths from host, which don't exist in container.
 	relCgroup, err := filepath.Rel(root, cgroup)
 	if err != nil {
 		return "", err
@@ -342,7 +353,7 @@ func getControllerPath(subsystem string, cgroups map[string]string) (string, err
 		return p, nil
 	}
 
-	if p, ok := cgroups[cgroupNamePrefix+subsystem]; ok {
+	if p, ok := cgroups[CgroupNamePrefix+subsystem]; ok {
 		return p, nil
 	}
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -141,9 +141,10 @@ type Config struct {
 
 	// OomScoreAdj specifies the adjustment to be made by the kernel when calculating oom scores
 	// for a process. Valid values are between the range [-1000, '1000'], where processes with
-	// higher scores are preferred for being killed.
+	// higher scores are preferred for being killed. If it is unset then we don't touch the current
+	// value.
 	// More information about kernel oom score calculation here: https://lwn.net/Articles/317814/
-	OomScoreAdj int `json:"oom_score_adj"`
+	OomScoreAdj *int `json:"oom_score_adj,omitempty"`
 
 	// UidMappings is an array of User ID mappings for User Namespaces
 	UidMappings []IDMap `json:"uid_mappings"`
@@ -185,12 +186,19 @@ type Config struct {
 	// callers keyring in this case.
 	NoNewKeyring bool `json:"no_new_keyring"`
 
-	// Rootless specifies whether the container is a rootless container.
-	Rootless bool `json:"rootless"`
-
-	// IntelRdt specifies settings for Intel RDT/CAT group that the container is placed into
-	// to limit the resources (e.g., L3 cache) the container has available
+	// IntelRdt specifies settings for Intel RDT group that the container is placed into
+	// to limit the resources (e.g., L3 cache, memory bandwidth) the container has available
 	IntelRdt *IntelRdt `json:"intel_rdt,omitempty"`
+
+	// RootlessEUID is set when the runc was launched with non-zero EUID.
+	// Note that RootlessEUID is set to false when launched with EUID=0 in userns.
+	// When RootlessEUID is set, runc creates a new userns for the container.
+	// (config.json needs to contain userns settings)
+	RootlessEUID bool `json:"rootless_euid,omitempty"`
+
+	// RootlessCgroups is set when unlikely to have the full access to cgroups.
+	// When RootlessCgroups is set, cgroups errors are ignored.
+	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
 }
 
 type Hooks struct {
@@ -264,26 +272,23 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// HookState is the payload provided to a hook on execution.
-type HookState specs.State
-
 type Hook interface {
 	// Run executes the hook with the provided state.
-	Run(HookState) error
+	Run(*specs.State) error
 }
 
 // NewFunctionHook will call the provided function when the hook is run.
-func NewFunctionHook(f func(HookState) error) FuncHook {
+func NewFunctionHook(f func(*specs.State) error) FuncHook {
 	return FuncHook{
 		run: f,
 	}
 }
 
 type FuncHook struct {
-	run func(HookState) error
+	run func(*specs.State) error
 }
 
-func (f FuncHook) Run(s HookState) error {
+func (f FuncHook) Run(s *specs.State) error {
 	return f.run(s)
 }
 
@@ -306,7 +311,7 @@ type CommandHook struct {
 	Command
 }
 
-func (c Command) Run(s HookState) error {
+func (c Command) Run(s *specs.State) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
@@ -4,4 +4,8 @@ type IntelRdt struct {
 	// The schema for L3 cache id and capacity bitmask (CBM)
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
+
+	// The schema of memory bandwidth percentage per L3 cache id
+	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	MemBwSchema string `json:"memBwSchema,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/namespaces_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/namespaces_linux.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	NEWNET  NamespaceType = "NEWNET"
-	NEWPID  NamespaceType = "NEWPID"
-	NEWNS   NamespaceType = "NEWNS"
-	NEWUTS  NamespaceType = "NEWUTS"
-	NEWIPC  NamespaceType = "NEWIPC"
-	NEWUSER NamespaceType = "NEWUSER"
+	NEWNET    NamespaceType = "NEWNET"
+	NEWPID    NamespaceType = "NEWPID"
+	NEWNS     NamespaceType = "NEWNS"
+	NEWUTS    NamespaceType = "NEWUTS"
+	NEWIPC    NamespaceType = "NEWIPC"
+	NEWUSER   NamespaceType = "NEWUSER"
+	NEWCGROUP NamespaceType = "NEWCGROUP"
 )
 
 var (
@@ -35,6 +36,8 @@ func NsName(ns NamespaceType) string {
 		return "user"
 	case NEWUTS:
 		return "uts"
+	case NEWCGROUP:
+		return "cgroup"
 	}
 	return ""
 }
@@ -68,6 +71,7 @@ func NamespaceTypes() []NamespaceType {
 		NEWNET,
 		NEWPID,
 		NEWNS,
+		NEWCGROUP,
 	}
 }
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/namespaces_syscall.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/namespaces_syscall.go
@@ -9,12 +9,13 @@ func (n *Namespace) Syscall() int {
 }
 
 var namespaceInfo = map[NamespaceType]int{
-	NEWNET:  unix.CLONE_NEWNET,
-	NEWNS:   unix.CLONE_NEWNS,
-	NEWUSER: unix.CLONE_NEWUSER,
-	NEWIPC:  unix.CLONE_NEWIPC,
-	NEWUTS:  unix.CLONE_NEWUTS,
-	NEWPID:  unix.CLONE_NEWPID,
+	NEWNET:    unix.CLONE_NEWNET,
+	NEWNS:     unix.CLONE_NEWNS,
+	NEWUSER:   unix.CLONE_NEWUSER,
+	NEWIPC:    unix.CLONE_NEWIPC,
+	NEWUTS:    unix.CLONE_NEWUTS,
+	NEWPID:    unix.CLONE_NEWPID,
+	NEWCGROUP: unix.CLONE_NEWCGROUP,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/rootless.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/rootless.go
@@ -2,23 +2,18 @@ package validate
 
 import (
 	"fmt"
-	"os"
-	"reflect"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-var (
-	geteuid = os.Geteuid
-	getegid = os.Getegid
-)
-
-func (v *ConfigValidator) rootless(config *configs.Config) error {
-	if err := rootlessMappings(config); err != nil {
+// rootlessEUID makes sure that the config can be applied when runc
+// is being executed as a non-root user (euid != 0) in the current user namespace.
+func (v *ConfigValidator) rootlessEUID(config *configs.Config) error {
+	if err := rootlessEUIDMappings(config); err != nil {
 		return err
 	}
-	if err := rootlessMount(config); err != nil {
+	if err := rootlessEUIDMount(config); err != nil {
 		return err
 	}
 
@@ -38,47 +33,24 @@ func hasIDMapping(id int, mappings []configs.IDMap) bool {
 	return false
 }
 
-func rootlessMappings(config *configs.Config) error {
-	if euid := geteuid(); euid != 0 {
-		if !config.Namespaces.Contains(configs.NEWUSER) {
-			return fmt.Errorf("rootless containers require user namespaces")
-		}
+func rootlessEUIDMappings(config *configs.Config) error {
+	if !config.Namespaces.Contains(configs.NEWUSER) {
+		return fmt.Errorf("rootless container requires user namespaces")
 	}
 
 	if len(config.UidMappings) == 0 {
 		return fmt.Errorf("rootless containers requires at least one UID mapping")
 	}
 	if len(config.GidMappings) == 0 {
-		return fmt.Errorf("rootless containers requires at least one UID mapping")
+		return fmt.Errorf("rootless containers requires at least one GID mapping")
 	}
-
-	return nil
-}
-
-// cgroup verifies that the user isn't trying to set any cgroup limits or paths.
-func rootlessCgroup(config *configs.Config) error {
-	// Nothing set at all.
-	if config.Cgroups == nil || config.Cgroups.Resources == nil {
-		return nil
-	}
-
-	// Used for comparing to the zero value.
-	left := reflect.ValueOf(*config.Cgroups.Resources)
-	right := reflect.Zero(left.Type())
-
-	// This is all we need to do, since specconv won't add cgroup options in
-	// rootless mode.
-	if !reflect.DeepEqual(left.Interface(), right.Interface()) {
-		return fmt.Errorf("cannot specify resource limits in rootless container")
-	}
-
 	return nil
 }
 
 // mount verifies that the user isn't trying to set up any mounts they don't have
 // the rights to do. In addition, it makes sure that no mount has a `uid=` or
 // `gid=` option that doesn't resolve to root.
-func rootlessMount(config *configs.Config) error {
+func rootlessEUIDMount(config *configs.Config) error {
 	// XXX: We could whitelist allowed devices at this point, but I'm not
 	//      convinced that's a good idea. The kernel is the best arbiter of
 	//      access control.

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/validator.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/validate/validator.go
@@ -38,14 +38,17 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 	if err := v.usernamespace(config); err != nil {
 		return err
 	}
+	if err := v.cgroupnamespace(config); err != nil {
+		return err
+	}
 	if err := v.sysctl(config); err != nil {
 		return err
 	}
 	if err := v.intelrdt(config); err != nil {
 		return err
 	}
-	if config.Rootless {
-		if err := v.rootless(config); err != nil {
+	if config.RootlessEUID {
+		if err := v.rootlessEUID(config); err != nil {
 			return err
 		}
 	}
@@ -116,6 +119,15 @@ func (v *ConfigValidator) usernamespace(config *configs.Config) error {
 	return nil
 }
 
+func (v *ConfigValidator) cgroupnamespace(config *configs.Config) error {
+	if config.Namespaces.Contains(configs.NEWCGROUP) {
+		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+			return fmt.Errorf("cgroup namespaces aren't enabled in the kernel")
+		}
+	}
+	return nil
+}
+
 // sysctl validates that the specified sysctl keys are valid or not.
 // /proc/sys isn't completely namespaced and depending on which namespaces
 // are specified, a subset of sysctls are permitted.
@@ -151,6 +163,16 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 				return fmt.Errorf("sysctl %q is not allowed in the hosts network namespace", s)
 			}
 		}
+		if config.Namespaces.Contains(configs.NEWUTS) {
+			switch s {
+			case "kernel.domainname":
+				// This is namespaced and there's no explicit OCI field for it.
+				continue
+			case "kernel.hostname":
+				// This is namespaced but there's a conflicting (dedicated) OCI field for it.
+				return fmt.Errorf("sysctl %q is not allowed as it conflicts with the OCI %q field", s, "hostname")
+			}
+		}
 		return fmt.Errorf("sysctl %q is not in a separate kernel namespace", s)
 	}
 
@@ -159,11 +181,22 @@ func (v *ConfigValidator) sysctl(config *configs.Config) error {
 
 func (v *ConfigValidator) intelrdt(config *configs.Config) error {
 	if config.IntelRdt != nil {
-		if !intelrdt.IsEnabled() {
-			return fmt.Errorf("intelRdt is specified in config, but Intel RDT feature is not supported or enabled")
+		if !intelrdt.IsCatEnabled() && !intelrdt.IsMbaEnabled() {
+			return fmt.Errorf("intelRdt is specified in config, but Intel RDT is not supported or enabled")
 		}
-		if config.IntelRdt.L3CacheSchema == "" {
-			return fmt.Errorf("intelRdt is specified in config, but intelRdt.l3CacheSchema is empty")
+
+		if !intelrdt.IsCatEnabled() && config.IntelRdt.L3CacheSchema != "" {
+			return fmt.Errorf("intelRdt.l3CacheSchema is specified in config, but Intel RDT/CAT is not enabled")
+		}
+		if !intelrdt.IsMbaEnabled() && config.IntelRdt.MemBwSchema != "" {
+			return fmt.Errorf("intelRdt.memBwSchema is specified in config, but Intel RDT/MBA is not enabled")
+		}
+
+		if intelrdt.IsCatEnabled() && config.IntelRdt.L3CacheSchema == "" {
+			return fmt.Errorf("Intel RDT/CAT is enabled and intelRdt is specified in config, but intelRdt.l3CacheSchema is empty")
+		}
+		if intelrdt.IsMbaEnabled() && config.IntelRdt.MemBwSchema == "" {
+			return fmt.Errorf("Intel RDT/MBA is enabled and intelRdt is specified in config, but intelRdt.memBwSchema is empty")
 		}
 	}
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/container.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/container.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Status is the status of a container.
@@ -84,6 +85,12 @@ type BaseContainer interface {
 	// errors:
 	// SystemError - System error.
 	State() (*State, error)
+
+	// OCIState returns the current container's state information.
+	//
+	// errors:
+	// SystemError - System error.
+	OCIState() (*specs.State, error)
 
 	// Returns the current config of the container.
 	Config() configs.Config

--- a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -25,10 +25,10 @@ import (
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
-	"github.com/syndtr/gocapability/capability"
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
@@ -60,7 +60,8 @@ type State struct {
 
 	// Platform specific fields below here
 
-	// Specifies if the container was started under the rootless mode.
+	// Specified if the container was started under the rootless mode.
+	// Set to true if BaseState.Config.RootlessEUID && BaseState.Config.RootlessCgroups
 	Rootless bool `json:"rootless"`
 
 	// Path to all the cgroups setup for a container. Key is cgroup subsystem name
@@ -156,6 +157,12 @@ func (c *linuxContainer) State() (*State, error) {
 	return c.currentState()
 }
 
+func (c *linuxContainer) OCIState() (*specs.State, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.currentOCIState()
+}
+
 func (c *linuxContainer) Processes() ([]int, error) {
 	pids, err := c.cgroupManager.GetAllPids()
 	if err != nil {
@@ -225,17 +232,13 @@ func (c *linuxContainer) Set(config configs.Config) error {
 func (c *linuxContainer) Start(process *Process) error {
 	c.m.Lock()
 	defer c.m.Unlock()
-	status, err := c.currentStatus()
-	if err != nil {
-		return err
-	}
-	if status == Stopped {
+	if process.Init {
 		if err := c.createExecFifo(); err != nil {
 			return err
 		}
 	}
-	if err := c.start(process, status == Stopped); err != nil {
-		if status == Stopped {
+	if err := c.start(process); err != nil {
+		if process.Init {
 			c.deleteExecFifo()
 		}
 		return err
@@ -244,17 +247,10 @@ func (c *linuxContainer) Start(process *Process) error {
 }
 
 func (c *linuxContainer) Run(process *Process) error {
-	c.m.Lock()
-	status, err := c.currentStatus()
-	if err != nil {
-		c.m.Unlock()
-		return err
-	}
-	c.m.Unlock()
 	if err := c.Start(process); err != nil {
 		return err
 	}
-	if status == Stopped {
+	if process.Init {
 		return c.exec()
 	}
 	return nil
@@ -335,8 +331,8 @@ type openResult struct {
 	err  error
 }
 
-func (c *linuxContainer) start(process *Process, isInit bool) error {
-	parent, err := c.newParentProcess(process, isInit)
+func (c *linuxContainer) start(process *Process) error {
+	parent, err := c.newParentProcess(process)
 	if err != nil {
 		return newSystemErrorWithCause(err, "creating new parent process")
 	}
@@ -349,7 +345,7 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 	}
 	// generate a timestamp indicating when the container was started
 	c.created = time.Now().UTC()
-	if isInit {
+	if process.Init {
 		c.state = &createdState{
 			c: c,
 		}
@@ -360,13 +356,9 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 		c.initProcessStartTime = state.InitProcessStartTime
 
 		if c.config.Hooks != nil {
-			bundle, annotations := utils.Annotations(c.config.Labels)
-			s := configs.HookState{
-				Version:     c.config.Version,
-				ID:          c.id,
-				Pid:         parent.pid(),
-				Bundle:      bundle,
-				Annotations: annotations,
+			s, err := c.currentOCIState()
+			if err != nil {
+				return err
 			}
 			for i, hook := range c.config.Hooks.Poststart {
 				if err := hook.Run(s); err != nil {
@@ -376,10 +368,6 @@ func (c *linuxContainer) start(process *Process, isInit bool) error {
 					return newSystemErrorWithCausef(err, "running poststart hook %d", i)
 				}
 			}
-		}
-	} else {
-		c.state = &runningState{
-			c: c,
 		}
 	}
 	return nil
@@ -415,10 +403,7 @@ func (c *linuxContainer) createExecFifo() error {
 		return err
 	}
 	unix.Umask(oldMask)
-	if err := os.Chown(fifoName, rootuid, rootgid); err != nil {
-		return err
-	}
-	return nil
+	return os.Chown(fifoName, rootuid, rootgid)
 }
 
 func (c *linuxContainer) deleteExecFifo() {
@@ -443,7 +428,7 @@ func (c *linuxContainer) includeExecFifo(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProcess, error) {
+func (c *linuxContainer) newParentProcess(p *Process) (parentProcess, error) {
 	parentPipe, childPipe, err := utils.NewSockPair("init")
 	if err != nil {
 		return nil, newSystemErrorWithCause(err, "creating new init pipe")
@@ -452,7 +437,7 @@ func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProces
 	if err != nil {
 		return nil, newSystemErrorWithCause(err, "creating new command template")
 	}
-	if !doInit {
+	if !p.Init {
 		return c.newSetnsProcess(p, cmd, parentPipe, childPipe)
 	}
 
@@ -477,6 +462,7 @@ func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOMAXPROCS=%s", os.Getenv("GOMAXPROCS")))
 	cmd.ExtraFiles = append(cmd.ExtraFiles, p.ExtraFiles...)
 	if p.ConsoleSocket != nil {
 		cmd.ExtraFiles = append(cmd.ExtraFiles, p.ConsoleSocket)
@@ -510,7 +496,7 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 	if err != nil {
 		return nil, err
 	}
-	return &initProcess{
+	init := &initProcess{
 		cmd:             cmd,
 		childPipe:       childPipe,
 		parentPipe:      parentPipe,
@@ -521,7 +507,9 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 		process:         p,
 		bootstrapData:   data,
 		sharePidns:      sharePidns,
-	}, nil
+	}
+	c.initProcess = init
+	return init, nil
 }
 
 func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, childPipe *os.File) (*setnsProcess, error) {
@@ -537,14 +525,15 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 		return nil, err
 	}
 	return &setnsProcess{
-		cmd:           cmd,
-		cgroupPaths:   c.cgroupManager.GetPaths(),
-		intelRdtPath:  state.IntelRdtPath,
-		childPipe:     childPipe,
-		parentPipe:    parentPipe,
-		config:        c.newInitConfig(p),
-		process:       p,
-		bootstrapData: data,
+		cmd:             cmd,
+		cgroupPaths:     c.cgroupManager.GetPaths(),
+		rootlessCgroups: c.config.RootlessCgroups,
+		intelRdtPath:    state.IntelRdtPath,
+		childPipe:       childPipe,
+		parentPipe:      parentPipe,
+		config:          c.newInitConfig(p),
+		process:         p,
+		bootstrapData:   data,
 	}, nil
 }
 
@@ -560,7 +549,8 @@ func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 		PassedFilesCount: len(process.ExtraFiles),
 		ContainerId:      c.ID(),
 		NoNewPrivileges:  c.config.NoNewPrivileges,
-		Rootless:         c.config.Rootless,
+		RootlessEUID:     c.config.RootlessEUID,
+		RootlessCgroups:  c.config.RootlessCgroups,
 		AppArmorProfile:  c.config.AppArmorProfile,
 		ProcessLabel:     c.config.ProcessLabel,
 		Rlimits:          c.config.Rlimits,
@@ -628,16 +618,16 @@ func (c *linuxContainer) Resume() error {
 
 func (c *linuxContainer) NotifyOOM() (<-chan struct{}, error) {
 	// XXX(cyphar): This requires cgroups.
-	if c.config.Rootless {
-		return nil, fmt.Errorf("cannot get OOM notifications from rootless container")
+	if c.config.RootlessCgroups {
+		logrus.Warn("getting OOM notifications may fail if you don't have the full access to cgroups")
 	}
 	return notifyOnOOM(c.cgroupManager.GetPaths())
 }
 
 func (c *linuxContainer) NotifyMemoryPressure(level PressureLevel) (<-chan struct{}, error) {
 	// XXX(cyphar): This requires cgroups.
-	if c.config.Rootless {
-		return nil, fmt.Errorf("cannot get memory pressure notifications from rootless container")
+	if c.config.RootlessCgroups {
+		logrus.Warn("getting memory pressure notifications may fail if you don't have the full access to cgroups")
 	}
 	return notifyMemoryPressure(c.cgroupManager.GetPaths(), level)
 }
@@ -672,7 +662,7 @@ func (c *linuxContainer) checkCriuFeatures(criuOpts *CriuOpts, rpcOpts *criurpc.
 		Features: criuFeat,
 	}
 
-	err := c.criuSwrk(nil, req, criuOpts, false)
+	err := c.criuSwrk(nil, req, criuOpts, false, nil)
 	if err != nil {
 		logrus.Debugf("%s", err)
 		return fmt.Errorf("CRIU feature check failed")
@@ -785,7 +775,7 @@ func (c *linuxContainer) checkCriuVersion(minVersion int) error {
 		Type: &t,
 	}
 
-	err := c.criuSwrk(nil, req, nil, false)
+	err := c.criuSwrk(nil, req, nil, false, nil)
 	if err != nil {
 		return fmt.Errorf("CRIU version check failed: %s", err)
 	}
@@ -881,12 +871,11 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	// Checkpoint is unlikely to work if os.Geteuid() != 0 || system.RunningInUserNS().
+	// (CLI prints a warning)
 	// TODO(avagin): Figure out how to make this work nicely. CRIU 2.0 has
 	//               support for doing unprivileged dumps, but the setup of
 	//               rootless containers might make this complicated.
-	if c.config.Rootless {
-		return fmt.Errorf("cannot checkpoint a rootless container")
-	}
 
 	// criu 1.5.2 => 10502
 	if err := c.checkCriuVersion(10502); err != nil {
@@ -941,6 +930,33 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 		OrphanPtsMaster: proto.Bool(true),
 		AutoDedup:       proto.Bool(criuOpts.AutoDedup),
 		LazyPages:       proto.Bool(criuOpts.LazyPages),
+	}
+
+	// If the container is running in a network namespace and has
+	// a path to the network namespace configured, we will dump
+	// that network namespace as an external namespace and we
+	// will expect that the namespace exists during restore.
+	// This basically means that CRIU will ignore the namespace
+	// and expect to be setup correctly.
+	nsPath := c.config.Namespaces.PathOf(configs.NEWNET)
+	if nsPath != "" {
+		// For this to work we need at least criu 3.11.0 => 31100.
+		// As there was already a successful version check we will
+		// not error out if it fails. runc will just behave as it used
+		// to do and ignore external network namespaces.
+		err := c.checkCriuVersion(31100)
+		if err == nil {
+			// CRIU expects the information about an external namespace
+			// like this: --external net[<inode>]:<key>
+			// This <key> is always 'extRootNetNS'.
+			var netns syscall.Stat_t
+			err = syscall.Stat(nsPath, &netns)
+			if err != nil {
+				return err
+			}
+			criuExternal := fmt.Sprintf("net[%d]:extRootNetNS", netns.Ino)
+			rpcOpts.External = append(rpcOpts.External, criuExternal)
+		}
 	}
 
 	fcg := c.cgroupManager.GetPaths()["freezer"]
@@ -1047,7 +1063,7 @@ func (c *linuxContainer) Checkpoint(criuOpts *CriuOpts) error {
 		}
 	}
 
-	err = c.criuSwrk(nil, req, criuOpts, false)
+	err = c.criuSwrk(nil, req, criuOpts, false, nil)
 	if err != nil {
 		return err
 	}
@@ -1091,11 +1107,12 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	var extraFiles []*os.File
+
+	// Restore is unlikely to work if os.Geteuid() != 0 || system.RunningInUserNS().
+	// (CLI prints a warning)
 	// TODO(avagin): Figure out how to make this work nicely. CRIU doesn't have
 	//               support for unprivileged restore at the moment.
-	if c.config.Rootless {
-		return fmt.Errorf("cannot restore a rootless container")
-	}
 
 	// criu 1.5.2 => 10502
 	if err := c.checkCriuVersion(10502); err != nil {
@@ -1165,6 +1182,38 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 		},
 	}
 
+	// Same as during checkpointing. If the container has a specific network namespace
+	// assigned to it, this now expects that the checkpoint will be restored in a
+	// already created network namespace.
+	nsPath := c.config.Namespaces.PathOf(configs.NEWNET)
+	if nsPath != "" {
+		// For this to work we need at least criu 3.11.0 => 31100.
+		// As there was already a successful version check we will
+		// not error out if it fails. runc will just behave as it used
+		// to do and ignore external network namespaces.
+		err := c.checkCriuVersion(31100)
+		if err == nil {
+			// CRIU wants the information about an existing network namespace
+			// like this: --inherit-fd fd[<fd>]:<key>
+			// The <key> needs to be the same as during checkpointing.
+			// We are always using 'extRootNetNS' as the key in this.
+			netns, err := os.Open(nsPath)
+			defer netns.Close()
+			if err != nil {
+				logrus.Errorf("If a specific network namespace is defined it must exist: %s", err)
+				return fmt.Errorf("Requested network namespace %v does not exist", nsPath)
+			}
+			inheritFd := new(criurpc.InheritFd)
+			inheritFd.Key = proto.String("extRootNetNS")
+			// The offset of four is necessary because 0, 1, 2 and 3 is already
+			// used by stdin, stdout, stderr, 'criu swrk' socket.
+			inheritFd.Fd = proto.Int32(int32(4 + len(extraFiles)))
+			req.Opts.InheritFd = append(req.Opts.InheritFd, inheritFd)
+			// All open FDs need to be transferred to CRIU via extraFiles
+			extraFiles = append(extraFiles, netns)
+		}
+	}
+
 	for _, m := range c.config.Mounts {
 		switch m.Device {
 		case "bind":
@@ -1223,7 +1272,7 @@ func (c *linuxContainer) Restore(process *Process, criuOpts *CriuOpts) error {
 			req.Opts.InheritFd = append(req.Opts.InheritFd, inheritFd)
 		}
 	}
-	return c.criuSwrk(process, req, criuOpts, true)
+	return c.criuSwrk(process, req, criuOpts, true, extraFiles)
 }
 
 func (c *linuxContainer) criuApplyCgroups(pid int, req *criurpc.CriuReq) error {
@@ -1253,7 +1302,7 @@ func (c *linuxContainer) criuApplyCgroups(pid int, req *criurpc.CriuReq) error {
 	return nil
 }
 
-func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuOpts, applyCgroups bool) error {
+func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuOpts, applyCgroups bool, extraFiles []*os.File) error {
 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return err
@@ -1294,6 +1343,9 @@ func (c *linuxContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *
 		cmd.Stderr = process.Stderr
 	}
 	cmd.ExtraFiles = append(cmd.ExtraFiles, criuServer)
+	if extraFiles != nil {
+		cmd.ExtraFiles = append(cmd.ExtraFiles, extraFiles...)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -1490,13 +1542,9 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 		}
 	case notify.GetScript() == "setup-namespaces":
 		if c.config.Hooks != nil {
-			bundle, annotations := utils.Annotations(c.config.Labels)
-			s := configs.HookState{
-				Version:     c.config.Version,
-				ID:          c.id,
-				Pid:         int(notify.GetPid()),
-				Bundle:      bundle,
-				Annotations: annotations,
+			s, err := c.currentOCIState()
+			if err != nil {
+				return nil
 			}
 			for i, hook := range c.config.Hooks.Prestart {
 				if err := hook.Run(s); err != nil {
@@ -1668,7 +1716,7 @@ func (c *linuxContainer) currentState() (*State, error) {
 			InitProcessStartTime: startTime,
 			Created:              c.created,
 		},
-		Rootless:            c.config.Rootless,
+		Rootless:            c.config.RootlessEUID && c.config.RootlessCgroups,
 		CgroupPaths:         c.cgroupManager.GetPaths(),
 		IntelRdtPath:        intelRdtPath,
 		NamespacePaths:      make(map[configs.NamespaceType]string),
@@ -1691,11 +1739,31 @@ func (c *linuxContainer) currentState() (*State, error) {
 	return state, nil
 }
 
+func (c *linuxContainer) currentOCIState() (*specs.State, error) {
+	bundle, annotations := utils.Annotations(c.config.Labels)
+	state := &specs.State{
+		Version:     specs.Version,
+		ID:          c.ID(),
+		Bundle:      bundle,
+		Annotations: annotations,
+	}
+	status, err := c.currentStatus()
+	if err != nil {
+		return nil, err
+	}
+	state.Status = status.String()
+	if status != Stopped {
+		if c.initProcess != nil {
+			state.Pid = c.initProcess.pid()
+		}
+	}
+	return state, nil
+}
+
 // orderNamespacePaths sorts namespace paths into a list of paths that we
 // can setns in order.
 func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
 	paths := []string{}
-
 	for _, ns := range configs.NamespaceTypes() {
 
 		// Remove namespaces that we don't need to join.
@@ -1769,7 +1837,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	if !joinExistingUser {
 		// write uid mappings
 		if len(c.config.UidMappings) > 0 {
-			if c.config.Rootless && c.newuidmapPath != "" {
+			if c.config.RootlessEUID && c.newuidmapPath != "" {
 				r.AddData(&Bytemsg{
 					Type:  UidmapPathAttr,
 					Value: []byte(c.newuidmapPath),
@@ -1795,39 +1863,33 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 				Type:  GidmapAttr,
 				Value: b,
 			})
-			if c.config.Rootless && c.newgidmapPath != "" {
+			if c.config.RootlessEUID && c.newgidmapPath != "" {
 				r.AddData(&Bytemsg{
 					Type:  GidmapPathAttr,
 					Value: []byte(c.newgidmapPath),
 				})
 			}
-			// The following only applies if we are root.
-			if !c.config.Rootless {
-				// check if we have CAP_SETGID to setgroup properly
-				pid, err := capability.NewPid(0)
-				if err != nil {
-					return nil, err
-				}
-				if !pid.Get(capability.EFFECTIVE, capability.CAP_SETGID) {
-					r.AddData(&Boolmsg{
-						Type:  SetgroupAttr,
-						Value: true,
-					})
-				}
+			if requiresRootOrMappingTool(c.config) {
+				r.AddData(&Boolmsg{
+					Type:  SetgroupAttr,
+					Value: true,
+				})
 			}
 		}
 	}
 
-	// write oom_score_adj
-	r.AddData(&Bytemsg{
-		Type:  OomScoreAdjAttr,
-		Value: []byte(fmt.Sprintf("%d", c.config.OomScoreAdj)),
-	})
+	if c.config.OomScoreAdj != nil {
+		// write oom_score_adj
+		r.AddData(&Bytemsg{
+			Type:  OomScoreAdjAttr,
+			Value: []byte(fmt.Sprintf("%d", *c.config.OomScoreAdj)),
+		})
+	}
 
 	// write rootless
 	r.AddData(&Boolmsg{
-		Type:  RootlessAttr,
-		Value: c.config.Rootless,
+		Type:  RootlessEUIDAttr,
+		Value: c.config.RootlessEUID,
 	})
 
 	return bytes.NewReader(r.Serialize()), nil
@@ -1846,4 +1908,11 @@ func ignoreTerminateErrors(err error) error {
 		return nil
 	}
 	return err
+}
+
+func requiresRootOrMappingTool(c *configs.Config) bool {
+	gidMap := []configs.IDMap{
+		{ContainerID: 0, HostID: os.Getegid(), Size: 1},
+	}
+	return !reflect.DeepEqual(c.GidMappings, gidMap)
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
@@ -30,8 +30,9 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 	}
 
 	var (
-		devNumber = stat.Rdev
+		devNumber = uint64(stat.Rdev)
 		major     = unix.Major(devNumber)
+		minor     = unix.Minor(devNumber)
 	)
 	if major == 0 {
 		return nil, ErrNotADevice
@@ -51,7 +52,7 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		Type:        devType,
 		Path:        path,
 		Major:       int64(major),
-		Minor:       int64(unix.Minor(devNumber)),
+		Minor:       int64(minor),
 		Permissions: permissions,
 		FileMode:    os.FileMode(mode),
 		Uid:         stat.Uid,

--- a/vendor/github.com/opencontainers/runc/libcontainer/factory_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/factory_linux.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strconv"
 
+	"github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
@@ -59,9 +60,9 @@ func SystemdCgroups(l *LinuxFactory) error {
 	return nil
 }
 
-// Cgroupfs is an options func to configure a LinuxFactory to return
-// containers that use the native cgroups filesystem implementation to
-// create and manage cgroups.
+// Cgroupfs is an options func to configure a LinuxFactory to return containers
+// that use the native cgroups filesystem implementation to create and manage
+// cgroups.
 func Cgroupfs(l *LinuxFactory) error {
 	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
 		return &fs.Manager{
@@ -72,9 +73,26 @@ func Cgroupfs(l *LinuxFactory) error {
 	return nil
 }
 
+// RootlessCgroupfs is an options func to configure a LinuxFactory to return
+// containers that use the native cgroups filesystem implementation to create
+// and manage cgroups. The difference between RootlessCgroupfs and Cgroupfs is
+// that RootlessCgroupfs can transparently handle permission errors that occur
+// during rootless container (including euid=0 in userns) setup (while still allowing cgroup usage if
+// they've been set up properly).
+func RootlessCgroupfs(l *LinuxFactory) error {
+	l.NewCgroupsManager = func(config *configs.Cgroup, paths map[string]string) cgroups.Manager {
+		return &fs.Manager{
+			Cgroups:  config,
+			Rootless: true,
+			Paths:    paths,
+		}
+	}
+	return nil
+}
+
 // IntelRdtfs is an options func to configure a LinuxFactory to return
 // containers that use the Intel RDT "resource control" filesystem to
-// create and manage Intel Xeon platform shared resources (e.g., L3 cache).
+// create and manage Intel RDT resources (e.g., L3 cache, memory bandwidth).
 func IntelRdtFs(l *LinuxFactory) error {
 	l.NewIntelRdtManager = func(config *configs.Config, id string, path string) intelrdt.Manager {
 		return &intelrdt.IntelRdtManager{
@@ -178,7 +196,10 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 	if err := l.Validator.Validate(config); err != nil {
 		return nil, newGenericError(err, ConfigInvalid)
 	}
-	containerRoot := filepath.Join(l.Root, id)
+	containerRoot, err := securejoin.SecureJoin(l.Root, id)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := os.Stat(containerRoot); err == nil {
 		return nil, newGenericError(fmt.Errorf("container with id exists: %v", id), IdInUse)
 	} else if !os.IsNotExist(err) {
@@ -201,7 +222,7 @@ func (l *LinuxFactory) Create(id string, config *configs.Config) (Container, err
 		newgidmapPath: l.NewgidmapPath,
 		cgroupManager: l.NewCgroupsManager(config.Cgroups, nil),
 	}
-	if intelrdt.IsEnabled() {
+	if intelrdt.IsCatEnabled() || intelrdt.IsMbaEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(config, id, "")
 	}
 	c.state = &stoppedState{c: c}
@@ -212,7 +233,14 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if l.Root == "" {
 		return nil, newGenericError(fmt.Errorf("invalid root"), ConfigInvalid)
 	}
-	containerRoot := filepath.Join(l.Root, id)
+	//when load, we need to check id is valid or not.
+	if err := l.validateID(id); err != nil {
+		return nil, err
+	}
+	containerRoot, err := securejoin.SecureJoin(l.Root, id)
+	if err != nil {
+		return nil, err
+	}
 	state, err := l.loadState(containerRoot, id)
 	if err != nil {
 		return nil, err
@@ -240,7 +268,7 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	if err := c.refreshState(); err != nil {
 		return nil, err
 	}
-	if intelrdt.IsEnabled() {
+	if intelrdt.IsCatEnabled() || intelrdt.IsMbaEnabled() {
 		c.intelRdtManager = l.NewIntelRdtManager(&state.Config, id, state.IntelRdtPath)
 	}
 	return c, nil
@@ -322,7 +350,11 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 }
 
 func (l *LinuxFactory) loadState(root, id string) (*State, error) {
-	f, err := os.Open(filepath.Join(root, stateFilename))
+	stateFilePath, err := securejoin.SecureJoin(root, stateFilename)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(stateFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, newGenericError(fmt.Errorf("container %q does not exist", id), ContainerNotExists)
@@ -338,7 +370,7 @@ func (l *LinuxFactory) loadState(root, id string) (*State, error) {
 }
 
 func (l *LinuxFactory) validateID(id string) error {
-	if !idRegex.MatchString(id) {
+	if !idRegex.MatchString(id) || string(os.PathSeparator)+id != utils.CleanPath(string(os.PathSeparator)+id) {
 		return newGenericError(fmt.Errorf("invalid id format: %v", id), InvalidIdFormat)
 	}
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/intelrdt/stats.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/intelrdt/stats.go
@@ -8,6 +8,13 @@ type L3CacheInfo struct {
 	NumClosids uint64 `json:"num_closids,omitempty"`
 }
 
+type MemBwInfo struct {
+	BandwidthGran uint64 `json:"bandwidth_gran,omitempty"`
+	DelayLinear   uint64 `json:"delay_linear,omitempty"`
+	MinBandwidth  uint64 `json:"min_bandwidth,omitempty"`
+	NumClosids    uint64 `json:"num_closids,omitempty"`
+}
+
 type Stats struct {
 	// The read-only L3 cache information
 	L3CacheInfo *L3CacheInfo `json:"l3_cache_info,omitempty"`
@@ -17,6 +24,15 @@ type Stats struct {
 
 	// The L3 cache schema in 'container_id' group
 	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
+
+	// The read-only memory bandwidth information
+	MemBwInfo *MemBwInfo `json:"mem_bw_info,omitempty"`
+
+	// The read-only memory bandwidth schema in root
+	MemBwSchemaRoot string `json:"mem_bw_schema_root,omitempty"`
+
+	// The memory bandwidth schema in 'container_id' group
+	MemBwSchema string `json:"mem_bw_schema,omitempty"`
 }
 
 func NewStats() *Stats {

--- a/vendor/github.com/opencontainers/runc/libcontainer/keys/keyctl.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/keys/keyctl.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -15,7 +17,7 @@ type KeySerial uint32
 func JoinSessionKeyring(name string) (KeySerial, error) {
 	sessKeyId, err := unix.KeyctlJoinSessionKeyring(name)
 	if err != nil {
-		return 0, fmt.Errorf("could not create session key: %v", err)
+		return 0, errors.Wrap(err, "create session key")
 	}
 	return KeySerial(sessKeyId), nil
 }
@@ -42,9 +44,5 @@ func ModKeyringPerm(ringId KeySerial, mask, setbits uint32) error {
 
 	perm := (uint32(perm64) & mask) | setbits
 
-	if err := unix.KeyctlSetperm(int(ringId), perm); err != nil {
-		return err
-	}
-
-	return nil
+	return unix.KeyctlSetperm(int(ringId), perm)
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/message_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/message_linux.go
@@ -10,16 +10,16 @@ import (
 // list of known message types we want to send to bootstrap program
 // The number is randomly chosen to not conflict with known netlink types
 const (
-	InitMsg         uint16 = 62000
-	CloneFlagsAttr  uint16 = 27281
-	NsPathsAttr     uint16 = 27282
-	UidmapAttr      uint16 = 27283
-	GidmapAttr      uint16 = 27284
-	SetgroupAttr    uint16 = 27285
-	OomScoreAdjAttr uint16 = 27286
-	RootlessAttr    uint16 = 27287
-	UidmapPathAttr  uint16 = 27288
-	GidmapPathAttr  uint16 = 27289
+	InitMsg          uint16 = 62000
+	CloneFlagsAttr   uint16 = 27281
+	NsPathsAttr      uint16 = 27282
+	UidmapAttr       uint16 = 27283
+	GidmapAttr       uint16 = 27284
+	SetgroupAttr     uint16 = 27285
+	OomScoreAdjAttr  uint16 = 27286
+	RootlessEUIDAttr uint16 = 27287
+	UidmapPathAttr   uint16 = 27288
+	GidmapPathAttr   uint16 = 27289
 )
 
 type Int32msg struct {
@@ -77,13 +77,13 @@ func (msg *Boolmsg) Serialize() []byte {
 	native.PutUint16(buf[0:2], uint16(msg.Len()))
 	native.PutUint16(buf[2:4], msg.Type)
 	if msg.Value {
-		buf[4] = 1
+		native.PutUint32(buf[4:8], uint32(1))
 	} else {
-		buf[4] = 0
+		native.PutUint32(buf[4:8], uint32(0))
 	}
 	return buf
 }
 
 func (msg *Boolmsg) Len() int {
-	return unix.NLA_HDRLEN + 1
+	return unix.NLA_HDRLEN + 4 // alignment
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/network_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/network_linux.go
@@ -5,18 +5,15 @@ package libcontainer
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/vishvananda/netlink"
 )
 
 var strategies = map[string]networkStrategy{
-	"veth":     &veth{},
 	"loopback": &loopback{},
 }
 
@@ -101,159 +98,5 @@ func (l *loopback) attach(n *configs.Network) (err error) {
 }
 
 func (l *loopback) detach(n *configs.Network) (err error) {
-	return nil
-}
-
-// veth is a network strategy that uses a bridge and creates
-// a veth pair, one that is attached to the bridge on the host and the other
-// is placed inside the container's namespace
-type veth struct {
-}
-
-func (v *veth) detach(n *configs.Network) (err error) {
-	return netlink.LinkSetMaster(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: n.HostInterfaceName}}, nil)
-}
-
-// attach a container network interface to an external network
-func (v *veth) attach(n *configs.Network) (err error) {
-	brl, err := netlink.LinkByName(n.Bridge)
-	if err != nil {
-		return err
-	}
-	br, ok := brl.(*netlink.Bridge)
-	if !ok {
-		return fmt.Errorf("Wrong device type %T", brl)
-	}
-	host, err := netlink.LinkByName(n.HostInterfaceName)
-	if err != nil {
-		return err
-	}
-
-	if err := netlink.LinkSetMaster(host, br); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetMTU(host, n.Mtu); err != nil {
-		return err
-	}
-	if n.HairpinMode {
-		if err := netlink.LinkSetHairpin(host, true); err != nil {
-			return err
-		}
-	}
-	if err := netlink.LinkSetUp(host); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (v *veth) create(n *network, nspid int) (err error) {
-	tmpName, err := v.generateTempPeerName()
-	if err != nil {
-		return err
-	}
-	n.TempVethPeerName = tmpName
-	if n.Bridge == "" {
-		return fmt.Errorf("bridge is not specified")
-	}
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:   n.HostInterfaceName,
-			TxQLen: n.TxQueueLen,
-		},
-		PeerName: n.TempVethPeerName,
-	}
-	if err := netlink.LinkAdd(veth); err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil {
-			netlink.LinkDel(veth)
-		}
-	}()
-	if err := v.attach(&n.Network); err != nil {
-		return err
-	}
-	child, err := netlink.LinkByName(n.TempVethPeerName)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetNsPid(child, nspid)
-}
-
-func (v *veth) generateTempPeerName() (string, error) {
-	return utils.GenerateRandomName("veth", 7)
-}
-
-func (v *veth) initialize(config *network) error {
-	peer := config.TempVethPeerName
-	if peer == "" {
-		return fmt.Errorf("peer is not specified")
-	}
-	child, err := netlink.LinkByName(peer)
-	if err != nil {
-		return err
-	}
-	if err := netlink.LinkSetDown(child); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetName(child, config.Name); err != nil {
-		return err
-	}
-	// get the interface again after we changed the name as the index also changes.
-	if child, err = netlink.LinkByName(config.Name); err != nil {
-		return err
-	}
-	if config.MacAddress != "" {
-		mac, err := net.ParseMAC(config.MacAddress)
-		if err != nil {
-			return err
-		}
-		if err := netlink.LinkSetHardwareAddr(child, mac); err != nil {
-			return err
-		}
-	}
-	ip, err := netlink.ParseAddr(config.Address)
-	if err != nil {
-		return err
-	}
-	if err := netlink.AddrAdd(child, ip); err != nil {
-		return err
-	}
-	if config.IPv6Address != "" {
-		ip6, err := netlink.ParseAddr(config.IPv6Address)
-		if err != nil {
-			return err
-		}
-		if err := netlink.AddrAdd(child, ip6); err != nil {
-			return err
-		}
-	}
-	if err := netlink.LinkSetMTU(child, config.Mtu); err != nil {
-		return err
-	}
-	if err := netlink.LinkSetUp(child); err != nil {
-		return err
-	}
-	if config.Gateway != "" {
-		gw := net.ParseIP(config.Gateway)
-		if err := netlink.RouteAdd(&netlink.Route{
-			Scope:     netlink.SCOPE_UNIVERSE,
-			LinkIndex: child.Attrs().Index,
-			Gw:        gw,
-		}); err != nil {
-			return err
-		}
-	}
-	if config.IPv6Gateway != "" {
-		gw := net.ParseIP(config.IPv6Gateway)
-		if err := netlink.RouteAdd(&netlink.Route{
-			Scope:     netlink.SCOPE_UNIVERSE,
-			LinkIndex: child.Attrs().Index,
-			Gw:        gw,
-		}); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/README.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/README.md
@@ -10,8 +10,8 @@ The `nsenter` package will `import "C"` and it uses [cgo](https://golang.org/cmd
 package. In cgo, if the import of "C" is immediately preceded by a comment, that comment, 
 called the preamble, is used as a header when compiling the C parts of the package.
 So every time we  import package `nsenter`, the C code function `nsexec()` would be 
-called. And package `nsenter` is now only imported in `main_unix.go`, so every time
-before we call `cmd.Start` on linux, that C code would run.
+called. And package `nsenter` is only imported in `init.go`, so every time the runc
+`init` command is invoked, that C code is run.
 
 Because `nsexec()` must be run before the Go runtime in order to use the
 Linux kernel namespace, you must `import` this library into a package if
@@ -37,7 +37,7 @@ the parent `nsexec()` will exit and the child `nsexec()` process will
 return to allow the Go runtime take over.
 
 NOTE: We do both `setns(2)` and `clone(2)` even if we don't have any
-CLONE_NEW* clone flags because we must fork a new process in order to
+`CLONE_NEW*` clone flags because we must fork a new process in order to
 enter the PID namespace.
 
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/process.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/process.go
@@ -72,6 +72,9 @@ type Process struct {
 	// ConsoleSocket provides the masterfd console.
 	ConsoleSocket *os.File
 
+	// Init specifies whether the process is the first process in the container.
+	Init bool
+
 	ops processOperations
 }
 

--- a/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
@@ -46,6 +46,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 		return newSystemErrorWithCause(err, "preparing rootfs")
 	}
 
+	hasCgroupns := config.Namespaces.Contains(configs.NEWCGROUP)
 	setupDev := needsSetupDev(config)
 	for _, m := range config.Mounts {
 		for _, precmd := range m.PremountCmds {
@@ -53,8 +54,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 				return newSystemErrorWithCause(err, "running premount command")
 			}
 		}
-
-		if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
+		if err := mountToRootfs(m, config.Rootfs, config.MountLabel, hasCgroupns); err != nil {
 			return newSystemErrorWithCausef(err, "mounting %q to rootfs %q at %q", m.Source, config.Rootfs, m.Destination)
 		}
 
@@ -152,6 +152,26 @@ func finalizeRootfs(config *configs.Config) (err error) {
 	return nil
 }
 
+// /tmp has to be mounted as private to allow MS_MOVE to work in all situations
+func prepareTmp(topTmpDir string) (string, error) {
+	tmpdir, err := ioutil.TempDir(topTmpDir, "runctop")
+	if err != nil {
+		return "", err
+	}
+	if err := unix.Mount(tmpdir, tmpdir, "bind", unix.MS_BIND, ""); err != nil {
+		return "", err
+	}
+	if err := unix.Mount("", tmpdir, "", uintptr(unix.MS_PRIVATE), ""); err != nil {
+		return "", err
+	}
+	return tmpdir, nil
+}
+
+func cleanupTmp(tmpdir string) error {
+	unix.Unmount(tmpdir, 0)
+	return os.RemoveAll(tmpdir)
+}
+
 func mountCmd(cmd configs.Command) error {
 	command := exec.Command(cmd.Path, cmd.Args[:]...)
 	command.Env = cmd.Env
@@ -162,7 +182,7 @@ func mountCmd(cmd configs.Command) error {
 	return nil
 }
 
-func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
+func mountToRootfs(m *configs.Mount, rootfs, mountLabel string, enableCgroupns bool) error {
 	var (
 		dest = m.Destination
 	)
@@ -199,7 +219,12 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			}
 		}
 		if copyUp {
-			tmpDir, err = ioutil.TempDir("/tmp", "runctmpdir")
+			tmpdir, err := prepareTmp("/tmp")
+			if err != nil {
+				return newSystemErrorWithCause(err, "tmpcopyup: failed to setup tmpdir")
+			}
+			defer cleanupTmp(tmpdir)
+			tmpDir, err = ioutil.TempDir(tmpdir, "runctmpdir")
 			if err != nil {
 				return newSystemErrorWithCause(err, "tmpcopyup: failed to create tmpdir")
 			}
@@ -294,12 +319,33 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			Data:             "mode=755",
 			PropagationFlags: m.PropagationFlags,
 		}
-		if err := mountToRootfs(tmpfs, rootfs, mountLabel); err != nil {
+		if err := mountToRootfs(tmpfs, rootfs, mountLabel, enableCgroupns); err != nil {
 			return err
 		}
 		for _, b := range binds {
-			if err := mountToRootfs(b, rootfs, mountLabel); err != nil {
-				return err
+			if enableCgroupns {
+				subsystemPath := filepath.Join(rootfs, b.Destination)
+				if err := os.MkdirAll(subsystemPath, 0755); err != nil {
+					return err
+				}
+				flags := defaultMountFlags
+				if m.Flags&unix.MS_RDONLY != 0 {
+					flags = flags | unix.MS_RDONLY
+				}
+				cgroupmount := &configs.Mount{
+					Source:      "cgroup",
+					Device:      "cgroup",
+					Destination: subsystemPath,
+					Flags:       flags,
+					Data:        filepath.Base(subsystemPath),
+				}
+				if err := mountNewCgroup(cgroupmount); err != nil {
+					return err
+				}
+			} else {
+				if err := mountToRootfs(b, rootfs, mountLabel, enableCgroupns); err != nil {
+					return err
+				}
 			}
 		}
 		for _, mc := range merged {
@@ -396,6 +442,7 @@ func checkMountDestination(rootfs, dest string) error {
 		"/proc/stat",
 		"/proc/swaps",
 		"/proc/uptime",
+		"/proc/loadavg",
 		"/proc/net/dev",
 	}
 	for _, valid := range validDestinations {
@@ -412,7 +459,7 @@ func checkMountDestination(rootfs, dest string) error {
 		if err != nil {
 			return err
 		}
-		if path == "." || !strings.HasPrefix(path, "..") {
+		if path != "." && !strings.HasPrefix(path, "..") {
 			return fmt.Errorf("%q cannot be mounted because it is located inside %q", dest, invalid)
 		}
 	}
@@ -778,10 +825,10 @@ func remountReadonly(m *configs.Mount) error {
 // mounts ( proc/kcore ).
 // For files, maskPath bind mounts /dev/null over the top of the specified path.
 // For directories, maskPath mounts read-only tmpfs over the top of the specified path.
-func maskPath(path string) error {
+func maskPath(path string, mountLabel string) error {
 	if err := unix.Mount("/dev/null", path, "", unix.MS_BIND, ""); err != nil && !os.IsNotExist(err) {
 		if err == unix.ENOTDIR {
-			return unix.Mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, "")
+			return unix.Mount("tmpfs", path, "tmpfs", unix.MS_RDONLY, label.FormatMountLabel("", mountLabel))
 		}
 		return err
 	}
@@ -802,10 +849,7 @@ func remount(m *configs.Mount, rootfs string) error {
 	if !strings.HasPrefix(dest, rootfs) {
 		dest = filepath.Join(rootfs, dest)
 	}
-	if err := unix.Mount(m.Source, dest, m.Device, uintptr(m.Flags|unix.MS_REMOUNT), ""); err != nil {
-		return err
-	}
-	return nil
+	return unix.Mount(m.Source, dest, m.Device, uintptr(m.Flags|unix.MS_REMOUNT), "")
 }
 
 // Do the mount operation followed by additional mounts required to take care
@@ -833,6 +877,21 @@ func mountPropagate(m *configs.Mount, rootfs string, mountLabel string) error {
 		if err := unix.Mount("", dest, "", uintptr(pflag), ""); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func mountNewCgroup(m *configs.Mount) error {
+	var (
+		data   = m.Data
+		source = m.Source
+	)
+	if data == "systemd" {
+		data = cgroups.CgroupNamePrefix + data
+		source = "systemd"
+	}
+	if err := unix.Mount(source, m.Destination, m.Device, uintptr(m.Flags), data); err != nil {
+		return err
 	}
 	return nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go
@@ -5,12 +5,14 @@ package libcontainer
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/keys"
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 
 	"golang.org/x/sys/unix"
 )
@@ -28,10 +30,19 @@ func (l *linuxSetnsInit) getSessionRingName() string {
 }
 
 func (l *linuxSetnsInit) Init() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if !l.config.Config.NoNewKeyring {
-		// do not inherit the parent's session keyring
+		// Do not inherit the parent's session keyring.
 		if _, err := keys.JoinSessionKeyring(l.getSessionRingName()); err != nil {
-			return err
+			// Same justification as in standart_init_linux.go as to why we
+			// don't bail on ENOSYS.
+			//
+			// TODO(cyphar): And we should have logging here too.
+			if errors.Cause(err) != unix.ENOSYS {
+				return errors.Wrap(err, "join session keyring")
+			}
 		}
 	}
 	if l.config.CreateConsole {
@@ -47,6 +58,10 @@ func (l *linuxSetnsInit) Init() error {
 			return err
 		}
 	}
+	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+		return err
+	}
+	defer label.SetProcessLabel("")
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible
 	// just before execve so as few syscalls take place after it as possible.
@@ -59,9 +74,6 @@ func (l *linuxSetnsInit) Init() error {
 		return err
 	}
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
-		return err
-	}
-	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
 		return err
 	}
 	// Set seccomp as close to execve as possible, so as few syscalls take

--- a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall" //only for Exec
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
@@ -14,6 +15,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/seccomp"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 
 	"golang.org/x/sys/unix"
 )
@@ -43,17 +45,31 @@ func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
 }
 
 func (l *linuxStandardInit) Init() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if !l.config.Config.NoNewKeyring {
 		ringname, keepperms, newperms := l.getSessionRingParams()
 
 		// Do not inherit the parent's session keyring.
-		sessKeyId, err := keys.JoinSessionKeyring(ringname)
-		if err != nil {
-			return err
-		}
-		// Make session keyring searcheable.
-		if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
-			return err
+		if sessKeyId, err := keys.JoinSessionKeyring(ringname); err != nil {
+			// If keyrings aren't supported then it is likely we are on an
+			// older kernel (or inside an LXC container). While we could bail,
+			// the security feature we are using here is best-effort (it only
+			// really provides marginal protection since VFS credentials are
+			// the only significant protection of keyrings).
+			//
+			// TODO(cyphar): Log this so people know what's going on, once we
+			//               have proper logging in 'runc init'.
+			if errors.Cause(err) != unix.ENOSYS {
+				return errors.Wrap(err, "join session keyring")
+			}
+		} else {
+			// Make session keyring searcheable. If we've gotten this far we
+			// bail on any error -- we don't want to have a keyring with bad
+			// permissions.
+			if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+				return errors.Wrap(err, "mod keyring permissions")
+			}
 		}
 	}
 
@@ -76,7 +92,7 @@ func (l *linuxStandardInit) Init() error {
 			return err
 		}
 		if err := system.Setctty(); err != nil {
-			return err
+			return errors.Wrap(err, "setctty")
 		}
 	}
 
@@ -89,46 +105,47 @@ func (l *linuxStandardInit) Init() error {
 
 	if hostname := l.config.Config.Hostname; hostname != "" {
 		if err := unix.Sethostname([]byte(hostname)); err != nil {
-			return err
+			return errors.Wrap(err, "sethostname")
 		}
 	}
 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
-		return err
-	}
-	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
-		return err
+		return errors.Wrap(err, "apply apparmor profile")
 	}
 
 	for key, value := range l.config.Config.Sysctl {
 		if err := writeSystemProperty(key, value); err != nil {
-			return err
+			return errors.Wrapf(err, "write sysctl key %s", key)
 		}
 	}
 	for _, path := range l.config.Config.ReadonlyPaths {
 		if err := readonlyPath(path); err != nil {
-			return err
+			return errors.Wrapf(err, "readonly path %s", path)
 		}
 	}
 	for _, path := range l.config.Config.MaskPaths {
-		if err := maskPath(path); err != nil {
-			return err
+		if err := maskPath(path, l.config.Config.MountLabel); err != nil {
+			return errors.Wrapf(err, "mask path %s", path)
 		}
 	}
 	pdeath, err := system.GetParentDeathSignal()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get pdeath signal")
 	}
 	if l.config.NoNewPrivileges {
 		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
-			return err
+			return errors.Wrap(err, "set nonewprivileges")
 		}
 	}
 	// Tell our parent that we're ready to Execv. This must be done before the
 	// Seccomp rules have been applied, because we need to be able to read and
 	// write to a socket.
 	if err := syncParentReady(l.pipe); err != nil {
-		return err
+		return errors.Wrap(err, "sync ready")
 	}
+	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+		return errors.Wrap(err, "set process label")
+	}
+	defer label.SetProcessLabel("")
 	// Without NoNewPrivileges seccomp is a privileged operation, so we need to
 	// do this before dropping capabilities; otherwise do it as late as possible
 	// just before execve so as few syscalls take place after it as possible.
@@ -143,7 +160,7 @@ func (l *linuxStandardInit) Init() error {
 	// finalizeNamespace can change user/group which clears the parent death
 	// signal, so we restore it here.
 	if err := pdeath.Restore(); err != nil {
-		return err
+		return errors.Wrap(err, "restore pdeath signal")
 	}
 	// Compare the parent from the initial start of the init process and make
 	// sure that it did not change.  if the parent changes that means it died

--- a/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/state_linux.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/utils"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -63,12 +62,9 @@ func destroy(c *linuxContainer) error {
 
 func runPoststopHooks(c *linuxContainer) error {
 	if c.config.Hooks != nil {
-		bundle, annotations := utils.Annotations(c.config.Labels)
-		s := configs.HookState{
-			Version:     c.config.Version,
-			ID:          c.id,
-			Bundle:      bundle,
-			Annotations: annotations,
+		s, err := c.currentOCIState()
+		if err != nil {
+			return err
 		}
 		for _, hook := range c.config.Hooks.Poststop {
 			if err := hook.Run(s); err != nil {

--- a/vendor/github.com/opencontainers/runc/libcontainer/sync.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/sync.go
@@ -41,10 +41,7 @@ type syncT struct {
 // writeSync is used to write to a synchronisation pipe. An error is returned
 // if there was a problem writing the payload.
 func writeSync(pipe io.Writer, sync syncType) error {
-	if err := utils.WriteJSON(pipe, syncT{sync}); err != nil {
-		return err
-	}
-	return nil
+	return utils.WriteJSON(pipe, syncT{sync})
 }
 
 // readSync is used to read from a synchronisation pipe. An error is returned

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/unsupported.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/unsupported.go
@@ -2,8 +2,26 @@
 
 package system
 
+import (
+	"os"
+
+	"github.com/opencontainers/runc/libcontainer/user"
+)
+
 // RunningInUserNS is a stub for non-Linux systems
 // Always returns false
 func RunningInUserNS() bool {
 	return false
+}
+
+// UIDMapInUserNS is a stub for non-Linux systems
+// Always returns false
+func UIDMapInUserNS(uidmap []user.IDMap) bool {
+	return false
+}
+
+// GetParentNSeuid returns the euid within the parent user namespace
+// Always returns os.Geteuid on non-linux
+func GetParentNSeuid() int {
+	return os.Geteuid()
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup.go
@@ -12,84 +12,30 @@ var (
 	ErrNoGroupEntries  = errors.New("no matching entries in group file")
 )
 
-func lookupUser(filter func(u User) bool) (User, error) {
-	// Get operating system-specific passwd reader-closer.
-	passwd, err := GetPasswd()
-	if err != nil {
-		return User{}, err
-	}
-	defer passwd.Close()
-
-	// Get the users.
-	users, err := ParsePasswdFilter(passwd, filter)
-	if err != nil {
-		return User{}, err
-	}
-
-	// No user entries found.
-	if len(users) == 0 {
-		return User{}, ErrNoPasswdEntries
-	}
-
-	// Assume the first entry is the "correct" one.
-	return users[0], nil
-}
-
 // LookupUser looks up a user by their username in /etc/passwd. If the user
 // cannot be found (or there is no /etc/passwd file on the filesystem), then
 // LookupUser returns an error.
 func LookupUser(username string) (User, error) {
-	return lookupUser(func(u User) bool {
-		return u.Name == username
-	})
+	return lookupUser(username)
 }
 
 // LookupUid looks up a user by their user id in /etc/passwd. If the user cannot
 // be found (or there is no /etc/passwd file on the filesystem), then LookupId
 // returns an error.
 func LookupUid(uid int) (User, error) {
-	return lookupUser(func(u User) bool {
-		return u.Uid == uid
-	})
-}
-
-func lookupGroup(filter func(g Group) bool) (Group, error) {
-	// Get operating system-specific group reader-closer.
-	group, err := GetGroup()
-	if err != nil {
-		return Group{}, err
-	}
-	defer group.Close()
-
-	// Get the users.
-	groups, err := ParseGroupFilter(group, filter)
-	if err != nil {
-		return Group{}, err
-	}
-
-	// No user entries found.
-	if len(groups) == 0 {
-		return Group{}, ErrNoGroupEntries
-	}
-
-	// Assume the first entry is the "correct" one.
-	return groups[0], nil
+	return lookupUid(uid)
 }
 
 // LookupGroup looks up a group by its name in /etc/group. If the group cannot
 // be found (or there is no /etc/group file on the filesystem), then LookupGroup
 // returns an error.
 func LookupGroup(groupname string) (Group, error) {
-	return lookupGroup(func(g Group) bool {
-		return g.Name == groupname
-	})
+	return lookupGroup(groupname)
 }
 
 // LookupGid looks up a group by its group id in /etc/group. If the group cannot
 // be found (or there is no /etc/group file on the filesystem), then LookupGid
 // returns an error.
 func LookupGid(gid int) (Group, error) {
-	return lookupGroup(func(g Group) bool {
-		return g.Gid == gid
-	})
+	return lookupGid(gid)
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
@@ -5,6 +5,7 @@ package user
 import (
 	"io"
 	"os"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -14,6 +15,76 @@ const (
 	unixPasswdPath = "/etc/passwd"
 	unixGroupPath  = "/etc/group"
 )
+
+func lookupUser(username string) (User, error) {
+	return lookupUserFunc(func(u User) bool {
+		return u.Name == username
+	})
+}
+
+func lookupUid(uid int) (User, error) {
+	return lookupUserFunc(func(u User) bool {
+		return u.Uid == uid
+	})
+}
+
+func lookupUserFunc(filter func(u User) bool) (User, error) {
+	// Get operating system-specific passwd reader-closer.
+	passwd, err := GetPasswd()
+	if err != nil {
+		return User{}, err
+	}
+	defer passwd.Close()
+
+	// Get the users.
+	users, err := ParsePasswdFilter(passwd, filter)
+	if err != nil {
+		return User{}, err
+	}
+
+	// No user entries found.
+	if len(users) == 0 {
+		return User{}, ErrNoPasswdEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return users[0], nil
+}
+
+func lookupGroup(groupname string) (Group, error) {
+	return lookupGroupFunc(func(g Group) bool {
+		return g.Name == groupname
+	})
+}
+
+func lookupGid(gid int) (Group, error) {
+	return lookupGroupFunc(func(g Group) bool {
+		return g.Gid == gid
+	})
+}
+
+func lookupGroupFunc(filter func(g Group) bool) (Group, error) {
+	// Get operating system-specific group reader-closer.
+	group, err := GetGroup()
+	if err != nil {
+		return Group{}, err
+	}
+	defer group.Close()
+
+	// Get the users.
+	groups, err := ParseGroupFilter(group, filter)
+	if err != nil {
+		return Group{}, err
+	}
+
+	// No user entries found.
+	if len(groups) == 0 {
+		return Group{}, ErrNoGroupEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return groups[0], nil
+}
 
 func GetPasswdPath() (string, error) {
 	return unixPasswdPath, nil
@@ -43,4 +114,31 @@ func CurrentUser() (User, error) {
 // /etc/group file on the filesystem), then CurrentGroup returns an error.
 func CurrentGroup() (Group, error) {
 	return LookupGid(unix.Getgid())
+}
+
+func currentUserSubIDs(fileName string) ([]SubID, error) {
+	u, err := CurrentUser()
+	if err != nil {
+		return nil, err
+	}
+	filter := func(entry SubID) bool {
+		return entry.Name == u.Name || entry.Name == strconv.Itoa(u.Uid)
+	}
+	return ParseSubIDFileFilter(fileName, filter)
+}
+
+func CurrentUserSubUIDs() ([]SubID, error) {
+	return currentUserSubIDs("/etc/subuid")
+}
+
+func CurrentUserSubGIDs() ([]SubID, error) {
+	return currentUserSubIDs("/etc/subgid")
+}
+
+func CurrentProcessUIDMap() ([]IDMap, error) {
+	return ParseIDMapFile("/proc/self/uid_map")
+}
+
+func CurrentProcessGIDMap() ([]IDMap, error) {
+	return ParseIDMapFile("/proc/self/gid_map")
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_windows.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_windows.go
@@ -1,0 +1,40 @@
+// +build windows
+
+package user
+
+import (
+	"fmt"
+	"os/user"
+)
+
+func lookupUser(username string) (User, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return User{}, err
+	}
+	return userFromOS(u)
+}
+
+func lookupUid(uid int) (User, error) {
+	u, err := user.LookupId(fmt.Sprintf("%d", uid))
+	if err != nil {
+		return User{}, err
+	}
+	return userFromOS(u)
+}
+
+func lookupGroup(groupname string) (Group, error) {
+	g, err := user.LookupGroup(groupname)
+	if err != nil {
+		return Group{}, err
+	}
+	return groupFromOS(g)
+}
+
+func lookupGid(gid int) (Group, error) {
+	g, err := user.LookupGroupId(fmt.Sprintf("%d", gid))
+	if err != nil {
+		return Group{}, err
+	}
+	return groupFromOS(g)
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"os"
@@ -16,19 +14,6 @@ import (
 const (
 	exitSignalOffset = 128
 )
-
-// GenerateRandomName returns a new name joined with a prefix.  This size
-// specified is used to truncate the randomly generated value
-func GenerateRandomName(prefix string, size int) (string, error) {
-	id := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, id); err != nil {
-		return "", err
-	}
-	if size > 64 {
-		size = 64
-	}
-	return prefix + hex.EncodeToString(id)[:size], nil
-}
 
 // ResolveRootfs ensures that the current working directory is
 // not a symlink and returns the absolute path to the rootfs


### PR DESCRIPTION
This PR fixes a number of issues I've been having with the planet container.

Most notable:
- switch to using systemd to create container cgroup
    - This causes the container to run in a separate scope that has delegate=true (/system.slice/planet-<uuid>.scope) which should hopefully prevent a possible conflict in having multiple systemd instances running and modifying the same cgroup hierarchy.
- Pass the container id to planet systemd. Not very important now, but if we setup machine integration, this should eventually allow journalctl to reach the planet journal without having to enter the container.
- Set Init/CWD on creation. This seems to be important on updating to runc rc6, where I've been having issues with the planet init process not running in the correct namespaces.
- Use CGROUP namespace. The other fixes cause systemd to correctly realize it is running within a container, however, systemd when starting remounts the /sys/fs/cgroup filesystem hierarchy to only contain its own portion of the hierarchy. This appears to greatly confuse kubelet, since when reading cgroup paths of processes, they do not match the mounted hierarchy. So this places planet in it's own cgroup namespace, so that all planet processes have a consistent view of the cgroup hierarchy.
