### PR TITLE
Implement workaround to clean up leaking cgroups

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -314,8 +314,6 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	go runSystemdCgroupCleaner(ctx)
 
 	signalc := make(chan os.Signal, 2)

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -314,6 +314,10 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 		}
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runSystemdCgroupCleaner(ctx)
+
 	signalc := make(chan os.Signal, 2)
 	signal.Notify(signalc, os.Interrupt, syscall.SIGTERM)
 

--- a/tool/planet/cgroup.go
+++ b/tool/planet/cgroup.go
@@ -421,7 +421,7 @@ func cleanSystemdScopes() error {
 		log.WithFields(logrus.Fields{
 			"path": procsPath,
 			"unit": unitName,
-		}).Warn("Stopped systemd scope unit with no pids.")
+		}).Info("Stopped systemd scope unit with no pids.")
 	}
 
 	return nil

--- a/tool/planet/cgroup.go
+++ b/tool/planet/cgroup.go
@@ -345,7 +345,10 @@ func runSystemdCgroupCleaner(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			cleanSystemdScopes()
+			err := cleanSystemdScopes()
+			if err != nil {
+				logrus.WithError(err).Warn("Failed to clean systemd scopes that don't contain processes")
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -387,7 +390,7 @@ func cleanSystemdScopes() error {
 
 	for _, path := range paths {
 		unitName := filepath.Base(path)
-		log = log.WithFields(logrus.Fields{
+		log := log.WithFields(logrus.Fields{
 			"path": path,
 			"unit": unitName,
 		})


### PR DESCRIPTION
This change implements a cleaner, that scans for cgroups created by
systemd-run --scope that do not have any pids assigned, indicating
that the cgroup is unused and should be cleaned up. On some systems
either due to systemd or the kernel, the scope is not being cleaned
up when the pids within the scope have completed execution, leading
to an eventual memory leak.

Kubernetes uses systemd-run --scope when creating mount points,
that may require drivers to be loaded/running in a separate context
from kubelet, which allows the above leak to occur.

https://github.com/kubernetes/kubernetes/issues/70324
https://github.com/kubernetes/kubernetes/issues/64137

Updates https://github.com/gravitational/gravity/issues/1219