### PR TITLE
[5.2.x] configurable timeout for HTTP-based monitoring checks.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -329,7 +329,7 @@
   revision = "f39421c51f636f6a03a79a168aacc628e37a584b"
 
 [[projects]]
-  digest = "1:f6a5754c4966ef474a4ff00e920a4424418452a115e022ad3e418f33069bccae"
+  digest = "1:2b834fa25388f2bda08992015e35000e002fabd11f257fbf9a996feb3ffa4d69"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -343,8 +343,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "d73d6045804133873d18ef223549672188107e4a"
-  version = "5.2.8"
+  revision = "f2806bba44319b357d45a6debf7e1234e0f153fc"
 
 [[projects]]
   digest = "1:e3391db7bc537e6d556635e3f8882dd877a1f04e98e40e64396b716d6a61cef6"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -343,7 +343,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "f2806bba44319b357d45a6debf7e1234e0f153fc"
+  revision = "097fbc4daa1440dc454385927340526c9850ef01"
+  version = "5.2.9"
 
 [[projects]]
   digest = "1:e3391db7bc537e6d556635e3f8882dd877a1f04e98e40e64396b716d6a61cef6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,8 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  #version = "=5.2.9"
-  revision = "f2806bba44319b357d45a6debf7e1234e0f153fc"
+  version = "=5.2.9"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,8 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.2.8"
+  #version = "=5.2.9"
+  revision = "f2806bba44319b357d45a6debf7e1234e0f153fc"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -11,7 +11,7 @@ COPY passwd /etc/passwd
 
 # Install build tools, dev tools and Go:
 RUN apt-get update && apt-get -t stretch-backports install -y libc6-dev libudev-dev && \
-	apt-get install -y curl make git gcc tar gzip vim screen
+	apt-get install -y curl make git gcc tar gzip vim screen dumb-init
 RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar xz
 RUN mkdir -p $GOPATH/src $GOPATH/bin;go get github.com/tools/godep
 RUN go get github.com/gravitational/version/cmd/linkflags

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -29,7 +29,7 @@ build: | $(ASSETDIR)
 		--env="TARGETDIR=/targetdir" \
 		--env="ASSETDIR=/assetdir" \
 		planet/buildbox:latest \
-		make -e \
+		dumb-init make -e \
 			KUBE_VER=$(KUBE_VER) \
 			FLANNEL_VER=$(FLANNEL_VER) \
 			ETCD_VER="$(ETCD_VER)" \

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package constants
 
+import "time"
+
 const (
 	// KubectlConfigPath is the path to kubectl configuration file
 	KubectlConfigPath = "/etc/kubernetes/kubectl.kubeconfig"
@@ -49,4 +51,7 @@ const (
 
 	// GravityDataDir is the directory where gravity data is stored in planet
 	GravityDataDir = "/var/lib/gravity"
+
+	// HTTPTimeout specifies the default HTTP timeout for checks
+	HTTPTimeout = 10 * time.Second
 )

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gravitational/planet/lib/constants"
 
@@ -64,14 +65,38 @@ type Config struct {
 	NodeName string
 	// HighWatermark is the usage limit percentage of monitored directories and devicemapper
 	HighWatermark uint
+	// HTTPTimeout specifies the HTTP timeout for checks
+	HTTPTimeout time.Duration
 }
 
-// Check validates monitoring configuration
-func (c Config) Check() error {
+// CheckAndSetDefaults validates monitoring configuration and sets defaults
+func (c Config) CheckAndSetDefaults() error {
 	if c.HighWatermark > 100 {
 		return trace.BadParameter("high watermark percentage should be 0-100")
 	}
+	if c.HTTPTimeout == 0 {
+		c.HTTPTimeout = constants.HTTPTimeout
+	}
 	return nil
+}
+
+// NewETCDConfig returns new ETCD configuration
+func (c Config) NewETCDConfig() (*monitoring.ETCDConfig, error) {
+	etcdConfig := &monitoring.ETCDConfig{
+		Endpoints: c.ETCDConfig.Endpoints,
+		CAFile:    c.ETCDConfig.CAFile,
+		CertFile:  c.ETCDConfig.CertFile,
+		KeyFile:   c.ETCDConfig.KeyFile,
+	}
+	transport, err := etcdConfig.NewHTTPTransport()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	etcdConfig.Client = &http.Client{
+		Transport: transport,
+		Timeout:   c.HTTPTimeout,
+	}
+	return etcdConfig, nil
 }
 
 // LocalTransport returns http transport that is set up with local certificate authority
@@ -146,6 +171,11 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 		return trace.Wrap(err)
 	}
 
+	localClient := &http.Client{
+		Transport: localTransport,
+		Timeout:   config.HTTPTimeout,
+	}
+
 	etcdChecker, err := monitoring.EtcdHealth(etcdConfig)
 	if err != nil {
 		return trace.Wrap(err)
@@ -165,7 +195,7 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 	kubeConfig := monitoring.KubeConfig{Client: client}
 	node.AddChecker(monitoring.KubeAPIServerHealth(monitoring.KubeConfig{Client: apiServerClient}))
 	node.AddChecker(monitoring.DockerHealth("/var/run/docker.sock"))
-	node.AddChecker(dockerRegistryHealth(config.RegistryAddr, localTransport))
+	node.AddChecker(dockerRegistryHealth(config.RegistryAddr, localClient))
 	node.AddChecker(etcdChecker)
 	node.AddChecker(monitoring.SystemdHealth())
 	node.AddChecker(monitoring.NewIPForwardChecker())
@@ -236,8 +266,8 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 	return nil
 }
 
-func dockerRegistryHealth(addr string, transport *http.Transport) health.Checker {
-	return monitoring.NewHTTPHealthzCheckerWithTransport("docker-registry", fmt.Sprintf("%v/v2/", addr), transport, noopResponseChecker)
+func dockerRegistryHealth(addr string, client *http.Client) health.Checker {
+	return monitoring.NewHTTPHealthzCheckerWithClient("docker-registry", fmt.Sprintf("%v/v2/", addr), client, noopResponseChecker)
 }
 
 func noopResponseChecker(response io.Reader) error {

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -242,7 +242,7 @@ func unitsCommand(command string) error {
 // runAgent starts the master election / health check loops in background and
 // blocks until a signal has been received.
 func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf *LeaderConfig, peers []string) error {
-	err := monitoringConf.Check()
+	err := monitoringConf.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -144,6 +144,10 @@ const (
 	// of the agent key file
 	EnvPlanetAgentClientKeyFile = "PLANET_AGENT_CLIENT_KEYFILE"
 
+	// EnvPlanetAgentHTTPTimeout names the environment variable that overrides the HTTP client
+	// timeout for monitoring checks
+	EnvPlanetAgentHTTPTimeout = "PLANET_AGENT_HTTP_TIMEOUT"
+
 	// EnvDockerPromiscuousMode names the environment variable that specifies the
 	// promiscuous mode for docker
 	EnvDockerPromiscuousMode = "PLANET_DOCKER_PROMISCUOUS_MODE"

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -30,12 +30,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gravitational/configure/cstrings"
 	"github.com/gravitational/planet/lib/box"
+	"github.com/gravitational/planet/lib/constants"
 	"github.com/gravitational/planet/lib/monitoring"
 	"github.com/gravitational/planet/test/e2e"
 
 	kv "github.com/gravitational/configure"
+	"github.com/gravitational/configure/cstrings"
 	etcdconf "github.com/gravitational/coordinate/config"
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/backend/inmemory"
@@ -143,6 +144,7 @@ func run() error {
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
 		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of monitored directories and devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
+		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
 
 		// stop a running container
 		cstop = app.Command("stop", "Stop planet container")
@@ -316,6 +318,7 @@ func run() error {
 			CloudProvider:         *cagentCloudProvider,
 			HighWatermark:         uint(*cagentHighWatermark),
 			NodeName:              *cagentNodeName,
+			HTTPTimeout:           *cagentHTTPTimeout,
 		}
 		leaderConf := &LeaderConfig{
 			PublicIP:        cagentPublicIP.String(),

--- a/vendor/github.com/gravitational/satellite/monitoring/checkers.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/checkers.go
@@ -63,13 +63,17 @@ func NodesStatusHealth(config KubeConfig, nodesReadyThreshold int) health.Checke
 func EtcdHealth(config *ETCDConfig) (health.Checker, error) {
 	const name = "etcd-healthz"
 
-	transport, err := config.NewHTTPTransport()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	client := config.Client
+	if client == nil {
+		var err error
+		client, err = config.NewClient()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	createChecker := func(addr string) (health.Checker, error) {
 		endpoint := fmt.Sprintf("%v/health", addr)
-		return NewHTTPHealthzCheckerWithTransport(name, endpoint, transport, etcdChecker), nil
+		return NewHTTPHealthzCheckerWithClient(name, endpoint, client, etcdChecker), nil
 	}
 	var checkers []health.Checker
 	for _, endpoint := range config.Endpoints {

--- a/vendor/github.com/gravitational/satellite/monitoring/etcd.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/etcd.go
@@ -46,7 +46,13 @@ type ETCDConfig struct {
 	// InsecureSkipVerify controls whether a client verifies the
 	// server's certificate chain and host name.
 	InsecureSkipVerify bool
+	// Client specifies the optional HTTP client to use for checks.
+	// If unspecified, one will be created with default settings
+	Client *http.Client
 }
+
+// defaultHTTPTimeout defines the default client timeout for HTTP-based checks
+const defaultHTTPTimeout = 10 * time.Second
 
 // defaultTLSHandshakeTimeout specifies the default maximum amount of time
 // spent waiting to for a TLS handshake
@@ -93,6 +99,18 @@ func etcdStatus(payload []byte) (healthy bool, err error) {
 	}
 
 	return (result.Health == "true" || nresult.Health == true), nil
+}
+
+// NewClient returns a new HTTP client with default configuration
+func (r *ETCDConfig) NewClient() (*http.Client, error) {
+	transport, err := r.NewHTTPTransport()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   defaultHTTPTimeout,
+	}, nil
 }
 
 // NewHTTPTransport creates a new http.Transport from the specified

--- a/vendor/github.com/gravitational/satellite/monitoring/healthz.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/healthz.go
@@ -22,14 +22,11 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 )
-
-const healthzCheckTimeout = 1 * time.Second
 
 // HTTPResponseChecker is a function that can validate service health
 // from the provided response
@@ -103,8 +100,14 @@ func NewUnixSocketHealthzChecker(name, URL, socketPath string, checker HTTPRespo
 func NewHTTPHealthzCheckerWithTransport(name, URL string, transport http.RoundTripper, checker HTTPResponseChecker) health.Checker {
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   healthzCheckTimeout,
+		Timeout:   defaultHTTPTimeout,
 	}
+	return NewHTTPHealthzCheckerWithClient(name, URL, client, checker)
+}
+
+// NewHTTPHealthzCheckerWithClient creates a health.Checker for an HTTP health endpoint
+// using the specified HTTP client, URL and a custom response checker
+func NewHTTPHealthzCheckerWithClient(name, URL string, client *http.Client, checker HTTPResponseChecker) health.Checker {
 	return &HTTPHealthzChecker{
 		name:    name,
 		URL:     URL,


### PR DESCRIPTION
Requires https://github.com/gravitational/satellite/pull/121.