### PR TITLE
Revert "Bump etcd to avoid corruption bugs (#641)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ SERF_VER := v0.8.5
 
 # ETCD Versions to include in the release
 # This list needs to include every version of etcd that we can upgrade from + latest
-ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.20 v3.3.22
+ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.20
 # This is the version of etcd we should upgrade to (from the version list)
-ETCD_LATEST_VER := v3.3.22
+ETCD_LATEST_VER := v3.3.20
 
 BUILDBOX_GO_VER ?= 1.12.9
 PLANET_BUILD_TAG ?= $(shell git describe --tags)


### PR DESCRIPTION
This reverts commit 21f34ef1773cf0f8992f1c66e2b4c3a955788b3b.

etcd 3.3.22 hasn't been released yet so build's failing. Will reopen when it's released/published, as of right now there's no even tag yet created (but changelog is there, which is why we tried to upgrade it in the first place).