### PR TITLE
Add optional prefix flag to etcd backup command.

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -421,6 +421,9 @@ const (
 	// ETCDRegistryPrefix is the etcd directory for the k8s api server data in etcd
 	ETCDRegistryPrefix = "/registry"
 
+	// ETCDBackupPrefix is the default etcd backup prefix
+	ETCDBackupPrefix = "/"
+
 	// WaitInterval is the amount of time to sleep between loops
 	WaitInterval = 100 * time.Millisecond
 

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -113,7 +113,7 @@ func etcdInit() error {
 	return nil
 }
 
-func etcdBackup(backupFile string) error {
+func etcdBackup(backupFile string, backupPrefix []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), EtcdUpgradeTimeout)
 	defer cancel()
 
@@ -132,7 +132,7 @@ func etcdBackup(backupFile string) error {
 			CertFile:  DefaultEtcdctlCertFile,
 			CAFile:    DefaultEtcdctlCAFile,
 		},
-		Prefix: []string{"/"}, // Backup all etcd data
+		Prefix: backupPrefix,
 		File:   backupFile,
 	}
 	log.Info("BackupConfig: ", spew.Sdump(backupConf))

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -217,8 +217,9 @@ func run() error {
 
 		cetcdInit = cetcd.Command("init", "Setup etcd to run the correct version").Hidden()
 
-		cetcdBackup     = cetcd.Command("backup", "Backup the etcd datastore to a file")
-		cetcdBackupFile = cetcdBackup.Arg("file", "The file to store the backup").Required().String()
+		cetcdBackup       = cetcd.Command("backup", "Backup the etcd datastore to a file")
+		cetcdBackupFile   = cetcdBackup.Arg("file", "The file to store the backup").Required().String()
+		cetcdBackupPrefix = cetcdBackup.Flag("prefix", "Optional etcd prefix to backup (e.g. /gravity). Can be supplied multiple times").Default(ETCDBackupPrefix).Strings()
 
 		cetcdDisable        = cetcd.Command("disable", "Disable etcd on this node")
 		cetcdDisableUpgrade = cetcdDisable.Flag("upgrade", "disable the upgrade service").Bool()
@@ -507,7 +508,7 @@ func run() error {
 		err = etcdInit()
 
 	case cetcdBackup.FullCommand():
-		err = etcdBackup(*cetcdBackupFile)
+		err = etcdBackup(*cetcdBackupFile, *cetcdBackupPrefix)
 
 	case cetcdEnable.FullCommand():
 		err = etcdEnable(*cetcdEnableUpgrade)


### PR DESCRIPTION
Update `planet etcd backup` command to accept an optional prefix argument to backup only specific etcd paths. I'm planning to use this for https://github.com/gravitational/gravity.e/issues/4036 to add gravity/planet specific etcd data dumps to debug reports.