### PR TITLE
5.5.x etcd additional restarts

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -317,10 +317,16 @@ const (
 	ETCDUpgradeServiceName = "etcd-upgrade.service"
 	// APIServerServiceName names the service unit for k8s apiserver
 	APIServerServiceName = "kube-apiserver.service"
+	// ProxyServiceName is the name of the k8s proxy systemd service
+	ProxyServiceName = "kube-proxy.service"
+	// KubeletServiceName is the name of the k8s kubelet systemd service
+	KubeletServiceName = "kube-kubelet.service"
 	// PlanetAgentServiceName is the name of the planet agent
 	PlanetAgentServiceName = "planet-agent.service"
 	// FlannelServiceName is the name of the flannel service
 	FlannelServiceName = "flanneld.service"
+	// CorednsServiceName is the name of the flannel service
+	CorednsServiceName = "coredns.service"
 
 	// ETCDDropinPath is the location of the systemd dropin when etcd is in gateway mode
 	ETCDGatewayDropinPath = "/etc/systemd/system/etcd.service.d/10-gateway.conf"

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -158,7 +158,7 @@ func etcdDisable(upgradeService, stopAPIServer bool) error {
 	defer cancel()
 
 	// Kevin: Workaround, for the API server presenting stale data to clients while etcd is down. Make sure we shut down
-	// the API server as well (passwed as flag from gravity to prevent accidental usage).
+	// the API server as well (passed as flag from gravity to prevent accidental usage).
 	// TODO: This fix needs to be revisited to include a permanent solution.
 	if stopAPIServer {
 		err := systemctl(ctx, "stop", APIServerServiceName)

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -280,7 +280,8 @@ func etcdUpgrade(rollback bool) error {
 // restartEtcdClients - because the etcd cluster has been recreated, all clients need to be refreshed so their
 // watches are not pointing at incorrect revisions.
 func restartEtcdClients(ctx context.Context) {
-	services := []string{APIServerServiceName, PlanetAgentServiceName, FlannelServiceName}
+	services := []string{APIServerServiceName, PlanetAgentServiceName, FlannelServiceName, ProxyServiceName,
+		KubeletServiceName, CorednsServiceName}
 
 	for _, service := range services {
 		// reset the kubernetes api server to take advantage of any new etcd settings that may have changed

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -221,6 +221,7 @@ func run() error {
 
 		cetcdDisable        = cetcd.Command("disable", "Disable etcd on this node")
 		cetcdDisableUpgrade = cetcdDisable.Flag("upgrade", "disable the upgrade service").Bool()
+		cetcdStopApiserver  = cetcdDisable.Flag("stop-api", "stops the kubernetes API service").Bool()
 
 		cetcdEnable        = cetcd.Command("enable", "Enable etcd on this node")
 		cetcdEnableUpgrade = cetcdEnable.Flag("upgrade", "enable the upgrade service").Bool()
@@ -511,7 +512,7 @@ func run() error {
 		err = etcdEnable(*cetcdEnableUpgrade)
 
 	case cetcdDisable.FullCommand():
-		err = etcdDisable(*cetcdDisableUpgrade)
+		err = etcdDisable(*cetcdDisableUpgrade, *cetcdStopApiserver)
 
 	case cetcdUpgrade.FullCommand():
 		err = etcdUpgrade(false)


### PR DESCRIPTION
This is a workaround to issues we've been seeing with upgrades that invoke the etcd upgrade behaviour. It relates to when originally designing the etcd upgrade, the kubernetes docs at the time exposed the underlying etcd index as a resourceVersion, but at the time I believe they indicated that clients should not rely on this behaviour. It looks like since then, kubernetes now does rely on the underlying etcd watch behaviour, which means kubernetes api consumers are now exposed to the same issues with the index resetting during the etcd upgrade.

This is a temporary workaround, to ensure the kubernetes apiserver is shutdown during the etcd upgrade, so that it is not able to serve any stale data to running clients. Each kubernetes client within planet is also restarted at this time. When planet-agent is restarted, planet-agent will be responsible for restarting the kubernetes api based on election results.

After discussing with @a-palchikov we'll have to take a longer term look at this as software running within the cluster using the kubernetes API will be exposed to the same problems.

Symptoms:
- kube-proxy / kubelet are running, but don't appear to be processing updates to objects from the API.

Note: I added stopping the api server as a flag, because I have used the planet command before during troubleshooting to stop etcd, and I believe it's unintuitive that this also stops the apiserver. 

Note: manual testing on a cluster that very frequently shows the kubernetes communications issues did not show symptoms after this workaround with 2 attempts.