### PR TITLE
restart etcd clients within planet during etcd upgrade

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -325,6 +325,8 @@ const (
 	APIServerServiceName = "kube-apiserver.service"
 	// PlanetAgentServiceName is the name of the planet agent
 	PlanetAgentServiceName = "planet-agent.service"
+	// FlannelServiceName is the name of the flannel service
+	FlannelServiceName = "flanneld.service"
 
 	// ETCDGatewayDropinPath is the location of the systemd dropin when etcd is in gateway mode
 	ETCDGatewayDropinPath = "/etc/systemd/system/etcd.service.d/10-gateway.conf"

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -170,6 +170,7 @@ func etcdEnable(upgradeService bool) error {
 	defer cancel()
 
 	if !upgradeService {
+		restartEtcdClients(ctx)
 		return trace.Wrap(enableService(ctx, ETCDServiceName))
 	}
 	// don't actually enable the service if this is a proxy
@@ -188,8 +189,6 @@ func etcdEnable(upgradeService bool) error {
 // etcdUpgrade upgrades / rollbacks the etcd upgrade
 // the procedure is basically the same for an upgrade or rollback, just with some paths reversed
 func etcdUpgrade(rollback bool) error {
-	ctx, cancel := context.WithTimeout(context.Background(), EtcdUpgradeTimeout)
-	defer cancel()
 	log.Info("Updating etcd")
 
 	env, err := box.ReadEnvironment(ContainerEnvironmentFile)
@@ -198,7 +197,7 @@ func etcdUpgrade(rollback bool) error {
 	}
 
 	if env.Get(EnvEtcdProxy) == EtcdProxyOn {
-		log.Info("etcd is in proxy mode, nothing to do")
+		log.Info("etcd is in proxy mode, restarting etcd clients")
 		return nil
 	}
 
@@ -272,20 +271,28 @@ func etcdUpgrade(rollback bool) error {
 		}
 	}
 
-	// reset the kubernetes api server to take advantage of any new etcd settings that may have changed
-	// this only happens if the service is already running
-	status, err := getServiceStatus(APIServerServiceName)
-	if err != nil {
-		log.Warnf("Failed to query status of service %v. Continuing upgrade. Error: %v", APIServerServiceName, err)
-	} else {
-		if status != "inactive" {
-			tryResetService(ctx, APIServerServiceName)
-		}
-	}
-
 	log.Info("Upgrade complete")
 
 	return nil
+}
+
+// restartEtcdClients - because the etcd cluster has been recreated, all clients need to be refreshed so their
+// watches are not pointing at incorrect revisions.
+func restartEtcdClients(ctx context.Context) {
+	services := []string{APIServerServiceName, PlanetAgentServiceName, FlannelServiceName}
+
+	for _, service := range services {
+		// reset the kubernetes api server to take advantage of any new etcd settings that may have changed
+		// this only happens if the service is already running
+		status, err := getServiceStatus(APIServerServiceName)
+		if err != nil {
+			log.Warnf("Failed to query status of service %v. Continuing upgrade. Error: %v", APIServerServiceName, err)
+			return
+		}
+		if status != "inactive" {
+			tryResetService(ctx, service)
+		}
+	}
 }
 
 // startWatchingEtcdMasters creates a control loop which polls etcd for the etcd cluster member list, and updates the


### PR DESCRIPTION
Still testing

Requires backports up to 5.2.x.

Resolves an issue where the etcd clients get confused after the upgrade, due to the cluster being re-created, but active watches can point to a revision that is in the future, causing watches not to fire. All clients of etcd need to be restarted to avoid this issue when the etcd cluster is re-created.