### PR TITLE
[7.0.x] update go-udev dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,12 +406,12 @@
   version = "0.0.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:170cc0c8108af9dd49569867e2d41097f9578ac65e7d02be098e301893d9b9ef"
+  branch = "dmitri/sync-upstream"
+  digest = "1:490c06877cc9794d9c58a18b354711e7aca760e14e83baf1b1d0ef8c7b7c0ae5"
   name = "github.com/gravitational/go-udev"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4cc8baba3689adc2d4ec4cf0e8e6be7bb136a3d2"
+  revision = "c0acc0f3a3526eef30dd091d9b19313c9d61650d"
 
 [[projects]]
   digest = "1:e025b0f4997273273c5dc46a17caddb27ab7dc8b8aa9ffb50d326e7aeb4059c7"
@@ -1056,6 +1056,14 @@
   revision = "9dcd33a902f40452422c2367fefcb95b54f9f8f8"
 
 [[projects]]
+  branch = "master"
+  digest = "1:b521f10a2d8fa85c04a8ef4e62f2d1e14d303599a55d64dabf9f5a02f84d35eb"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  pruneopts = "UT"
+  revision = "43a5402ce75a95522677f77c619865d66b8c57ab"
+
+[[projects]]
   digest = "1:689d11c3e6d3df8a1e2d2ad5a494ea99659d09faf706472bdd64cac7ac5f6887"
   name = "golang.org/x/sys"
   packages = [
@@ -1480,6 +1488,7 @@
     "github.com/syndtr/gocapability/capability",
     "go.etcd.io/etcd/client",
     "go.etcd.io/etcd/clientv3",
+    "golang.org/x/sync/errgroup",
     "golang.org/x/sys/unix",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/check.v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,7 +89,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
   name = "github.com/gravitational/etcd-backup"
 
 [[constraint]]
-  branch = "master"
+  branch = "dmitri/sync-upstream"
   name = "github.com/gravitational/go-udev"
 
 [[constraint]]
@@ -175,3 +175,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 [[override]]
   name = "google.golang.org/grpc"
   version = "=v1.26.0"
+
+[[constraint]]
+  name = "golang.org/x/sync"
+  branch = "master"

--- a/lib/ctxgroup/ctxgroup.go
+++ b/lib/ctxgroup/ctxgroup.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 Gravitational, Inc.
+Copyright 2018 The Cockroach Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package ctxgroup wraps golang.org/x/sync/errgroup with a context func.
+This package extends and modifies the errgroup API slightly to
+make context variables more explicit. WithContext no longer returns
+a context. Instead, the GoCtx method explicitly passes one to the
+invoked func. The goal is to make misuse of context vars with errgroups
+more difficult. Example usage:
+
+	ctx := context.Background()
+	g := ctxgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.GoCtx(func(ctx context.Context) error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.GoCtx(func(ctx context.Context) error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+Problems with errgroup
+The bugs this package attempts to prevent are: misuse of shadowed
+ctx variables after errgroup closure and confusion in the face of
+multiple ctx variables when trying to prevent shadowing. The following
+are all example bugs that Cockroach has had during its use of errgroup:
+
+	ctx := context.Background()
+	g, ctx := errgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.Go(func() error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+The ctx used by the final api.Call is already closed because the
+errgroup has returned. This happened because of the desire to not
+create another ctx variable, and so we shadowed the original ctx var,
+but then incorrectly continued to use it after the errgroup had closed
+its context. So we make a modification and create new gCtx variable
+that doesn't shadow the original ctx:
+
+	ctx := context.Background()
+	g, gCtx := errgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.Go(func() error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+Now the final api.Call is correct. But the other api.Call is incorrect
+and the ctx.Done receive is incorrect because they are using the wrong
+context and thus won't correctly exit early if the errgroup needs to
+exit early.
+*/
+
+// This is a simplified version of the ctxgroup package from https://github.com/cockroachdb/cockroach/blob/v20.1.0/pkg/util/ctxgroup/ctxgroup.go
+package ctxgroup
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Group wraps errgroup.
+type Group struct {
+	wrapped *errgroup.Group
+	ctx     context.Context
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them. If Wait() is invoked
+// after the context (originally supplied to WithContext) is canceled, Wait
+// returns an error, even if no Go invocation did. In particular, calling
+// Wait() after Done has been closed is guaranteed to return an error.
+func (g Group) Wait() error {
+	ctxErr := g.ctx.Err()
+	err := g.wrapped.Wait()
+	if err != nil {
+		return err
+	}
+	return ctxErr
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+func WithContext(ctx context.Context) Group {
+	grp, ctx := errgroup.WithContext(ctx)
+	return Group{
+		wrapped: grp,
+		ctx:     ctx,
+	}
+}
+
+// Go calls the given function in a new goroutine.
+func (g Group) Go(f func() error) {
+	g.wrapped.Go(f)
+}
+
+// GoCtx calls the given function in a new goroutine.
+func (g Group) GoCtx(f func(ctx context.Context) error) {
+	g.wrapped.Go(func() error {
+		return f(g.ctx)
+	})
+}

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -287,6 +287,12 @@ func start(config *Config) (*runtimeContext, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	defer func() {
+		if err != nil {
+			listener.Close()
+		}
+	}()
+	listener.Start()
 
 	// start the container:
 	box, err := box.Start(cfg)

--- a/vendor/github.com/gravitational/go-udev/device.go
+++ b/vendor/github.com/gravitational/go-udev/device.go
@@ -81,6 +81,13 @@ func (d *Device) Devtype() string {
 	return C.GoString(C.udev_device_get_devtype(d.ptr))
 }
 
+// Sysname returns the sysname of the udev device (e.g. ttyS3, sda1...).
+func (d *Device) Sysname() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_sysname(d.ptr))
+}
+
 // Syspath returns the sys path of the udev device.
 // The path is an absolute path and starts with the sys mount point.
 func (d *Device) Syspath() string {

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
* Update go-udev package to latest upstream master to attempt and fix device propagation.
* Log more information in udev loop.

Requires https://github.com/gravitational/go-udev/pull/1.