### PR TITLE
Bump satellite to 5.5.17

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:39eead73c0faff19ef0e16b3f193936aff324cf9e603cf229929e578ee571055"
+  digest = "1:fd94cef69d351f4dcb5a0e72c59055560d7e09279cab016836f4a2642e325a6d"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -387,8 +387,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "a1d572af2b441e3f2d6da234f3e197c8e23443b3"
-  version = "5.5.16"
+  revision = "785d3473c054f254da9eeec3fb2d240e929b099a"
+  version = "5.5.17"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.16"
+  version = "=5.5.17"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/ping.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/ping.go
@@ -198,20 +198,16 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
 
-		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
-			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
-		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
-			c.self.Name, node.Name,
-			latency95.Milliseconds(),
-			latencyQuantile)
+		c.logger.Debugf("%s <-ping-> %s = %s [latest]", c.self.Name, node.Name, time.Duration(rttNanoSec))
+		c.logger.Debugf("%s <-ping-> %s = %s [%.2f percentile]", c.self.Name, node.Name, latency95, latencyQuantile)
 
 		if latency95 >= latencyThreshold {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %s over threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %s within threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 		}
 	}
 
@@ -293,9 +289,9 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
-		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
-			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %s",
+			c.self.Name, node, latencyThreshold),
+		Error:    fmt.Sprintf("ping latency at %s", latency),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}


### PR DESCRIPTION
### Description
Bump satellite to 5.5.17. This patches satellite to remove use of `Duration.Milliseconds()` which requires golang >= 1.13.

### Linked tickets and PRs
- Requires https://github.com/gravitational/satellite/pull/219