### PR TITLE
Use env var instead of flag in helm script.

### DIFF
--- a/build.assets/docker/os-rootfs/usr/local/bin/helm
+++ b/build.assets/docker/os-rootfs/usr/local/bin/helm
@@ -16,4 +16,4 @@ fi
 PLANET_ROOT=$(realpath ${DIR}/../../../)
 
 # invoke the real helm binary with a proper config and propagate all arguments as-is
-${PLANET_ROOT}/usr/bin/helm --kubeconfig=${PLANET_ROOT}${KUBE_CONFIG} "$@"
+KUBECONFIG=${PLANET_ROOT}${KUBE_CONFIG} ${PLANET_ROOT}/usr/bin/helm "$@"


### PR DESCRIPTION
By using environment variable to specify kubeconfig instead of a CLI flag we do not affect all helm commands which do not support such flag (e.g. ones added by installed plugins). Refs https://github.com/gravitational/gravity.e/issues/4117.