### PR TITLE
[5.5.x] Update buildbox go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.20 v3.3.22
 # This is the version of etcd we should upgrade to (from the version list)
 ETCD_LATEST_VER := v3.3.22
 
-BUILDBOX_GO_VER ?= 1.12.9
+BUILDBOX_GO_VER ?= 1.14
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)


### PR DESCRIPTION
### Description
Bump buildbox go version to 1.14. Latest satellite patch uses `time.Duration.Millisecond()` which is undefined in go 1.12.9.