### PR TITLE
Allow quoted values for environment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -375,12 +375,12 @@
   version = "6.0.0"
 
 [[projects]]
-  digest = "1:89dfd879adc40793de2e59f4f7c42c1b4ad6bdab32fcb5d6b769c1fcc6fc452a"
+  digest = "1:afb36747f009e72637bdf1b3f5d27f3c1d5e1fc5478fc4aba2a33e40e8829dee"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3318e711adee0b3f48d3399ebf5aaddf329a2b4f"
-  version = "1.1.5"
+  revision = "a5c40b57db7203332a073f20771214d0eeb2a168"
+  version = "1.1.7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,7 +92,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/trace"
-  version = "1.0.0"
+  version = "1.1.7"
 
 [[constraint]]
   name = "github.com/julienschmidt/httprouter"

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ planet-bin:
 	go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
+.PHONY: dev-deploy
+dev-deploy:
+	$(MAKE) -C $(ASSETS)/makefiles/deploy deploy-s3
+
+# Deploys the build artifacts to Amazon S3 and quay.io
 .PHONY: deploy
 deploy:
 	$(MAKE) -C $(ASSETS)/makefiles/deploy deploy

--- a/lib/box/cfg.go
+++ b/lib/box/cfg.go
@@ -462,8 +462,8 @@ const (
 )
 
 // newEnvParser returns a new parser for environment.
-// input is expected to be a comma-separated list of name=value pairs,
-// where values can be quoted (in which case, they can themselves contain commas)
+// input is expected to be a comma-separated list of name=value pairs.
+// If a value contains a comma, it must be quoted.
 func newEnvParser(input string) *envParser {
 	var s scanner.Scanner
 	s.Init(strings.NewReader(input))

--- a/lib/box/cfg_test.go
+++ b/lib/box/cfg_test.go
@@ -117,6 +117,20 @@ func (*CommandFlagSuite) TestEnvParse(c *check.C) {
 			},
 			comment: "allows upper and lower-case names",
 		},
+		{
+			value: ` var1=value1, var2 = value2 `,
+			expected: EnvVars{
+				{
+					Name: "var1",
+					Val:  "value1",
+				},
+				{
+					Name: "var2",
+					Val:  "value2",
+				},
+			},
+			comment: "allows whitespace around names/values",
+		},
 	}
 
 	for _, tt := range cases {

--- a/lib/box/cfg_test.go
+++ b/lib/box/cfg_test.go
@@ -17,50 +17,152 @@ limitations under the License.
 package box
 
 import (
-	"strings"
 	check "gopkg.in/check.v1"
+	"strings"
 )
 
 type CommandFlagSuite struct{}
 
-
 var _ = check.Suite(&CommandFlagSuite{})
+
+func (*CommandFlagSuite) TestEnvParse(c *check.C) {
+	var cases = []struct {
+		value    string
+		expected EnvVars
+		comment  string
+	}{
+		{
+			value: "var=value",
+			expected: EnvVars{
+				{
+					Name: "var",
+					Val:  "value",
+				},
+			},
+			comment: "simple value",
+		},
+		{
+			value: `var="value1,value2"`,
+			expected: EnvVars{
+				{
+					Name: "var",
+					Val:  "value1,value2",
+				},
+			},
+			comment: "comma-separated value",
+		},
+		{
+			value: `var1="value1,value2",var2="value1=value2"`,
+			expected: EnvVars{
+				{
+					Name: "var1",
+					Val:  "value1,value2",
+				},
+				{
+					Name: "var2",
+					Val:  "value1=value2",
+				},
+			},
+			comment: "multiple comma-separated values",
+		},
+		{
+			value: `var="value1,value2;value3:"`,
+			expected: EnvVars{
+				{
+					Name: "var",
+					Val:  "value1,value2;value3:",
+				},
+			},
+			comment: "value in quotes is not interpreted",
+		},
+		{
+			value: `var1=value1,var2=value2`,
+			expected: EnvVars{
+				{
+					Name: "var1",
+					Val:  "value1",
+				},
+				{
+					Name: "var2",
+					Val:  "value2",
+				},
+			},
+			comment: "multiple variables",
+		},
+		{
+			value: `var1=value1,var2=value2,`,
+			expected: EnvVars{
+				{
+					Name: "var1",
+					Val:  "value1",
+				},
+				{
+					Name: "var2",
+					Val:  "value2",
+				},
+			},
+			comment: "empty input ignored",
+		},
+		{
+			value: `VAR1=VALUE1,var2=value2`,
+			expected: EnvVars{
+				{
+					Name: "VAR1",
+					Val:  "VALUE1",
+				},
+				{
+					Name: "var2",
+					Val:  "value2",
+				},
+			},
+			comment: "allows upper and lower-case names",
+		},
+	}
+
+	for _, tt := range cases {
+		comment := check.Commentf(tt.comment)
+		p := newEnvParser(tt.value)
+		vars, err := p.parse()
+		c.Assert(err, check.IsNil, comment)
+		c.Assert(vars, check.DeepEquals, tt.expected, comment)
+	}
+}
 
 func (r *CommandFlagSuite) TestEnvDelete(c *check.C) {
 	var cases = []struct {
-		add string
-		delete string
-		expected string
+		add         string
+		delete      string
+		expected    string
 		description string
-	} {
+	}{
 		{
-			add: "alpha=1",
-			expected: "alpha=1",
+			add:         "alpha=1",
+			expected:    "alpha=1",
 			description: "add alpha",
 		},
 		{
-			add: "bravo=2",
-			expected: "alpha=1,bravo=2",
+			add:         "bravo=2",
+			expected:    "alpha=1,bravo=2",
 			description: "add bravo",
 		},
 		{
-			add: "charlie=3",
-			expected: "alpha=1,bravo=2,charlie=3",
+			add:         "charlie=3",
+			expected:    "alpha=1,bravo=2,charlie=3",
 			description: "add charlie",
 		},
 		{
-			delete: "bravo",
-			expected: "alpha=1,charlie=3",
+			delete:      "bravo",
+			expected:    "alpha=1,charlie=3",
 			description: "delete bravo",
 		},
 		{
-			delete: "charlie",
-			expected: "alpha=1",
+			delete:      "charlie",
+			expected:    "alpha=1",
 			description: "delete charlie",
 		},
 		{
-			delete: "alpha",
-			expected: "",
+			delete:      "alpha",
+			expected:    "",
 			description: "delete alpha",
 		},
 	}

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -731,7 +731,7 @@ func initLogging(debug bool) {
 
 // die prints the error message in red to the console and exits with a non-zero exit code
 func die(err error) {
-	log.Error(trace.DebugReport(err))
+	log.WithError(err).Warn("Failed to run.")
 	color.Red("[ERROR]: %v\n", trace.UserMessage(err))
 	os.Exit(255)
 }

--- a/vendor/github.com/gravitational/trace/log.go
+++ b/vendor/github.com/gravitational/trace/log.go
@@ -20,7 +20,11 @@ package trace
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"reflect"
 	"regexp"
+	"runtime"
 	rundebug "runtime/debug"
 	"sort"
 	"strconv"
@@ -28,8 +32,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"runtime"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -50,6 +53,16 @@ const (
 	DefaultLevelPadding = 4
 )
 
+// IsTerminal checks whether writer is a terminal
+func IsTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
 // TextFormatter is logrus-compatible formatter and adds
 // file and line details to every logged entry.
 type TextFormatter struct {
@@ -59,6 +72,8 @@ type TextFormatter struct {
 	// ComponentPadding is a padding to pick when displaying
 	// and formatting component field, defaults to DefaultComponentPadding
 	ComponentPadding int
+	// EnableColors enables colored output
+	EnableColors bool
 }
 
 // Format implements logrus.Formatter interface and adds file and line
@@ -69,9 +84,10 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 			return
 		}
 	}()
+
 	var file string
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		file = t.Loc()
 	}
 
@@ -79,21 +95,26 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// time
 	if !tf.DisableTimestamp {
-		w.writeField(e.Time.Format(time.RFC3339))
+		w.writeField(e.Time.Format(time.RFC3339), noColor)
 	}
 
 	// level
-	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)))
+	color := noColor
+	if tf.EnableColors {
+		switch e.Level {
+		case log.DebugLevel:
+			color = gray
+		case log.WarnLevel:
+			color = yellow
+		case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+			color = red
+		default:
+			color = blue
+		}
+	}
+	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)), color)
 
-	// component, always output
-	componentI, ok := e.Data[Component]
-	if !ok {
-		componentI = ""
-	}
-	component, ok := componentI.(string)
-	if !ok {
-		component = fmt.Sprintf("%v", componentI)
-	}
+	// always output the component field if available
 	padding := DefaultComponentPadding
 	if tf.ComponentPadding != 0 {
 		padding = tf.ComponentPadding
@@ -101,8 +122,10 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 	if w.Len() > 0 {
 		w.WriteByte(' ')
 	}
-	if component != "" {
-		component = fmt.Sprintf("[%v]", component)
+	value := e.Data[Component]
+	var component string
+	if reflect.ValueOf(value).IsValid() {
+		component = fmt.Sprintf("[%v]", value)
 	}
 	component = strings.ToUpper(padMax(component, padding))
 	if component[len(component)-1] != ' ' {
@@ -112,7 +135,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// message
 	if e.Message != "" {
-		w.writeField(e.Message)
+		w.writeField(e.Message, noColor)
 	}
 
 	// rest of the fields
@@ -122,7 +145,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// file, if present, always last
 	if file != "" {
-		w.writeField(file)
+		w.writeField(file, noColor)
 	}
 
 	w.WriteByte('\n')
@@ -138,8 +161,8 @@ type JSONFormatter struct {
 
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		new := e.WithFields(log.Fields{
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
@@ -149,44 +172,79 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 		new.Message = e.Message
 		e = new
 	}
-	return (&j.JSONFormatter).Format(e)
+	return j.JSONFormatter.Format(e)
 }
 
-var r = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
 
-func findFrame() int {
-	for i := 3; i < 10; i++ {
-		_, file, _, ok := runtime.Caller(i)
-		if !ok {
-			return -1
-		}
-		if !r.MatchString(file) {
-			return i
+// findFrames positions the stack pointer to the first
+// function that does not match the frameIngorePattern
+// and returns the rest of the stack frames
+func findFrame() *frameCursor {
+	var buf [32]uintptr
+	// Skip enough frames to start at user code.
+	// This number is a mere hint to the following loop
+	// to start as close to user code as possible and getting it right is not mandatory.
+	// The skip count might need to get updated if the call to findFrame is
+	// moved up/down the call stack
+	n := runtime.Callers(4, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	for i := 0; i < n; i++ {
+		frame, _ := frames.Next()
+		if !frameIgnorePattern.MatchString(frame.File) {
+			return &frameCursor{
+				current: &frame,
+				rest:    frames,
+				n:       n,
+			}
 		}
 	}
-	return -1
+	return nil
 }
+
+const (
+	noColor = -1
+	red     = 31
+	yellow  = 33
+	blue    = 36
+	gray    = 37
+)
 
 type writer struct {
 	bytes.Buffer
 }
 
-func (w *writer) writeField(value interface{}) {
+func (w *writer) writeField(value interface{}, color int) {
 	if w.Len() > 0 {
 		w.WriteByte(' ')
 	}
-	w.writeValue(value)
+	w.writeValue(value, color)
 }
 
-func (w *writer) writeValue(value interface{}) {
-	stringVal, ok := value.(string)
-	if !ok {
-		stringVal = fmt.Sprint(value)
+func (w *writer) writeValue(value interface{}, color int) {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+		if needsQuoting(s) {
+			s = fmt.Sprintf("%q", v)
+		}
+	default:
+		s = fmt.Sprintf("%v", v)
 	}
-	if !needsQuoting(stringVal) {
-		w.WriteString(stringVal)
-	} else {
-		w.WriteString(fmt.Sprintf("%q", stringVal))
+	if color != noColor {
+		s = fmt.Sprintf("\x1b[%dm%s\x1b[0m", color, s)
+	}
+	w.WriteString(s)
+}
+
+func (w *writer) writeError(value interface{}) {
+	switch err := value.(type) {
+	case Error:
+		w.WriteString(fmt.Sprintf("[%v]", err.DebugReport()))
+	default:
+		w.WriteString(fmt.Sprintf("[%v]", value))
 	}
 }
 
@@ -196,7 +254,11 @@ func (w *writer) writeKeyValue(key string, value interface{}) {
 	}
 	w.WriteString(key)
 	w.WriteByte(':')
-	w.writeValue(value)
+	if key == log.ErrorKey {
+		w.writeError(value)
+		return
+	}
+	w.writeValue(value, noColor)
 }
 
 func (w *writer) writeMap(m map[string]interface{}) {
@@ -212,11 +274,11 @@ func (w *writer) writeMap(m map[string]interface{}) {
 		if key == Component {
 			continue
 		}
-		switch val := m[key].(type) {
+		switch value := m[key].(type) {
 		case log.Fields:
-			w.writeMap(val)
+			w.writeMap(value)
 		default:
-			w.writeKeyValue(key, val)
+			w.writeKeyValue(key, value)
 		}
 	}
 }

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -19,8 +19,10 @@ limitations under the License.
 package trace
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -40,7 +42,7 @@ func SetDebug(enabled bool) {
 	}
 }
 
-// IsDebug returns true if debug mode is on, false otherwize
+// IsDebug returns true if debug mode is on, false otherwise
 func IsDebug() bool {
 	return atomic.LoadInt32(&debug) == 1
 }
@@ -75,6 +77,25 @@ func UserMessage(err error) string {
 	return err.Error()
 }
 
+// UserMessageWithFields returns user-friendly error with key-pairs as part of the message
+func UserMessageWithFields(err error) string {
+	if err == nil {
+		return ""
+	}
+	if wrap, ok := err.(Error); ok {
+		if len(wrap.GetFields()) == 0 {
+			return wrap.UserMessage()
+		}
+
+		var kvps []string
+		for k, v := range wrap.GetFields() {
+			kvps = append(kvps, fmt.Sprintf("%v=%q", k, v))
+		}
+		return fmt.Sprintf("%v %v", strings.Join(kvps, " "), wrap.UserMessage())
+	}
+	return err.Error()
+}
+
 // DebugReport returns debug report with all known information
 // about the error including stack trace if it was captured
 func DebugReport(err error) string {
@@ -85,6 +106,17 @@ func DebugReport(err error) string {
 		return wrap.DebugReport()
 	}
 	return err.Error()
+}
+
+// GetFields returns any fields that have been added to the error message
+func GetFields(err error) map[string]interface{} {
+	if err == nil {
+		return map[string]interface{}{}
+	}
+	if wrap, ok := err.(Error); ok {
+		return wrap.GetFields()
+	}
+	return map[string]interface{}{}
 }
 
 // WrapWithMessage wraps the original error into Error and adds user message if any
@@ -124,31 +156,58 @@ func Errorf(format string, args ...interface{}) (err error) {
 // true Fatalf calls panic
 func Fatalf(format string, args ...interface{}) error {
 	if IsDebug() {
-		panic(fmt.Sprintf(format, args))
+		panic(fmt.Sprintf(format, args...))
 	} else {
-		return Errorf(format, args)
+		return Errorf(format, args...)
 	}
 }
 
 func newTrace(depth int, err error) *TraceErr {
-	var pc [32]uintptr
-	count := runtime.Callers(depth+1, pc[:])
+	var buf [32]uintptr
+	n := runtime.Callers(depth+1, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	cursor := frameCursor{
+		rest: frames,
+		n:    n,
+	}
+	return newTraceFromFrames(cursor, err)
+}
 
-	traces := make(Traces, count)
-	for i := 0; i < count; i++ {
-		fn := runtime.FuncForPC(pc[i])
-		filePath, line := fn.FileLine(pc[i])
-		traces[i] = Trace{
-			Func: fn.Name(),
-			Path: filePath,
-			Line: line,
+func newTraceFromFrames(cursor frameCursor, err error) *TraceErr {
+	traces := make(Traces, 0, cursor.n)
+	if cursor.current != nil {
+		traces = append(traces, frameToTrace(*cursor.current))
+	}
+	for {
+		frame, more := cursor.rest.Next()
+		traces = append(traces, frameToTrace(frame))
+		if !more {
+			break
 		}
 	}
 	return &TraceErr{
-		err,
-		traces,
-		"",
+		Err:    err,
+		Traces: traces,
 	}
+}
+
+func frameToTrace(frame runtime.Frame) Trace {
+	return Trace{
+		Func: frame.Function,
+		Path: frame.File,
+		Line: frame.Line,
+	}
+}
+
+type frameCursor struct {
+	// current specifies the current stack frame.
+	// if omitted, rest contains the complete stack
+	current *runtime.Frame
+	// rest specifies the rest of stack frames to explore
+	rest *runtime.Frames
+	// n specifies the total number of stack frames
+	n int
 }
 
 // Traces is a list of trace entries
@@ -223,9 +282,14 @@ func (t *Trace) String() string {
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
-	Err     error `json:"error"`
-	Traces  `json:"traces"`
-	Message string `json:"message,omitemtpy"`
+	// Err is the underlying error that TraceErr wraps
+	Err error `json:"error"`
+	// Traces is a slice of stack trace entries for the error
+	Traces `json:"traces"`
+	// Message is an optional message that can be wrapped with the original error
+	Message string `json:"message,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty`
 }
 
 type RawTrace struct {
@@ -244,6 +308,28 @@ func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) {
 	}
 }
 
+// AddFields adds the given map of fields to the error being reported
+func (e *TraceErr) AddFields(fields map[string]interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, len(fields))
+	}
+	for k, v := range fields {
+		e.Fields[k] = v
+	}
+	return e
+}
+
+// AddField adds a single field to the error wrapper as context for the error
+func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, 1)
+	}
+
+	e.Fields[k] = v
+
+	return e
+}
+
 // UserMessage returns user-friendly error message
 func (e *TraceErr) UserMessage() string {
 	if e.Message != "" {
@@ -252,14 +338,46 @@ func (e *TraceErr) UserMessage() string {
 	return UserMessage(e.Err)
 }
 
-// DebugReport returns develeoper-friendly error report
+// DebugReport returns developer-friendly error report
 func (e *TraceErr) DebugReport() string {
-	return fmt.Sprintf("\nERROR REPORT:\nOriginal Error: %T %v\nStack Trace:\n%v\nUser Message: %v\n", e.Err, e.Err.Error(), e.Traces.String(), e.Message)
+	var buffer bytes.Buffer
+	err := reportTemplate.Execute(&buffer, struct {
+		OrigErrType    string
+		OrigErrMessage string
+		Fields         map[string]interface{}
+		StackTrace     string
+		UserMessage    string
+	}{
+		OrigErrType:    fmt.Sprintf("%T", e.Err),
+		OrigErrMessage: e.Err.Error(),
+		Fields:         e.Fields,
+		StackTrace:     e.Traces.String(),
+		UserMessage:    e.UserMessage(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buffer.String()
 }
+
+var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
+var reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields: 
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+User Message: {{.UserMessage}}
+`
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
 	return e.UserMessage()
+}
+
+func (e *TraceErr) GetFields() map[string]interface{} {
+	return e.Fields
 }
 
 // OrigError returns original wrapped error
@@ -280,6 +398,12 @@ func (e *TraceErr) OrigError() error {
 	return err
 }
 
+// GoString formats this trace object for use with
+// with the "%#v" format string
+func (e *TraceErr) GoString() string {
+	return e.DebugReport()
+}
+
 // maxHops is a max supported nested depth for errors
 const maxHops = 50
 
@@ -297,11 +421,20 @@ type Error interface {
 	// arguments as structured args
 	AddUserMessage(formatArg interface{}, rest ...interface{})
 
+	// AddField adds additional field information to the error
+	AddField(key string, value interface{}) *TraceErr
+
+	// AddFields adds a map of additional fields to the error
+	AddFields(fields map[string]interface{}) *TraceErr
+
 	// UserMessage returns user-friendly error message
 	UserMessage() string
 
-	// DebugReport returns develeoper-friendly error report
+	// DebugReport returns developer-friendly error report
 	DebugReport() string
+
+	// GetFields returns any fields that have been added to the error
+	GetFields() map[string]interface{}
 }
 
 // NewAggregate creates a new aggregate instance from the specified

--- a/vendor/github.com/gravitational/trace/udphook.go
+++ b/vendor/github.com/gravitational/trace/udphook.go
@@ -67,8 +67,8 @@ type Frame struct {
 func (elk *UDPHook) Fire(e *log.Entry) error {
 	// Make a copy to safely modify
 	entry := e.WithFields(nil)
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo-1, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		entry.Data[FileField] = t.String()
 		entry.Data[FunctionField] = t.Func()
 	}


### PR DESCRIPTION
Allow environment specification of the form `name=value,name2=value2` where `value` can itself contain a comma (or be basically free-form).

Updates https://github.com/gravitational/gravity.e/issues/4095.