### PR TITLE
Bump satellite to 6.1.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,7 +364,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2e612f27a79e63d3b5a7d78300143dc45f182ee9614e3865fe40a9b83f34bf40"
+  digest = "1:6c23d9679e4ebe082cad54b926b6d8b8a67c4818ca5b4f735856add17e9b52ba"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -384,8 +384,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "0b663054292a8b395f74082a0608bc3829f22a99"
-  version = "6.1.9"
+  revision = "17e9515705bceb5f0fed9e63770f3c9d447e7975"
+  version = "6.1.10"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.9"
+  version = "=6.1.10"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/ping.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/ping.go
@@ -198,20 +198,16 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
 
-		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
-			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
-		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
-			c.self.Name, node.Name,
-			latency95.Milliseconds(),
-			latencyQuantile)
+		c.logger.Debugf("%s <-ping-> %s = %s [latest]", c.self.Name, node.Name, time.Duration(rttNanoSec))
+		c.logger.Debugf("%s <-ping-> %s = %s [%.2f percentile]", c.self.Name, node.Name, latency95, latencyQuantile)
 
 		if latency95 >= latencyThreshold {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %s over threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %s within threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 		}
 	}
 
@@ -293,9 +289,9 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
-		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
-			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %s",
+			c.self.Name, node, latencyThreshold),
+		Error:    fmt.Sprintf("ping latency at %s", latency),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}


### PR DESCRIPTION
### Description
Bump satellite to 6.1.10. This patches satellite to remove use of `Duration.Milliseconds()` which requires golang >= 1.13.

### Linked tickets and PRs
- Requires https://github.com/gravitational/satellite/pull/220