### PR TITLE
Tune image pulls within kubelet for large images

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-kubelet.service
+++ b/build.assets/makefiles/master/k8s-master/kube-kubelet.service
@@ -22,7 +22,6 @@ ExecStart=/usr/bin/kubelet \
         --system-reserved=${KUBE_SYSTEM_RESERVED} \
         --cgroup-root=${KUBE_CGROUP_ROOT} \
         --config=/etc/kubernetes/kubelet.yaml \
-        --serialize-image-pulls=false \
         --image-pull-progress-deadline=15m \
         --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
         $KUBE_KUBELET_FLAGS \

--- a/build.assets/makefiles/master/k8s-master/kube-kubelet.service
+++ b/build.assets/makefiles/master/k8s-master/kube-kubelet.service
@@ -22,6 +22,8 @@ ExecStart=/usr/bin/kubelet \
         --system-reserved=${KUBE_SYSTEM_RESERVED} \
         --cgroup-root=${KUBE_CGROUP_ROOT} \
         --config=/etc/kubernetes/kubelet.yaml \
+        --serialize-image-pulls=false \
+        --image-pull-progress-deadline=15m \
         --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
         $KUBE_KUBELET_FLAGS \
         $KUBE_CLOUD_FLAGS \

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -513,6 +513,9 @@ var KubeletConfig = kubeletconfig.KubeletConfiguration{
 	Authorization: kubeletconfig.KubeletAuthorization{
 		Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 	},
+	// Allow parallel image pulls to avoid head of line blocking
+	// https://github.com/gravitational/gravity/issues/1167
+	SerializeImagePulls: utils.BoolPtr(false),
 }
 
 // KubeletConfigOverrides specifies the subset of kubelet configuration


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/1167

Tune kubelet parameters to allows parallel image pulls and increase the progress deadline from 1m to 15m. 

Increasing the deadilne should be relatively safe, but I'm not sure how risky changing the serialize-image-pulls setting is. Based on some descriptions, aufs apparently had some corruption problems with parallel pulls, which isn't present when using overlay2. On my test cluster, I didn't observe any issues in limited testing, and confirmed that image pulls are not blocked while a large image is still downloading.
