### PR TITLE
remove setting a default upstream resolver of 127.0.0.1 when reading …

### DIFF
--- a/lib/utils/dns.go
+++ b/lib/utils/dns.go
@@ -33,8 +33,6 @@ import (
 	"strings"
 )
 
-var defaultNS = []string{"127.0.0.1", "::1"}
-
 type DNSConfig struct {
 	Servers    []string // servers to use
 	Domain     string   // Domain parameter
@@ -173,10 +171,6 @@ func DNSReadConfig(rdr io.Reader) (*DNSConfig, error) {
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
-	}
-
-	if len(conf.Servers) == 0 {
-		conf.Servers = append(conf.Servers, defaultNS...)
 	}
 
 	return conf, nil

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -138,12 +138,9 @@ options ndots:1 timeout:5 attempts:2
 		{
 			input: `# /etc/resolv.conf
 `,
-			output: `nameserver 127.0.0.1
-nameserver ::1
-options ndots:1 timeout:5 attempts:2
+			output: `options ndots:1 timeout:5 attempts:2
 `,
 			want: &DNSConfig{
-				Servers:  defaultNS,
 				Ndots:    1,
 				Timeout:  5,
 				Attempts: 2,


### PR DESCRIPTION
…resolv.conf settings

Updates https://github.com/gravitational/gravity/issues/613
Requires backport

When reading DNS configuration for planet, if no upstream nameservers are configured, a default of 127.0.0.1 is added as an upstream resolver. It's not clear to me why this was done, but I don't believe it's currently necessary or beneficial to do so. 