### PR TITLE
Remove start dependency on docker

### DIFF
--- a/build.assets/makefiles/base/docker/registry.service
+++ b/build.assets/makefiles/base/docker/registry.service
@@ -3,7 +3,6 @@ Description=Local Docker Registry
 Wants=docker.service
 
 [Service]
-ExecStartPre=/bin/systemctl is-active docker.service
 ExecStart=/usr/bin/registry serve /etc/docker/registry/config.yml
 Restart=always
 RestartSec=5


### PR DESCRIPTION
The registry doesn't actually require docker to be running, so remove this dependency. The latest version of docker seems to be taking longer than normal to start, which can cause a race in the installer where the registry won't be started before it's used (the installer should also be separately fixed to wait longer).