### PR TITLE
(6.1) Upgrade serf to v0.8.5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ DOCKER_VER ?= 18.09.9
 FLANNEL_VER := v0.10.1-gravitational
 HELM_VER := v2.14.3
 COREDNS_VER := 1.3.1
+SERF_VER := v0.8.5
 
 # ETCD Versions to include in the release
 # This list needs to include every version of etcd that we can upgrade from + latest

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,6 +1,6 @@
 .PHONY: all
 
-VER := v0.8.0
+VER := v0.8.5
 REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
 OUT := $(ASSETDIR)/serf-$(VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
@@ -10,7 +10,7 @@ all: agent.mk $(OUT) $(BINARIES)
 $(OUT):
 	@echo "\n---> Building Serf:\n"
 	mkdir -p $(GOPATH)/src/github.com/hashicorp
-	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(VER) --depth 1 
+	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(VER) --depth 1
 	cd $(REPODIR) && \
 	go get -t -d ./... && \
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,8 +1,7 @@
 .PHONY: all
 
-VER := v0.8.5
 REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
-OUT := $(ASSETDIR)/serf-$(VER)
+OUT := $(ASSETDIR)/serf-$(SERF_VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
 
 all: agent.mk $(OUT) $(BINARIES)
@@ -10,7 +9,7 @@ all: agent.mk $(OUT) $(BINARIES)
 $(OUT):
 	@echo "\n---> Building Serf:\n"
 	mkdir -p $(GOPATH)/src/github.com/hashicorp
-	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(VER) --depth 1
+	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(SERF_VER) --depth 1
 	cd $(REPODIR) && \
 	go get -t -d ./... && \
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf

--- a/build.assets/makefiles/base/agent/serf.service
+++ b/build.assets/makefiles/base/agent/serf.service
@@ -10,9 +10,10 @@ StartLimitBurst=720
 
 EnvironmentFile=/etc/container-environment
 ExecStart=/usr/bin/serf agent \
-        -bind=${PLANET_PUBLIC_IP}:7496 \
+	-bind=${PLANET_PUBLIC_IP}:7496 \
 	-node=${PLANET_AGENT_NAME} \
 	-snapshot=/ext/state/serf-snapshot \
+	-protocol=4 \
 	-tag role=${PLANET_ROLE} \
 	-tag publicip=${PLANET_PUBLIC_IP}
 User=planet

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -32,6 +32,7 @@ build: | $(ASSETDIR)
 		make -e \
 			KUBE_VER=$(KUBE_VER) \
 			FLANNEL_VER=$(FLANNEL_VER) \
+			SERF_VER=$(SERF_VER) \
 			ETCD_VER="$(ETCD_VER)" \
 			ETCD_LATEST_VER=$(ETCD_LATEST_VER) \
 			-C /assets/makefiles -f planet.mk


### PR DESCRIPTION
Upgrade serf to v0.8.5 to take advantage of a new `-prune` flag that allows to immediately evict a member when executing a `force-leave` command.

Note: serf v0.8.5 uses new protocol version 5 by default which older agents do not recognize so I set it to use the previous version 4. We will be able to get rid of this flag when serf agents in all supported upgrade paths understand it.