### PR TITLE
Ignore same leader re-elected case

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -158,6 +158,10 @@ func startLeaderClient(conf *LeaderConfig, agent agent.Agent, errorC chan error)
 		if newVal != conf.PublicIP {
 			return
 		}
+		// Ignore if same leader is re-elected
+		if newVal == prevVal {
+			return
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), recordEventTimeout)
 		defer cancel()


### PR DESCRIPTION
### Description
This PR updates the Planet agent so that new events are not reported when the same leader is re-elected.