### PR TITLE
(6.3) Add apiserver flags for token volume projection.

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -16,6 +16,8 @@ ExecStart=/usr/bin/kube-apiserver \
         --insecure-port=0 \
         --service-account-key-file=/var/state/apiserver.key \
         --service-account-lookup=true \
+        --service-account-signing-key-file=/var/state/apiserver.key \
+        --service-account-issuer=api \
         --enable-admission-plugins=PodSecurityPolicy,NodeRestriction,AlwaysPullImages \
         --authorization-mode=Node,RBAC \
         --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true \


### PR DESCRIPTION
Add a couple of flags to apiserver to enable support for [service account token volume projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). This will allow kubelet to request the token on behalf of the pod and mount it into containers via a projected volume (there's an example at that link above).

There's another flag that's also required, `--api-audiences`, which indicates which token audiences are allowed, but it's application specific so should be set by users via ClusterConfiguration resource.

Refs https://github.com/gravitational/gravity/issues/1342.