### PR TITLE
[6.2.x] remove docker bridge and promiscous mode that's no longer used

### DIFF
--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -342,14 +342,6 @@
                 }
             },
             {
-                "type": "Bool",
-                "name": "dockerpromiscuousmode",
-                "env": "PLANET_DOCKER_PROMISCUOUS_MODE",
-                "cli": {
-                    "name": "docker-promiscuous-mode"
-                }
-            },
-            {
                 "type": "String",
                 "name": "serviceuid",
                 "env": "PLANET_SERVICE_UID",

--- a/build.assets/makefiles/base/docker/docker.service
+++ b/build.assets/makefiles/base/docker/docker.service
@@ -19,7 +19,7 @@ ExecStartPre=-/bin/rm -f /var/run/docker.pid
 # On upgrade, docker will use the flannel network, conflicting with the bridge created by CNI
 # So remove any cached network setting, so that docker gets reset back to 172.17.0.0/16 for its network
 ExecStartPre=-/bin/rm -r /ext/docker/network
-ExecStart=/usr/bin/dockerd  --iptables=false --ip-masq=false --graph=/ext/docker $DOCKER_OPTS
+ExecStart=/usr/bin/dockerd  --bridge=none --iptables=false --ip-masq=false --graph=/ext/docker $DOCKER_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -121,8 +121,6 @@ type Config struct {
 	APIServerOptions string
 	// ServiceUser defines the user context for container's service user
 	ServiceUser serviceUser
-	// DockerPromiscuousMode specifies whether to put docker bridge into promiscuous mode
-	DockerPromiscuousMode bool
 	// DNS is the local DNS configuration
 	DNS DNS
 	// Taints is a list of kubernetes taints to apply to the object

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -66,14 +66,14 @@ const (
 	// EnvAPIServerName names the environment variable that specifies
 	// the address of the API server
 	EnvAPIServerName = "KUBE_APISERVER"
-	// See https://coreos.com/etcd/docs/latest/v2/configuration.html
 	// EnvEtcdProxy names the environment variable that specifies
 	// the value of the proxy mode setting
+	// See https://coreos.com/etcd/docs/latest/v2/configuration.html
 	EnvEtcdProxy = "PLANET_ETCD_PROXY"
 	// EnvEtcdMemberName names the environment variable that specifies
 	// the name of this node in the etcd cluster
 	EnvEtcdMemberName = "PLANET_ETCD_MEMBER_NAME"
-	// EnvEtcdInitialClusterState names the environment variable that specifies
+	// EnvEtcdInitialCluster names the environment variable that specifies
 	// the initial etcd cluster configuration for bootstrapping
 	EnvEtcdInitialCluster = "ETCD_INITIAL_CLUSTER"
 	// EnvEtcdGatewayEndpoints is a list of endpoints the etcd gateway can use
@@ -190,10 +190,11 @@ const (
 	// of the agent key file
 	EnvPlanetAgentClientKeyFile = "PLANET_AGENT_CLIENT_KEYFILE"
 
-	// EnvDockerPromiscuousMode names the environment variable that specifies the
-	// promiscuous mode for docker
-	EnvDockerPromiscuousMode = "PLANET_DOCKER_PROMISCUOUS_MODE"
-	// EnvServiceGID names the environment variable that specifies the service user ID
+	// EnvPlanetAgentHTTPTimeout names the environment variable that overrides the HTTP client
+	// timeout for monitoring checks
+	EnvPlanetAgentHTTPTimeout = "PLANET_AGENT_HTTP_TIMEOUT"
+
+	// EnvServiceUID names the environment variable that specifies the service user ID
 	EnvServiceUID = "PLANET_SERVICE_UID"
 	// EnvServiceGID names the environment variable that specifies the service group ID
 	EnvServiceGID = "PLANET_SERVICE_GID"
@@ -309,10 +310,9 @@ const (
 	// This is kept for backwards-compatibility
 	LegacyAPIServerDNSName = "apiserver"
 
-	// See resolv.conf(5) on a Linux machine
-	//
 	// DNSNdots defines the threshold for amount of dots that must appear in a name
 	// before an initial absolute query will be made
+	// See resolv.conf(5) on a Linux machine
 	DNSNdots = 2
 	// DNSTimeout is the amount time resolver will wait for response before retrying
 	// the query with a different name server. Measured in seconds
@@ -335,7 +335,7 @@ const (
 	// CorednsServiceName is the name of the coredns service
 	CorednsServiceName = "coredns.service"
 
-	// ETCDDropinPath is the location of the systemd dropin when etcd is in gateway mode
+	// ETCDGatewayDropinPath is the location of the systemd dropin when etcd is in gateway mode
 	ETCDGatewayDropinPath = "/etc/systemd/system/etcd.service.d/10-gateway.conf"
 
 	// PlanetResolv is planet local resolver
@@ -399,10 +399,6 @@ const (
 
 	// DefaultDockerUnit specifies the name of the docker service unit file
 	DefaultDockerUnit = "docker.service"
-
-	// DockerPromiscuousModeDropIn names the drop-in file with promiscuous mode configuration
-	// for docker bridge
-	DockerPromiscuousModeDropIn = "99-docker-promisc.conf"
 
 	// MinKernelVersion specifies the minimum kernel version on the host
 	MinKernelVersion = 310

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -131,7 +131,6 @@ func run() error {
 					OverrideDefaultFromEnvar(EnvPlanetAPIServerOptions).String()
 		cstartDNSListenAddrs        = List(cstart.Flag("dns-listen-addr", "Comma-separated list of addresses for CoreDNS to listen on").OverrideDefaultFromEnvar(EnvPlanetDNSListenAddr).Default(DefaultDNSListenAddr))
 		cstartDNSPort               = cstart.Flag("dns-port", "DNS port for CoreDNS").OverrideDefaultFromEnvar(EnvPlanetDNSPort).Default(strconv.Itoa(DNSPort)).Int()
-		cstartDockerPromiscuousMode = cstart.Flag("docker-promiscuous-mode", "Whether to put docker bridge into promiscuous mode").OverrideDefaultFromEnvar(EnvDockerPromiscuousMode).Bool()
 		cstartTaints                = List(cstart.Flag("taint", "Kubernetes taints to apply to the node during creation").OverrideDefaultFromEnvar(EnvPlanetTaints))
 		cstartNodeLabels            = List(cstart.Flag("node-label", "Kubernetes node label to apply upon node registration").OverrideDefaultFromEnvar(EnvPlanetNodeLabels))
 		cstartDisableFlannel        = cstart.Flag("disable-flannel", "Disable flannel within the planet container").OverrideDefaultFromEnvar(EnvDisableFlannel).Bool()
@@ -427,7 +426,6 @@ func run() error {
 			},
 			KubeletOptions:        *cstartKubeletOptions,
 			APIServerOptions:      *cstartAPIServerOptions,
-			DockerPromiscuousMode: *cstartDockerPromiscuousMode,
 			Taints:                *cstartTaints,
 			NodeLabels:            *cstartNodeLabels,
 			DisableFlannel:        *cstartDisableFlannel,

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -159,7 +159,6 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 		box.EnvPair{Name: EnvClusterID, Val: config.ClusterID},
 		box.EnvPair{Name: EnvNodeName, Val: config.NodeName},
 		box.EnvPair{Name: EnvElectionEnabled, Val: strconv.FormatBool(config.ElectionEnabled)},
-		box.EnvPair{Name: EnvDockerPromiscuousMode, Val: strconv.FormatBool(config.DockerPromiscuousMode)},
 		box.EnvPair{Name: EnvDNSHosts, Val: config.DNS.Hosts.String()},
 		box.EnvPair{Name: EnvDNSZones, Val: config.DNS.Zones.String()},
 		box.EnvPair{Name: EnvPlanetAllowPrivileged, Val: strconv.FormatBool(config.AllowPrivileged)},
@@ -479,20 +478,6 @@ func addDockerOptions(config *Config) error {
 	config.Env.Append(EnvDockerOptions, "--log-opt max-file=9", " ")
 	if config.DockerOptions != "" {
 		config.Env.Append(EnvDockerOptions, config.DockerOptions, " ")
-	}
-
-	if config.DockerPromiscuousMode {
-		dropInDir := filepath.Join(config.Rootfs, constants.SystemdUnitPath, utils.DropInDir(DefaultDockerUnit))
-		err := utils.WriteDropIn(dropInDir, DockerPromiscuousModeDropIn, []byte(`
-[Service]
-ExecStartPost=
-ExecStartPost=/usr/bin/gravity system enable-promisc-mode docker0
-ExecStopPost=
-ExecStopPost=-/usr/bin/gravity system disable-promisc-mode docker0
-`))
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Backports https://github.com/gravitational/planet/pull/511.