### PR TITLE
[5.4] fix a typo in environment variable with apiserver options.

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -53,7 +53,7 @@ ExecStart=/usr/bin/kube-apiserver \
         --audit-log-maxage=30 \
         --audit-log-maxbackup=10 \
         --audit-log-maxsize=100 \
-        $KUBE_APISERVER_OPTIONS \
+        $KUBE_APISERVER_FLAGS \
         $KUBE_CLOUD_FLAGS \
         $KUBE_COMPONENT_FLAGS
 Restart=always


### PR DESCRIPTION
Backport of https://github.com/gravitational/planet/pull/415.