### PR TITLE
[6.1.x] Re-enable nethealth check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,7 +364,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:164c7bd87f7353e872b3fc40728c80b553099f9ce8ae8058c56ee7ca71777f6d"
+  digest = "1:339cc440cc6a232a5e10dd89ea667217fef0028c5ecb522f0d15877309e8b3d9"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -384,8 +384,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "3af6e21e95042446bc3d00fa3e7027944e26afc1"
-  version = "6.1.7"
+  revision = "77ab3d8928cea7e3cae346b80327dcae58a9ebaf"
+  version = "6.1.8"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"
@@ -513,7 +513,6 @@
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:35f49695a600c368ad7811a672d583b3e004b44fe883a0a1eb2a6c0d75eaeb1b"
   name = "github.com/jonboulle/clockwork"
   packages = ["."]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.7"
+  version = "=6.1.8"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -238,7 +238,13 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 		node.AddChecker(monitoring.NewAWSHasProfileChecker())
 	}
 
-	// TODO: reenable nethealth checker once issues are fixed
+	nethealthChecker, err := monitoring.NewNethealthChecker(
+		monitoring.NethealthConfig{
+			NodeName:   config.NodeName,
+			KubeConfig: &kubeConfig,
+		},
+	)
+	node.AddChecker(nethealthChecker)
 
 	return nil
 }
@@ -287,7 +293,13 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 		node.AddChecker(monitoring.NewAWSHasProfileChecker())
 	}
 
-	// TODO: reenable nethealth checker once issues are fixed
+	nethealthChecker, err := monitoring.NewNethealthChecker(
+		monitoring.NethealthConfig{
+			NodeName:   config.NodeName,
+			KubeConfig: &nodeConfig,
+		},
+	)
+	node.AddChecker(nethealthChecker)
 
 	return nil
 }

--- a/vendor/github.com/gravitational/satellite/agent/health/health.go
+++ b/vendor/github.com/gravitational/satellite/agent/health/health.go
@@ -99,7 +99,7 @@ func (r Probes) GetFailed() []*pb.Probe {
 func (r Probes) Status() pb.NodeStatus_Type {
 	result := pb.NodeStatus_Running
 	for _, probe := range r {
-		if probe.Status == pb.Probe_Failed {
+		if probe.Status == pb.Probe_Failed && probe.Severity != pb.Probe_Warning {
 			result = pb.NodeStatus_Degraded
 			break
 		}

--- a/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
@@ -35,14 +35,16 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NethealthConfig specifies configuration for a nethealth checker.
 type NethealthConfig struct {
-	// AdvertiseIP specifies the advertised ip address of the host running this checker.
-	AdvertiseIP string
+	// NodeName specifies the kubernetes name of this node.
+	NodeName string
 	// NethealthPort specifies the port that nethealth is listening on.
 	NethealthPort int
 	// NetStatsInterval specifies the duration to store net stats.
@@ -55,8 +57,8 @@ type NethealthConfig struct {
 // value defaults where necessary.
 func (c *NethealthConfig) CheckAndSetDefaults() error {
 	var errors []error
-	if c.AdvertiseIP == "" {
-		errors = append(errors, trace.BadParameter("host advertise ip must be provided"))
+	if c.NodeName == "" {
+		errors = append(errors, trace.BadParameter("node name must be provided"))
 	}
 	if c.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
@@ -77,7 +79,7 @@ type nethealthChecker struct {
 	NethealthConfig
 	// Mutex locks access to peerStats
 	sync.Mutex
-	// peerStats maps a peer to its recorded nethealth stats.
+	// peerStats maps a peer's node name to its recorded nethealth stats.
 	peerStats *netStats
 }
 
@@ -109,7 +111,13 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 	err := c.check(ctx, reporter)
 	if err != nil {
 		log.WithError(err).Warn("Failed to verify nethealth")
-		reporter.Add(NewProbeFromErr(c.Name(), "failed to verify nethealth", err))
+		reporter.Add(&pb.Probe{
+			Checker:  c.Name(),
+			Detail:   "failed to verify nethealth",
+			Error:    trace.UserMessage(err),
+			Status:   pb.Probe_Failed,
+			Severity: pb.Probe_Warning,
+		})
 		return
 	}
 	if reporter.NumProbes() == 0 {
@@ -140,6 +148,12 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 		return nil
 	}
 
+	netData, err = c.filterNetData(netData)
+	if err != nil {
+		log.WithError(err).Error("Failed to filter nethealth data.")
+		return nil
+	}
+
 	updated, err := c.updateStats(netData)
 	if err != nil {
 		return trace.Wrap(err, "failed to update nethealth stats")
@@ -152,22 +166,27 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) getNethealthAddr() (addr string, err error) {
 	opts := metav1.ListOptions{
 		LabelSelector: nethealthLabelSelector.String(),
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", c.NodeName).String(),
+		Limit:         1,
 	}
 	pods, err := c.Client.CoreV1().Pods(nethealthNamespace).List(opts)
 	if err != nil {
 		return addr, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
 	}
 
-	for _, pod := range pods.Items {
-		if pod.Status.HostIP == c.AdvertiseIP {
-			if pod.Status.PodIP == "" {
-				return addr, trace.NotFound("local nethealth pod IP has not been assigned yet.")
-			}
-			return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, c.NethealthPort), nil
-		}
+	if len(pods.Items) < 1 {
+		return addr, trace.NotFound("nethealth pod not found on local node %s", c.NodeName)
 	}
 
-	return addr, trace.NotFound("unable to find nethealth pod running on host %s", c.AdvertiseIP)
+	pod := pods.Items[0]
+	if pod.Status.Phase != corev1.PodRunning {
+		return addr, trace.NotFound("local nethealth pod %v is not Running: %v", pod.Name, pod.Status.Phase)
+	}
+	if pod.Status.PodIP == "" {
+		return addr, trace.NotFound("local nethealth pod %v has not been assigned an IP", pod.Name)
+	}
+
+	return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, c.NethealthPort), nil
 }
 
 // updateStats updates netStats with new incoming data.
@@ -290,9 +309,10 @@ func (c *nethealthChecker) isHealthy(peer string) (healthy bool, err error) {
 func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 	return &pb.Probe{
 		Checker: name,
-		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %.2f%%: %.2f%%",
-			peer, thresholdPercent, packetLoss*100),
-		Status: pb.Probe_Failed,
+		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %d%%: %d%%",
+			peer, int(thresholdPercent), int(packetLoss*100)),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
 	}
 }
 
@@ -393,6 +413,34 @@ func getPeerName(labels []*dto.LabelPair) (peer string, err error) {
 		}
 	}
 	return "", trace.NotFound("unable to find %s label", peerLabel)
+}
+
+// filterNetData filters the netData. Nethealth may retain metrics for nodes
+// that are no longer part of the cluster. Metrics for these nodes should not
+// be further processed.
+func (c *nethealthChecker) filterNetData(netData map[string]networkData) (filtered map[string]networkData, err error) {
+	nodes, err := c.Client.CoreV1().Nodes().List(metav1.ListOptions{
+		FieldSelector: fields.OneTermNotEqualSelector("metadata.name", c.NodeName).String(),
+	})
+	if err != nil {
+		return filtered, trace.Wrap(err)
+	}
+	return filterByK8s(netData, nodes.Items)
+}
+
+// filterByK8s removes netData for nodes that are no longer members of the
+// kubernetes cluster.
+func filterByK8s(netData map[string]networkData, nodes []corev1.Node) (filtered map[string]networkData, err error) {
+	filtered = make(map[string]networkData)
+	for _, node := range nodes {
+		data, exists := netData[node.Name]
+		if !exists {
+			log.WithField("node", node.Name).Warn("Missing nethealth data for peer.")
+			continue
+		}
+		filtered[node.Name] = data
+	}
+	return filtered, nil
 }
 
 // netStats holds nethealth data for a peer.

--- a/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
@@ -223,8 +223,7 @@ func (c *timeDriftChecker) successProbe() *pb.Probe {
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
 			c.SerfMember.Addr, timeDriftThreshold),
-		Status:   pb.Probe_Running,
-		Severity: pb.Probe_None,
+		Status: pb.Probe_Running,
 	}
 }
 
@@ -235,8 +234,7 @@ func (c *timeDriftChecker) failureProbe(node serf.Member, drift time.Duration) *
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and %s is higher than the allowed threshold of %s: %s",
 			c.SerfMember.Addr, node.Addr, timeDriftThreshold, drift),
-		Status:   pb.Probe_Failed,
-		Severity: pb.Probe_Warning,
+		Status: pb.Probe_Failed,
 	}
 }
 


### PR DESCRIPTION
### Description
This PR re-enables the nethealth check. 
Satellite 6.1.8 patch updates the nethealth check so that incoming data is filtered for nodes that are no longer members of the cluster. The nethealth check now also only reports a warning and will not degrade cluster status.

### Linked tickets and other PRs
* Ref https://github.com/gravitational/satellite/pull/201.