### PR TITLE
etcd gateway tracking

### DIFF
--- a/build.assets/makefiles/base/agent/planet-agent.service
+++ b/build.assets/makefiles/base/agent/planet-agent.service
@@ -9,6 +9,7 @@ RestartSec=5
 StartLimitInterval=3600
 StartLimitBurst=720
 EnvironmentFile=/etc/container-environment
+EnvironmentFile=-/ext/etcd/etcd-synced.txt
 LimitNOFILE=40000
 LimitNPROC=1048576
 ExecStartPre=/bin/systemctl is-active etcd.service

--- a/build.assets/makefiles/etcd/etcd.service
+++ b/build.assets/makefiles/etcd/etcd.service
@@ -11,7 +11,7 @@ Type=notify
 TimeoutStartSec=0
 EnvironmentFile=/etc/container-environment
 EnvironmentFile=-/ext/etcd/etcd-version.txt
-EnvironmentFile=-/ext/etcd/etcd-gw.env
+EnvironmentFile=-/ext/etcd/etcd-synced.txt
 # Set TLS ciphers as per mozilla recommendations
 # https://wiki.mozilla.org/Security/Server_Side_TLS
 Environment=ETCD_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256

--- a/build.assets/makefiles/etcd/etcd.service
+++ b/build.assets/makefiles/etcd/etcd.service
@@ -11,6 +11,7 @@ Type=notify
 TimeoutStartSec=0
 EnvironmentFile=/etc/container-environment
 EnvironmentFile=-/ext/etcd/etcd-version.txt
+EnvironmentFile=-/ext/etcd/etcd-gw.env
 # Set TLS ciphers as per mozilla recommendations
 # https://wiki.mozilla.org/Security/Server_Side_TLS
 Environment=ETCD_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -199,6 +199,14 @@ func startLeaderClient(conf *LeaderConfig, errorC chan error) (leaderClient io.C
 		}
 	})
 
+	// Only non-masters run etcd gateway service
+	if conf.Role != RoleMaster {
+		err = startWatchingEtcdMasters()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	return client, nil
 }
 

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -306,7 +306,7 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 
 	// Only non-masters run etcd gateway service
 	if leaderConf.Role != RoleMaster {
-		err = startWatchingEtcdMasters(ctx)
+		err = startWatchingEtcdMasters(ctx, monitoringConf)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -199,14 +199,6 @@ func startLeaderClient(conf *LeaderConfig, errorC chan error) (leaderClient io.C
 		}
 	})
 
-	// Only non-masters run etcd gateway service
-	if conf.Role != RoleMaster {
-		err = startWatchingEtcdMasters()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
 	return client, nil
 }
 
@@ -310,6 +302,14 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 	err = setupResolver(ctx, monitoringConf.Role)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	// Only non-masters run etcd gateway service
+	if leaderConf.Role != RoleMaster {
+		err = startWatchingEtcdMasters(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	signalc := make(chan os.Signal, 2)

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -289,6 +289,9 @@ const (
 	DefaultEtcdStoreBase = "/ext/etcd"
 	// DefaultEtcdCurrentVersionFile is the file location that contains version information about the etcd datastore
 	DefaultEtcdCurrentVersionFile = "/ext/etcd/etcd-version.txt"
+	// DefaultEtcdSyncedEnvFile is an environment file for etcd that is updated as the cluster changes
+	DefaultEtcdSyncedEnvFile = "/ext/etcd/etcd-synced.txt"
+
 	// DefaultPlanetReleaseFile is the planet file that indicates the latest available etcd version
 	DefaultPlanetReleaseFile = "/etc/planet-release"
 

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -348,7 +348,7 @@ func (e *etcdGateway) resyncEtcdMasters(ctx context.Context, client *etcdv3.Clie
 	log.WithField("file", DefaultEtcdSyncedEnvFile).Info("Updating etcd gateway environment: ", env)
 	err = utils.SafeWriteFile(DefaultEtcdSyncedEnvFile, []byte(env), constants.SharedReadMask)
 	if err != nil {
-		return trace.Wrap(err, "failed to update etcd synced environment").AddField("file", DefaultEtcdSyncedEnvFile)
+		return trace.Wrap(err, "failed to update etcd environment file").AddField("file", DefaultEtcdSyncedEnvFile)
 	}
 
 	err = systemctl(ctx, "restart", ETCDServiceName)


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity/issues/535
Requires Backport

This is a quick PR that will stand up a goroutine in planet-agent that will monitor the etcd cluster members list, and keep the etcd gateway upstream list updated with cluster changes and restart the etcd gateway on change. 