### PR TITLE
Use separate kubeconfig for host kubectl.

### DIFF
--- a/build.assets/docker/os-rootfs/usr/local/bin/kubectl
+++ b/build.assets/docker/os-rootfs/usr/local/bin/kubectl
@@ -5,13 +5,15 @@ set -eu
 if [ -L $0 ]; then
     # invoked from host via a kubectl symlink set up during installation
     DIR=$(dirname $(readlink $0))
+    KUBE_CONFIG=/etc/kubernetes/kubectl-host.kubeconfig
 else
     # invoked directly, e.g. from inside the planet
     DIR=$(dirname $0)
+    KUBE_CONFIG=/etc/kubernetes/kubectl.kubeconfig
 fi
 
 # determine the absolute path to the planet rootfs
 PLANET_ROOT=$(realpath ${DIR}/../../../)
 
 # invoke the real kubectl binary with a proper config and propagate all arguments as-is
-${PLANET_ROOT}/usr/bin/kubectl --kubeconfig=${PLANET_ROOT}/etc/kubernetes/kubectl.kubeconfig "$@"
+${PLANET_ROOT}/usr/bin/kubectl --kubeconfig=${PLANET_ROOT}${KUBE_CONFIG} "$@"

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -19,6 +19,9 @@ package constants
 const (
 	// KubectlConfigPath is the path to kubectl configuration file
 	KubectlConfigPath = "/etc/kubernetes/kubectl.kubeconfig"
+	// KubectlHostConfigPath is the path to configuration file that kubectl
+	// uses when invoked from host
+	KubectlHostConfigPath = "/etc/kubernetes/kubectl-host.kubeconfig"
 	// SchedulerConfigPath is the path to kube-scheduler configuration file
 	SchedulerConfigPath = "/etc/kubernetes/scheduler.kubeconfig"
 	// ProxyConfigPath is the path to kube-proxy configuration file

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -563,7 +563,7 @@ func addKubeConfig(config *Config) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = ioutil.WriteFile(path, kubeConfig, constants.SharedReadMask)
+		err = utils.SafeWriteFile(path, kubeConfig, constants.SharedReadMask)
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
When generating `kubectl.kubeconfig` planet uses secrets from `/var/lib/gravity` which does not work when kubectl is invoked from host and custom state directory was used for gravity data.

This PR addresses this issue by generating two configs: one will be used when kubectl is invoked from host and uses correct host state dir, another one - when kubectl is invoked from inside planet.