### PR TITLE
Increase max etcd request size to 10MB.

### DIFF
--- a/build.assets/makefiles/etcd/etcd-upgrade.service
+++ b/build.assets/makefiles/etcd/etcd-upgrade.service
@@ -34,6 +34,7 @@ ExecStart=/usr/bin/etcd \
         --peer-key-file=/var/state/etcd.key \
         --peer-trusted-ca-file=/var/state/root.cert \
         --peer-client-cert-auth $ETCD_OPTS \
+        --max-request-bytes=10485760 \
         --initial-cluster-state new
 User=planet
 Group=planet

--- a/build.assets/makefiles/etcd/etcd.service
+++ b/build.assets/makefiles/etcd/etcd.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/etcd \
         --peer-key-file=/var/state/etcd.key \
         --peer-trusted-ca-file=/var/state/root.cert \
         --peer-client-cert-auth=true \
+        --max-request-bytes=10485760 \
         $ETCD_OPTS
 User=planet
 Group=planet


### PR DESCRIPTION
The default limit is 1.5MB and it can't handle our large "changeset" CRDs, for example for monitoring app upgrade which has a lot of resources.