### PR TITLE
bump kubernetes for cve-2019-11253

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.14.7
+KUBE_VER ?= v1.14.8
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 18.09.5
 # we currently use our own flannel fork: gravitational/flannel


### PR DESCRIPTION
Upstream Notes: https://github.com/kubernetes/kubernetes/issues/83253