### PR TITLE
[6.1.x] Handle error if nethealth checker failed to initialize

### DIFF
--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -244,6 +244,9 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 			KubeConfig: &kubeConfig,
 		},
 	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	node.AddChecker(nethealthChecker)
 
 	return nil
@@ -299,6 +302,9 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 			KubeConfig: &nodeConfig,
 		},
 	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	node.AddChecker(nethealthChecker)
 
 	return nil


### PR DESCRIPTION
### Description
Missing error handling after nethealth checker initialization. This can lead to nil pointer dereference panic if nethealth checker failed to initialize.