### PR TITLE
return error if mount point is missing

### DIFF
--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -373,8 +373,14 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 			return nil, trace.Wrap(err, "invalid glob pattern %q", mountSpec.Src)
 		}
 
-		if len(matches) == 0 && mountSpec.SkipIfMissing {
-			// Skip the non-existent mount source
+		if len(matches) == 0 {
+			if !mountSpec.SkipIfMissing {
+				return nil, trace.NotFound("mount source not found").AddFields(map[string]interface{}{
+					"src": mountSpec.Src,
+					"dst": mountSpec.Dst,
+				})
+			}
+			// Skip the non-existent mount source if SkipIfMissing is set
 			continue
 		}
 


### PR DESCRIPTION
Not sure if I'm missing something, but I noticed this while trying to explain an issue I ran into with a customer this week.

If the filepath.glob returns an empty list with no error, we don't appear to turn that into an error anywhere, and silently skip the missing mount. I assume the presence of SkipIfMissing is meant to allow a missing mount, and as such we should throw an error when not set.