### PR TITLE
Add procps package to planet

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -q -y --allow-downgrades bridge-utils \
         iftop \
         traceroute \
         tcpdump \
+        procps \
         coreutils \
         lsof \
         socat \


### PR DESCRIPTION
It seems that top / ps and other commands are no longer getting included with planet. This adds the procps package to the install base image, so common utils for the proc filesystem are available within planet.