### PR TITLE
Testplan improvements

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -396,7 +396,7 @@ const (
 	DefaultVxlanPort = 8472
 
 	// DefaultFeatureGates is the default set of component feature gates
-	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false"
+	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIDriverRegistry=false,KubeletPodResources=false"
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"


### PR DESCRIPTION
Update default feature gates:
  * Disable `CSIDriverRegistry` to avoid informer log spam.
  * Disable `KubeletPodResources` to avoid race condition in kubelet when it initializes the gRPC server for pod resources.