### PR TITLE
Bump satellite to 7.1.12

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -422,7 +422,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:d83a2a6fd92b3375c00d0644ba9187ce6b70569a21ed520c6d7770f45fa7ce4f"
+  digest = "1:dadcc963a4351005362d321709467b5afe37ac6eea365e882a463242a9e846ba"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -442,8 +442,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "5519305175a0f97a905bd672b5d9d7c3c10a811d"
-  version = "7.0.11"
+  revision = "c1a5e7b09c45fde4d70068f3441ab8c5870917d6"
+  version = "7.0.12"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.11"
+  version = "=7.0.12"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/ping.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/ping.go
@@ -195,20 +195,16 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
 
-		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
-			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
-		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
-			c.self.Name, node.Name,
-			latency95.Milliseconds(),
-			latencyQuantile)
+		c.logger.Debugf("%s <-ping-> %s = %s [latest]", c.self.Name, node.Name, time.Duration(rttNanoSec))
+		c.logger.Debugf("%s <-ping-> %s = %s [%.2f percentile]", c.self.Name, node.Name, latency95, latencyQuantile)
 
 		if latency95 >= latencyThreshold {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %s over threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %s within threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 		}
 	}
 
@@ -290,9 +286,9 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
-		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
-			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %s",
+			c.self.Name, node, latencyThreshold),
+		Error:    fmt.Sprintf("ping latency at %s", latency),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}


### PR DESCRIPTION
### Description
Bump satellite to 7.1.12. This patches satellite to remove use of `Duration.Milliseconds()` which requires golang >= 1.13.

### Linked tickets and PRs
- Requires gravitational/satellite#221