### PR TITLE
[6.1.x] Fix health check behavior during cluster modification

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,7 +364,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:339cc440cc6a232a5e10dd89ea667217fef0028c5ecb522f0d15877309e8b3d9"
+  digest = "1:2e612f27a79e63d3b5a7d78300143dc45f182ee9614e3865fe40a9b83f34bf40"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -384,8 +384,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "77ab3d8928cea7e3cae346b80327dcae58a9ebaf"
-  version = "6.1.8"
+  revision = "0b663054292a8b395f74082a0608bc3829f22a99"
+  version = "6.1.9"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.8"
+  version = "=6.1.9"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/ping.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/ping.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -135,44 +136,36 @@ func (c *pingChecker) Name() string {
 // desired threshold
 // Implements health.Checker
 func (c *pingChecker) Check(ctx context.Context, r health.Reporter) {
-	probeSeverity, err := c.check(ctx, r)
-
-	if err != nil {
-		c.logger.Error(err.Error())
-		r.Add(NewProbeFromErr(c.Name(), "", err))
+	if err := c.check(ctx, r); err != nil {
+		c.logger.WithError(err).Debug("Failed to verify ping latency.")
 		return
 	}
-	r.Add(&pb.Probe{
-		Checker:  c.Name(),
-		Status:   pb.Probe_Running,
-		Severity: probeSeverity,
-	})
+	if r.NumProbes() == 0 {
+		r.Add(NewSuccessProbe(c.Name()))
+	}
 }
 
 // check runs the actual system status verification code and returns an error
 // in case issues arise in the process
-func (c *pingChecker) check(ctx context.Context, r health.Reporter) (probeSeverity pb.Probe_Severity, err error) {
-
+func (c *pingChecker) check(_ context.Context, r health.Reporter) (err error) {
 	client := c.serfClient
 
 	nodes, err := client.Members()
 	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	probeSeverity, err = c.checkNodesRTT(nodes, client)
-	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+	if err = c.checkNodesRTT(nodes, client, r); err != nil {
+		return trace.Wrap(err)
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // checkNodesRTT implements the bulk of the logic by checking the ping time
 // between this node (self) and the other Serf Cluster member nodes
-func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient) (probeSeverity pb.Probe_Severity, err error) {
-	probeSeverity = pb.Probe_None
-
+func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient,
+	reporter health.Reporter) (err error) {
 	// ping each other node and raise a warning in case the results are over
 	// a specified threshold
 	for _, node := range nodes {
@@ -190,39 +183,39 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		rttNanoSec, err := c.calculateRTT(client, c.self, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencies, err := c.saveLatencyStats(rttNanoSec, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencyHistogram, err := c.buildLatencyHistogram(node.Name, latencies)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
-		c.logger.Debugf("%s <-ping-> %s = %dns [latest]", c.self.Name, node.Name, rttNanoSec)
-		c.logger.Debugf("%s <-ping-> %s = %dns [%.2f percentile]",
+		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
+
+		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
+			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
+		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
 			c.self.Name, node.Name,
-			latencyHistogram.ValueAtQuantile(latencyQuantile),
+			latency95.Milliseconds(),
 			latencyQuantile)
 
-		latencyPercentile := latencyHistogram.ValueAtQuantile(latencyQuantile)
-		if latencyPercentile >= latencyThreshold.Nanoseconds() {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dns over threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
-			probeSeverity = pb.Probe_Warning
+		if latency95 >= latencyThreshold {
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dns within threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
 		}
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // buildLatencyHistogram maps latencies to a HDRHistrogram
@@ -293,4 +286,17 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 		latency,
 		otherNodeCoord.Vec, otherNodeCoord.Error, otherNodeCoord.Height, otherNodeCoord.Adjustment)
 	return latency, nil
+}
+
+// failureProbe constructs a new probe that represents a failed ping check
+// against the specified node.
+func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
+	return &pb.Probe{
+		Checker: c.Name(),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
+			c.self.Name, node, latencyThreshold.Milliseconds()),
+		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
 }


### PR DESCRIPTION
### Description
Satellite 6.1.9 updates the timedrift, nethealth, and ping checks so that they no longer report failed probes if the check does not run to completion.

### Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/215