### PR TITLE
[5.5.x] use encryption key for serf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ buildbox: base
 .PHONY: clean
 clean:
 	$(MAKE) -C $(ASSETS)/makefiles -f buildbox.mk clean
-	rm -rf $(BUILDDIR)
+	rm -rf $(BUILDDIR)/planet
 
 # internal use:
 .PHONY: make-docker-image

--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -460,6 +460,14 @@
                 "cli": {
                     "name": "feature-gates"
                 }
+            },
+            {
+                "type": "String",
+                "name": "serf-key",
+                "env": "PLANET_SERF_KEY",
+                "cli": {
+                    "name": "serf-key"
+                }
             }
         ]
     }

--- a/build.assets/makefiles/base/agent/serf.service
+++ b/build.assets/makefiles/base/agent/serf.service
@@ -10,6 +10,7 @@ StartLimitBurst=720
 
 EnvironmentFile=/etc/container-environment
 ExecStart=/usr/bin/serf agent \
+	-encrypt=${PLANET_SERF_KEY} \
 	-bind=${PLANET_PUBLIC_IP}:7496 \
 	-node=${PLANET_AGENT_NAME} \
 	-snapshot=/ext/state/serf-snapshot \

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -133,6 +133,9 @@ type Config struct {
 	KubeletConfig string
 	// CloudConfig specifies the cloud configuration as JSON-encoded payload
 	CloudConfig string
+	// SerfKey specifies the encryption key for serf.
+	// Assumsed to be base64-encoded 16, 24 or 32-byte key
+	SerfKey string
 }
 
 // DNS describes DNS server configuration

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -246,6 +246,10 @@ const (
 	// This is external configuration for the container
 	EnvPlanetCloudConfig = "PLANET_CLOUD_CONFIG"
 
+	// EnvSerfKey specifies the encryption key for the serf agent.
+	// Assumed to be base64-encoded 16, 24 or 32-byte key for the respective AES cipher
+	EnvSerfKey = "PLANET_SERF_KEY"
+
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
 

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -139,6 +139,7 @@ func run() error {
 		cstartDisableFlannel = cstart.Flag("disable-flannel", "Disable flannel within the planet container").OverrideDefaultFromEnvar(EnvDisableFlannel).Bool()
 		cstartKubeletConfig  = cstart.Flag("kubelet-config", "Kubelet configuration as base64-encoded JSON payload").OverrideDefaultFromEnvar(EnvPlanetKubeletConfig).String()
 		cstartCloudConfig    = cstart.Flag("cloud-config", "Cloud configuration as base64-encoded payload").OverrideDefaultFromEnvar(EnvPlanetCloudConfig).String()
+		cstartSerfKey        = cstart.Flag("serf-key", "Encryption key for serf cluster").Envar(EnvSerfKey).Required().String()
 
 		// start the planet agent
 		cagent                 = app.Command("agent", "Start Planet Agent")
@@ -441,6 +442,7 @@ func run() error {
 			DisableFlannel:   *cstartDisableFlannel,
 			KubeletConfig:    *cstartKubeletConfig,
 			CloudConfig:      *cstartCloudConfig,
+			SerfKey:          *cstartSerfKey,
 		}
 		if *cstartSelfTest {
 			err = selfTest(config, *cstartTestKubeRepoPath, *cstartTestSpec, extraArgs)

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -161,6 +161,7 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 		box.EnvPair{Name: EnvElectionEnabled, Val: strconv.FormatBool(config.ElectionEnabled)},
 		box.EnvPair{Name: EnvDNSHosts, Val: config.DNS.Hosts.String()},
 		box.EnvPair{Name: EnvDNSZones, Val: config.DNS.Zones.String()},
+		box.EnvPair{Name: EnvSerfKey, Val: config.SerfKey},
 	)
 
 	// Setup http_proxy / no_proxy environment configuration


### PR DESCRIPTION
Use encryption key with serf to avoid unrelated members joining the cluster after incomplete or unfinished cleanup.