### PR TITLE
build registry off fork with hardened ciphers

### DIFF
--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -1,7 +1,7 @@
 .PHONY: all
 
 REPODIR=$(GOPATH)/src/github.com/docker/
-VER=v2.6.0
+VER=v2.7.1-gravitational
 
 # VERSION_PACKAGE defines contents of a `version.go` file which is part of docker
 # registry source code distribution responsible for defining a registry's Version
@@ -30,7 +30,8 @@ all: $(BINARIES) install
 $(BINARIES):
 	@echo "\n---> Building docker registry:\n"
 	mkdir -p $(REPODIR)
-	cd $(REPODIR) && git clone https://github.com/docker/distribution -b $(VER) --depth 1
+#	cd $(REPODIR) && git clone https://github.com/docker/distribution -b $(VER) --depth 1
+	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -31,6 +31,7 @@ $(BINARIES):
 	@echo "\n---> Building docker registry:\n"
 	mkdir -p $(REPODIR)
 #	cd $(REPODIR) && git clone https://github.com/docker/distribution -b $(VER) --depth 1
+# TODO(knisbet) build off fork until upstream allows limiting cipher selection to modern standards
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \


### PR DESCRIPTION
Temporarily build registry from fork, which has been hardcoded to use modern TLS and ciphers.

Requires Backport