### PR TITLE
Fix planet version linker update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ build: $(BUILD_ASSETS)/planet $(BUILDDIR)/planet.tar.gz
 
 .PHONY: planet-bin
 planet-bin:
-	GO111MODULE=on go build -mod=vendor -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
+	GO111MODULE=on go build -mod=vendor -o $(OUTPUTDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
 .PHONY: dev-deploy

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -35,4 +35,4 @@ $(ASSETDIR)/docker-import:
 .PHONY: flags
 flags:
 	go install github.com/gravitational/version/cmd/linkflags
-	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/planet/vendor/github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")
+	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")


### PR DESCRIPTION
Do not use absolute path for -X when building in modules mode - otherwise the linker skips over the version.XXX variables.
Update `k8s.io` dependencies to `v0.17.6`.

Updates https://github.com/gravitational/gravity/issues/1640.
Requires https://github.com/gravitational/satellite/pull/223.