### PR TITLE
bump kubernetes and golang for CVEs CVE-2019-9512, CVE-2019-9514

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BUILD_ASSETS := $(PWD)/build/assets
 BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 
-KUBE_VER := v1.9.12-gravitational.0
+KUBE_VER := v1.9.13-gravitational.0
 SECCOMP_VER :=  2.3.1-2.1+deb9u1
 DOCKER_VER := 17.03.2
 # we currently use our own flannel fork: gravitational/flannel

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -3,7 +3,7 @@ FROM planet/base
 ENV GOPATH /gopath
 ENV GOROOT /opt/go
 ENV PATH $PATH:$GOPATH/bin:$GOROOT/bin
-ENV GOVERSION 1.10.7
+ENV GOVERSION 1.11.13
 
 # Have our own /etc/passwd with users populated from 990 to 1000
 COPY passwd /etc/passwd


### PR DESCRIPTION
Bump kubernetes / golang for CVE-2019-9512, CVE-2019-9514

Note: the fix is in net/http, which golang didn't patch in 1.10.7, so this requires going to golang 1.13 to patch planet components.