### PR TITLE
Add symlinks for helm and kubectl binaries

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -61,6 +61,8 @@ RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_V
 RUN curl https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
     mkdir -p /tmp/helm && tar -xvzf /tmp/helm-$HELM_VER.tar.gz -C /tmp/helm && \
     cp /tmp/helm/linux-amd64/helm /usr/bin && \
+    # make symlink for helm for backward compatibility
+    ln -sf /usr/bin/helm /bin/helm && \
     rm -rf /tmp/helm*
 
 RUN curl -L https://github.com/coredns/coredns/releases/download/v${COREDNS_VER}/coredns_${COREDNS_VER}_linux_amd64.tgz -o /tmp/coredns-${COREDNS_VER}.tar.gz && \

--- a/build.assets/makefiles/master/k8s-master/k8s-master.mk
+++ b/build.assets/makefiles/master/k8s-master/k8s-master.mk
@@ -19,3 +19,6 @@ all: k8s-master.mk
 	install -m 0755 $(BINDIR)/kubectl $(ROOTFS)/usr/bin
 	install -m 0755 $(BINDIR)/kube-proxy $(ROOTFS)/usr/bin
 	install -m 0755 $(BINDIR)/kubelet $(ROOTFS)/usr/bin
+	
+	# make symlink for kubectl for backward compatibility
+	ln -sf /usr/bin/kubectl $(ROOTFS)/bin/kubectl


### PR DESCRIPTION
What tested:
```
ls -gG rootfs/bin/{helm,kubectl}
lrwxrwxrwx 1 13 Apr 30 21:03 rootfs/bin/helm -> /usr/bin/helm
lrwxrwxrwx 1 16 Apr 30 21:07 rootfs/bin/kubectl -> /usr/bin/kubectl
```