### PR TITLE
[7.0.x] Update buildbox go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ETCD_VER := v3.3.12 v3.3.15 v3.3.20 v3.3.22 v3.4.3 v3.4.7 v3.4.9
 #   - Modify build.go and run the etcd upgrade integration test (go run mage.go ci:testEtcdUpgrade)
 ETCD_LATEST_VER := v3.4.9
 
-BUILDBOX_GO_VER ?= 1.12.9
+BUILDBOX_GO_VER ?= 1.14
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)


### PR DESCRIPTION
### Description
Bump buildbox go version to 1.14. Latest satellite patch uses `time.Duration.Millisecond()` which is undefined in go 1.12.9.