### PR TITLE
Use cached etcd artifacts for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,11 @@ buildbox: base
 .PHONY: clean
 clean:
 	$(MAKE) -C $(ASSETS)/makefiles -f buildbox.mk clean
+	rm -rf $(BUILDDIR)
+
+.PHONY: dev-clean
+dev-clean:
+	$(MAKE) -C $(ASSETS)/makefiles -f buildbox.mk clean
 	rm -rf $(BUILDDIR)/planet
 
 # internal use:

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ build: $(BUILD_ASSETS)/planet $(BUILDDIR)/planet.tar.gz
 
 .PHONY: planet-bin
 planet-bin:
-	GO111MODULE=on go build -mod=vendor -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
+	GO111MODULE=on go build -mod=vendor -o $(OUTPUTDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
 .PHONY: dev-deploy

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -8,6 +8,13 @@ TARBALL ?= $(BUILDDIR)/planet.tar.gz
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 BUILDBOX_NAME ?= planet/buildbox
 BUILDBOX_IMAGE ?= $(BUILDBOX_NAME):$(PLANET_BUILD_TAG)
+
+GOCACHE_DOCKER_OPTIONS ?=
+GOCACHE ?= $(HOME)/.cache/go-build
+ifdef GOCACHE_ENABLED
+GOCACHE_DOCKER_OPTIONS = --volume $(GOCACHE):$(GOCACHE) --env "GOCACHE=$(GOCACHE)"
+endif
+
 export
 TMPFS_SIZE ?= 900m
 VER_UPDATES = ETCD_LATEST_VER KUBE_VER FLANNEL_VER DOCKER_VER HELM_VER COREDNS_VER NODE_PROBLEM_DETECTOR_VER
@@ -19,7 +26,7 @@ $(ASSETDIR):
 	@mkdir -p $(ASSETDIR)
 
 .PHONY: build
-build: | $(ASSETDIR)
+build: | $(ASSETDIR) $(GOCACHE)
 	@echo -e "\n---> Launching 'buildbox' Docker container to build planet:\n"
 	docker run -i -u $$(id -u) --rm=true \
 		--volume=$(ASSETS):/assets \
@@ -31,6 +38,7 @@ build: | $(ASSETDIR)
 		--env="ROOTFS=/rootfs" \
 		--env="TARGETDIR=/targetdir" \
 		--env="ASSETDIR=/assetdir" \
+		$(GOCACHE_DOCKER_OPTIONS) \
 		$(BUILDBOX_IMAGE) \
 		dumb-init make -e \
 			KUBE_VER=$(KUBE_VER) \
@@ -47,6 +55,9 @@ build: | $(ASSETDIR)
 			PLANET_GID=$(PLANET_GID) \
 			-C /assets/makefiles -f planet.mk
 	$(MAKE) -C $(ASSETS)/makefiles/master/k8s-master -e -f containers.mk
+
+$(GOCACHE):
+	mkdir -p $@
 
 .PHONY: planet-image
 planet-image:

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -10,7 +10,7 @@ BUILDBOX_NAME ?= planet/buildbox
 BUILDBOX_IMAGE ?= $(BUILDBOX_NAME):$(PLANET_BUILD_TAG)
 
 GOCACHE_DOCKER_OPTIONS ?=
-GOCACHE ?= $(HOME)/.cache/go-build
+GOCACHE ?= $(shell go env GOCACHE 2>/dev/null || echo $${HOME}/.cache/go-build)
 ifdef GOCACHE_ENABLED
 GOCACHE_DOCKER_OPTIONS = --volume $(GOCACHE):$(GOCACHE) --env "GOCACHE=$(GOCACHE)"
 endif

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -35,4 +35,4 @@ $(ASSETDIR)/docker-import:
 .PHONY: flags
 flags:
 	go install github.com/gravitational/version/cmd/linkflags
-	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/planet/vendor/github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")
+	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")


### PR DESCRIPTION
I'm frequently running into performance issues with (re-)building the planet package. This change cuts the time almost in half (in good case - with docker cache and no system package updates).

 * Enable optional caching for go build (off by default), can be enabled with `GOCACHE_ENABLED=yes make ...`
 * Use cached artifacts when building etcd targets

## Testing
```
$ make clean production

# This branch
real	3m20,738s
user	1m15,559s
sys	0m7,153s

# subsequent run
real	2m19,836s
user	1m12,291s
sys	0m4,958s

# master (671409bfdc4852ded8bb04f2669d4636a91269a6)
real	4m11,317s
user	1m15,975s
sys	0m4,885s

# subsequent run
real	3m57,880s
user	1m13,773s
sys	0m4,900s
```