### PR TITLE
[5.5.x] Ignore same leader re-elected case (#635)

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -154,6 +154,10 @@ func startLeaderClient(conf *LeaderConfig, agent agent.Agent, errorC chan error)
 		if newVal != conf.PublicIP {
 			return
 		}
+		// Ignore if same leader is re-elected
+		if newVal == prevVal {
+			return
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), recordEventTimeout)
 		defer cancel()


### PR DESCRIPTION
### Description
This PR updates the Planet agent so that new events are not reported when the same leader is re-elected.

### Linked Tickets and PRs
* Ports https://github.com/gravitational/planet/pull/635