### PR TITLE
[5.5.x] Fix health check behavior during cluster modification

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5e339bebf0b5b31b3543a8d01d8a986d451499b85e2ca652564627a93f0d7261"
+  digest = "1:39eead73c0faff19ef0e16b3f193936aff324cf9e603cf229929e578ee571055"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -387,8 +387,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "c015eb9c2471d3ab679a187c9bf561ca155d02b2"
-  version = "5.5.15"
+  revision = "a1d572af2b441e3f2d6da234f3e197c8e23443b3"
+  version = "5.5.16"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.15"
+  version = "=5.5.16"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
@@ -111,14 +111,7 @@ func (c *nethealthChecker) Name() string {
 func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := c.check(ctx, reporter)
 	if err != nil {
-		log.WithError(err).Warn("Failed to verify nethealth")
-		reporter.Add(&pb.Probe{
-			Checker:  c.Name(),
-			Detail:   "failed to verify nethealth",
-			Error:    trace.UserMessage(err),
-			Status:   pb.Probe_Failed,
-			Severity: pb.Probe_Warning,
-		})
+		log.WithError(err).Debug("Failed to verify nethealth.")
 		return
 	}
 	if reporter.NumProbes() == 0 {

--- a/vendor/github.com/gravitational/satellite/monitoring/ping.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/ping.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -135,44 +136,36 @@ func (c *pingChecker) Name() string {
 // desired threshold
 // Implements health.Checker
 func (c *pingChecker) Check(ctx context.Context, r health.Reporter) {
-	probeSeverity, err := c.check(ctx, r)
-
-	if err != nil {
-		c.logger.Error(err.Error())
-		r.Add(NewProbeFromErr(c.Name(), "", err))
+	if err := c.check(ctx, r); err != nil {
+		c.logger.WithError(err).Debug("Failed to verify ping latency.")
 		return
 	}
-	r.Add(&pb.Probe{
-		Checker:  c.Name(),
-		Status:   pb.Probe_Running,
-		Severity: probeSeverity,
-	})
+	if r.NumProbes() == 0 {
+		r.Add(NewSuccessProbe(c.Name()))
+	}
 }
 
 // check runs the actual system status verification code and returns an error
 // in case issues arise in the process
-func (c *pingChecker) check(ctx context.Context, r health.Reporter) (probeSeverity pb.Probe_Severity, err error) {
-
+func (c *pingChecker) check(_ context.Context, r health.Reporter) (err error) {
 	client := c.serfClient
 
 	nodes, err := client.Members()
 	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	probeSeverity, err = c.checkNodesRTT(nodes, client)
-	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+	if err = c.checkNodesRTT(nodes, client, r); err != nil {
+		return trace.Wrap(err)
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // checkNodesRTT implements the bulk of the logic by checking the ping time
 // between this node (self) and the other Serf Cluster member nodes
-func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient) (probeSeverity pb.Probe_Severity, err error) {
-	probeSeverity = pb.Probe_None
-
+func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient,
+	reporter health.Reporter) (err error) {
 	// ping each other node and raise a warning in case the results are over
 	// a specified threshold
 	for _, node := range nodes {
@@ -190,39 +183,39 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		rttNanoSec, err := c.calculateRTT(client, c.self, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencies, err := c.saveLatencyStats(rttNanoSec, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencyHistogram, err := c.buildLatencyHistogram(node.Name, latencies)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
-		c.logger.Debugf("%s <-ping-> %s = %dns [latest]", c.self.Name, node.Name, rttNanoSec)
-		c.logger.Debugf("%s <-ping-> %s = %dns [%.2f percentile]",
+		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
+
+		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
+			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
+		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
 			c.self.Name, node.Name,
-			latencyHistogram.ValueAtQuantile(latencyQuantile),
+			latency95.Milliseconds(),
 			latencyQuantile)
 
-		latencyPercentile := latencyHistogram.ValueAtQuantile(latencyQuantile)
-		if latencyPercentile >= latencyThreshold.Nanoseconds() {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dns over threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
-			probeSeverity = pb.Probe_Warning
+		if latency95 >= latencyThreshold {
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dns within threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
 		}
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // buildLatencyHistogram maps latencies to a HDRHistrogram
@@ -293,4 +286,17 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 		latency,
 		otherNodeCoord.Vec, otherNodeCoord.Error, otherNodeCoord.Height, otherNodeCoord.Adjustment)
 	return latency, nil
+}
+
+// failureProbe constructs a new probe that represents a failed ping check
+// against the specified node.
+func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
+	return &pb.Probe{
+		Checker: c.Name(),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
+			c.self.Name, node, latencyThreshold.Milliseconds()),
+		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
 }


### PR DESCRIPTION
### Description
Satellite 5.5.16 updates the timedrift, nethealth, and ping checks so that they no longer report failed probes if the check does not run to completion.

### Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/214