### PR TITLE
CVE-2019-6486

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ COREDNS_VER := 1.3.1
 
 # ETCD Versions to include in the release
 # This list needs to include every version of etcd that we can upgrade from + latest
-ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11
+ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.12
 # This is the version of etcd we should upgrade to (from the version list)
-ETCD_LATEST_VER := v3.3.11
+ETCD_LATEST_VER := v3.3.12
 
 BUILDBOX_GO_VER ?= 1.10.7
 PLANET_BUILD_TAG ?= $(shell git describe --tags)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.12
 # This is the version of etcd we should upgrade to (from the version list)
 ETCD_LATEST_VER := v3.3.12
 
-BUILDBOX_GO_VER ?= 1.10.7
+BUILDBOX_GO_VER ?= 1.10.8
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -4,7 +4,7 @@ FROM $PLANET_BASE_IMAGE
 ENV GOPATH /gopath
 ENV GOROOT /opt/go
 ENV PATH $PATH:$GOPATH/bin:$GOROOT/bin
-ARG GOVERSION=go1.10.7
+ARG GOVERSION=go1.10.8
 
 # Have our own /etc/passwd with users populated from 990 to 1000
 COPY passwd /etc/passwd


### PR DESCRIPTION
Bump versions related to CVE-2019-6486
- ETCD -> 3.3.12
- Go version: 1.10.8