### PR TITLE
[5.5.x] Re-enable nethealth check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:24aba03ef5b69226880b5ed7cef1e660607d498b8c143ebdfc07f30d7e6560af"
+  digest = "1:96ca5428bf35f04dd28e72ccdfb6bce406ad88298246ba1548d9db8f4927be08"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -385,8 +385,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "921ea7b2da1e5152895d7da0799a0f8cf36816ad"
-  version = "5.5.13"
+  revision = "649873d24de588dba4ea0098b66fc8f6b5d94c24"
+  version = "5.5.14"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.13"
+  version = "=5.5.14"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -266,7 +266,13 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 		node.AddChecker(monitoring.NewAWSHasProfileChecker())
 	}
 
-	// TODO: reenable nethealth checker once issues are fixed
+	nethealthChecker, err := monitoring.NewNethealthChecker(
+		monitoring.NethealthConfig{
+			NodeName:   config.NodeName,
+			KubeConfig: &kubeConfig,
+		},
+	)
+	node.AddChecker(nethealthChecker)
 
 	return nil
 }
@@ -313,7 +319,13 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 		node.AddChecker(monitoring.NewAWSHasProfileChecker())
 	}
 
-	// TODO: reenable nethealth checker once issues are fixed
+	nethealthChecker, err := monitoring.NewNethealthChecker(
+		monitoring.NethealthConfig{
+			NodeName:   config.NodeName,
+			KubeConfig: &nodeConfig,
+		},
+	)
+	node.AddChecker(nethealthChecker)
 
 	return nil
 }

--- a/vendor/github.com/gravitational/satellite/agent/health/health.go
+++ b/vendor/github.com/gravitational/satellite/agent/health/health.go
@@ -99,7 +99,7 @@ func (r Probes) GetFailed() []*pb.Probe {
 func (r Probes) Status() pb.NodeStatus_Type {
 	result := pb.NodeStatus_Running
 	for _, probe := range r {
-		if probe.Status == pb.Probe_Failed {
+		if probe.Status == pb.Probe_Failed && probe.Severity != pb.Probe_Warning {
 			result = pb.NodeStatus_Degraded
 			break
 		}

--- a/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
@@ -223,8 +223,7 @@ func (c *timeDriftChecker) successProbe() *pb.Probe {
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
 			c.SerfMember.Addr, timeDriftThreshold),
-		Status:   pb.Probe_Running,
-		Severity: pb.Probe_None,
+		Status: pb.Probe_Running,
 	}
 }
 
@@ -235,8 +234,7 @@ func (c *timeDriftChecker) failureProbe(node serf.Member, drift time.Duration) *
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and %s is higher than the allowed threshold of %s: %s",
 			c.SerfMember.Addr, node.Addr, timeDriftThreshold, drift),
-		Status:   pb.Probe_Failed,
-		Severity: pb.Probe_Warning,
+		Status: pb.Probe_Failed,
 	}
 }
 


### PR DESCRIPTION
### Description
This PR re-enables the nethealth check. 
Satellite **5.5.14** patch updates the nethealth check so that incoming data is filtered for nodes that are no longer members of the cluster. The nethealth check now also only reports a warning and will not degrade cluster status.

### Linked tickets and other PRs
* Ref https://github.com/gravitational/satellite/pull/200.