### PR TITLE
(5.5) Increase max etcd request size

### DIFF
--- a/build.assets/makefiles/etcd/etcd-upgrade.service
+++ b/build.assets/makefiles/etcd/etcd-upgrade.service
@@ -34,6 +34,7 @@ ExecStart=/usr/bin/etcd \
         --peer-key-file=/var/state/etcd.key \
         --peer-trusted-ca-file=/var/state/root.cert \
         --peer-client-cert-auth $ETCD_OPTS \
+        --max-request-bytes=10485760 \
         --initial-cluster-state new
 User=planet
 Group=planet

--- a/build.assets/makefiles/etcd/etcd.service
+++ b/build.assets/makefiles/etcd/etcd.service
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/etcd \
         --peer-key-file=/var/state/etcd.key \
         --peer-trusted-ca-file=/var/state/root.cert \
         --peer-client-cert-auth=true \
+        --max-request-bytes=10485760 \
         $ETCD_OPTS
 User=planet
 Group=planet


### PR DESCRIPTION
Backport https://github.com/gravitational/planet/pull/423 to 5.5 to increase max etcd request size to 10MB. By default it's 1.5MB and it can't handle our large changesets generated during upgrades.