### PR TITLE
[5.5] etcdctl proxy support

### DIFF
--- a/build.assets/makefiles/etcd/etcd.mk
+++ b/build.assets/makefiles/etcd/etcd.mk
@@ -18,7 +18,8 @@ all: $(targets)
 	cp -afv ./etcd-upgrade.service $(ROOTFS)/lib/systemd/system/
 	cp -afv ./etcd-gateway.dropin $(ROOTFS)/lib/systemd/system/
 	cp -afv ./etcdctl3 $(ROOTFS)/usr/bin/etcdctl3
-	chmod +x $(ROOTFS)/usr/bin/etcdctl3
+	cp -afv ./etcdctl $(ROOTFS)/usr/bin/etcdctl
+	chmod +x $(ROOTFS)/usr/bin/etcdctl3 $(ROOTFS)/usr/bin/etcdctl
 	ln -sf /lib/systemd/system/etcd.service $(ROOTFS)/lib/systemd/system/multi-user.target.wants/
 
 	# mask the etcd-upgrade service so that it can only be run if intentionally unmasked
@@ -39,7 +40,7 @@ $(ETCD_VER):
 	tar -xzf $(ASSETDIR)/$(output) -C $(ASSETDIR)
 
 	cp -afv $(targetdir)/etcd $(ROOTFS)/usr/bin/etcd-$@
-	cp -afv $(targetdir)/etcdctl $(ROOTFS)/usr/bin/etcdctl-$@
+	cp -afv $(targetdir)/etcdctl $(ROOTFS)/usr/bin/etcdctl-cmd-$@
 
 
 $(targets): version=$(lastword $(subst -, ,$(notdir $@)))

--- a/build.assets/makefiles/etcd/etcdctl
+++ b/build.assets/makefiles/etcd/etcdctl
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This is a helper script, to wipe proxy related env variables when running etcdctl, which will cause etcdctl to
+# try and use a customer provided http proxy.
+# TODO(knisbet) The current build of etcd doesn't support NO_PROXY in CIDR format, once it does, this wrapper is
+# no longer needed. Requires etcd release built with golang 1.12 or later: 
+# https://github.com/etcd-io/etcd/blob/master/Makefile#L54
+#
+
+HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" \
+/usr/bin/etcdctl-cmd --key-file /var/state/etcd.key --cert-file /var/state/etcd.cert --ca-file /var/state/root.cert "$@"

--- a/build.assets/makefiles/etcd/etcdctl3
+++ b/build.assets/makefiles/etcd/etcdctl3
@@ -4,4 +4,5 @@
 #
 
 ETCDCTL_API=3 ETCDCTL_CERT_FILE="" ETCDCTL_KEY_FILE="" ETCDCTL_CA_FILE="" ETCDCTL_PEERS="" \
-/usr/bin/etcdctl --key /var/state/etcd.key --cert /var/state/etcd.cert --cacert /var/state/root.cert "$@"
+HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" \
+/usr/bin/etcdctl-cmd --key /var/state/etcd.key --cert /var/state/etcd.cert --cacert /var/state/root.cert "$@"

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -72,7 +72,9 @@ func etcdInit() error {
 	log.Info("Current etcd version: ", currentVersion)
 
 	// symlink /usr/bin/etcd to the version we expect to be running
-	for _, path := range []string{"/usr/bin/etcd", "/usr/bin/etcdctl"} {
+	// Note: we wrap etcdctl in a shell script to wipe any proxy env variables when running. So the path to the etcdctl
+	// binary is actually etcdctl-cmd
+	for _, path := range []string{"/usr/bin/etcd", "/usr/bin/etcdctl-cmd"} {
 		// ignore the error from os.Remove, since we don't care if it fails
 		_ = os.Remove(path)
 		err = os.Symlink(


### PR DESCRIPTION
This is a backport of https://github.com/gravitational/planet/pull/430.

In order to workaround issues with etcdctl when run with http_proxy env variables set:

- Rename binary etcdctl -> etcdctl-cmd
- Create wrapper script as etcdctl, that unsets the possible HTTP_PROXY env variables.
- Update etcdctl3 script to also unset http_proxy env variables
- The hardlink that points to the correct etcdctl now is set of etcdctl-cmd.

These changes can be reverted once we go to an etcd version built with golang 1.12 or later. It looks like etcd has already updated master, but it's not in any release yet: https://github.com/etcd-io/etcd/blob/master/Makefile#L54

Updates https://github.com/gravitational/gravity.e/issues/4115.