### PR TITLE
don't drop domain from search domain list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ enter.sh
 make.sh
 
 *.swp
+.vscode

--- a/lib/utils/dns.go
+++ b/lib/utils/dns.go
@@ -72,14 +72,8 @@ func (d *DNSConfig) String() string {
 	if d.Domain != "" {
 		fmt.Fprintf(buf, "%v %v\n", domainParam, d.Domain)
 	}
-	search := []string{}
-	for _, domain := range d.Search {
-		if domain != d.Domain {
-			search = append(search, domain)
-		}
-	}
-	if len(search) != 0 {
-		fmt.Fprintf(buf, "%v %v\n", searchParam, strings.Join(search, " "))
+	if len(d.Search) != 0 {
+		fmt.Fprintf(buf, "%v %v\n", searchParam, strings.Join(d.Search, " "))
 	}
 	for _, server := range d.Servers {
 		fmt.Fprintf(buf, "%v %v\n", nameserverParam, server)
@@ -100,6 +94,7 @@ func DNSReadConfig(rdr io.Reader) (*DNSConfig, error) {
 		Ndots:    1,
 		Timeout:  5,
 		Attempts: 2,
+		Search:   []string{},
 	}
 
 	scanner := bufio.NewScanner(rdr)
@@ -124,7 +119,6 @@ func DNSReadConfig(rdr io.Reader) (*DNSConfig, error) {
 		case domainParam: // set search path to just this domain
 			if len(f) > 1 {
 				conf.Domain = f[1]
-				conf.Search = []string{f[1]}
 			}
 
 		case searchParam: // set search path to given servers

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -85,7 +85,7 @@ options ndots:5 timeout:10 attempts:3 rotate
 `,
 			want: &DNSConfig{
 				Servers:    []string{"8.8.8.8", "2001:4860:4860::8888", "fe80::1%lo0"},
-				Search:     []string{"localdomain"},
+				Search:     []string{},
 				Domain:     "localdomain",
 				Ndots:      5,
 				Timeout:    10,
@@ -102,12 +102,13 @@ domain localdomain
 nameserver 8.8.8.8
 `,
 			output: `domain localdomain
+search test invalid
 nameserver 8.8.8.8
 options ndots:1 timeout:5 attempts:2
 `,
 			want: &DNSConfig{
 				Servers:  []string{"8.8.8.8"},
-				Search:   []string{"localdomain"},
+				Search:   []string{"test", "invalid"},
 				Domain:   "localdomain",
 				Ndots:    1,
 				Timeout:  5,
@@ -147,6 +148,7 @@ options ndots:1 timeout:5 attempts:2
 				Ndots:    1,
 				Timeout:  5,
 				Attempts: 2,
+				Search:   []string{},
 			},
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity/issues/1180

Requires Backport

It appears that the DNS parsing code is modified from the golang sources, which interprets the domain parameter as a search domain if the search parameter isn't specified (as per man resolv.conf), and overridden if search is specified. The current code also filters out the domain parameter if it appears in the search list, which I wasn't able to locate a reason for (including asking Sasha).  This updates the behaviour that the parsed resolv.conf is closer to an original representation, that is then copied as is into planet, without dropping search domain fields.

