### PR TITLE
[5.5.x] Update disk check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,7 +366,7 @@
 
 [[projects]]
   branch = "bernard/5.5.x/disk-check"
-  digest = "1:30dc57208109e0ab1107fcaa504ff3d453139662f3720dfba975c18142015c3b"
+  digest = "1:a3f07f90b6f18bedef3a5b61241cd164243adafa8e81a8bb323a841925a10f27"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -388,7 +388,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "e20b3e1d3f3811ee5a8ab1ec32678300e0110c04"
+  revision = "fbce70c96afd1d155e99dac272821be14fca0f06"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,7 +366,7 @@
 
 [[projects]]
   branch = "bernard/5.5.x/disk-check"
-  digest = "1:a3f07f90b6f18bedef3a5b61241cd164243adafa8e81a8bb323a841925a10f27"
+  digest = "1:728a93a26354757e33dbc25b3bac2ca5f6d1a8733452c806d256eafbae07c0a0"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -388,7 +388,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "fbce70c96afd1d155e99dac272821be14fca0f06"
+  revision = "c1ded94b8ebd5ef053e82c2473e61d112b6ddddb"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -256,7 +256,7 @@
   version = "v4.1.0"
 
 [[projects]]
-  digest = "1:33f49b72fdad072a03d13b31a42edfff08088b7c27198f4073b8213a58884f27"
+  digest = "1:43ba1b70c14af39f51fb3553b40c528214d7a9ddf1dd384d8748d1010ecb9d6b"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -265,8 +265,8 @@
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
-  version = "v1.2.1"
+  revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
@@ -365,7 +365,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:fd94cef69d351f4dcb5a0e72c59055560d7e09279cab016836f4a2642e325a6d"
+  branch = "bernard/5.5.x/disk-check"
+  digest = "1:30dc57208109e0ab1107fcaa504ff3d453139662f3720dfba975c18142015c3b"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -387,8 +388,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "785d3473c054f254da9eeec3fb2d240e929b099a"
-  version = "5.5.17"
+  revision = "e20b3e1d3f3811ee5a8ab1ec32678300e0110c04"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/5.5.x/disk-check"
   digest = "1:728a93a26354757e33dbc25b3bac2ca5f6d1a8733452c806d256eafbae07c0a0"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -388,7 +387,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "c1ded94b8ebd5ef053e82c2473e61d112b6ddddb"
+  revision = "d8d2853ec49f580e14fa5fe62f98cddf49709875"
+  version = "5.5.18"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,8 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=5.5.17"
-  branch = "bernard/5.5.x/disk-check"
+  version = "=5.5.18"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,8 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.17"
+  # version = "=5.5.17"
+  branch = "bernard/5.5.x/disk-check"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -70,7 +70,7 @@ type Config struct {
 	NodeName string
 	// LowWatermark is the disk usage warning limit percentage of monitored directories
 	LowWatermark uint
-	// HighWatermark is the disk usage critical limit percentage of monitored directores
+	// HighWatermark is the disk usage critical limit percentage of monitored directories
 	HighWatermark uint
 	// HTTPTimeout specifies the HTTP timeout for checks
 	HTTPTimeout time.Duration

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -68,10 +68,10 @@ type Config struct {
 	CloudProvider string
 	// NodeName is the kubernetes name of this node
 	NodeName string
-	// WatermarkWarning is the usage limit percentage of monitored directories
-	WatermarkWarning uint
-	// WatermarkCritical is the usage limit percentage of monitored directories
-	WatermarkCritical uint
+	// LowWatermark is the disk usage warning limit percentage of monitored directories
+	LowWatermark uint
+	// HighWatermark is the disk usage critical limit percentage of monitored directores
+	HighWatermark uint
 	// HTTPTimeout specifies the HTTP timeout for checks
 	HTTPTimeout time.Duration
 }
@@ -217,9 +217,9 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 
 	storageChecker, err := monitoring.NewStorageChecker(
 		monitoring.StorageConfig{
-			Path:              constants.GravityDataDir,
-			WatermarkCritical: config.WatermarkCritical,
-			WatermarkWarning:  config.WatermarkWarning,
+			Path:          constants.GravityDataDir,
+			LowWatermark:  config.LowWatermark,
+			HighWatermark: config.HighWatermark,
 		},
 	)
 	if err != nil {
@@ -311,9 +311,9 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 
 	storageChecker, err := monitoring.NewStorageChecker(
 		monitoring.StorageConfig{
-			Path:              constants.GravityDataDir,
-			WatermarkCritical: config.WatermarkCritical,
-			WatermarkWarning:  config.WatermarkWarning,
+			Path:          constants.GravityDataDir,
+			LowWatermark:  config.LowWatermark,
+			HighWatermark: config.HighWatermark,
 		},
 	)
 	if err != nil {

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -439,9 +439,6 @@ const (
 
 	// EtcdUpgradeTimeout is the amount of time to wait for operations during the etcd upgrade
 	EtcdUpgradeTimeout = 15 * time.Minute
-
-	// HighWatermark is the disk usage percentage that is considered degrading
-	HighWatermark = 80
 )
 
 // K8sSearchDomains are default k8s search domain settings

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -167,8 +167,8 @@ func run() error {
 		cagentDNSUpstreamNameservers = List(cagent.Flag("nameservers", "List of additional upstream nameservers to add to DNS configuration as a comma-separated list of IPs").OverrideDefaultFromEnvar(EnvDNSUpstreamNameservers))
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
-		cagentWatermarkWarning       = cagent.Flag("warning-watermark", "Usage percentage of monitored directories which will trigger a warning probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_WARNING").Uint64()
-		cagentWatermarkCritical      = cagent.Flag("critical-watermark", "Usage percentage of monitored directories which will trigger a critical probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_CRITICAL").Uint64()
+		cagentLowWatermark           = cagent.Flag("low-watermark", "Low disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_LOW_WATERMARK").Uint64()
+		cagentHighWatermark          = cagent.Flag("high-watermark", "High disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_HIGH_WATERMARK").Uint64()
 		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
@@ -353,8 +353,8 @@ func run() error {
 			ETCDConfig:            etcdConf,
 			DisableInterPodCheck:  disableInterPodCheck,
 			CloudProvider:         *cagentCloudProvider,
-			WatermarkCritical:     uint(*cagentWatermarkCritical),
-			WatermarkWarning:      uint(*cagentWatermarkWarning),
+			LowWatermark:          uint(*cagentLowWatermark),
+			HighWatermark:         uint(*cagentHighWatermark),
 			NodeName:              *cagentNodeName,
 			HTTPTimeout:           *cagentHTTPTimeout,
 		}

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -167,7 +167,9 @@ func run() error {
 		cagentDNSUpstreamNameservers = List(cagent.Flag("nameservers", "List of additional upstream nameservers to add to DNS configuration as a comma-separated list of IPs").OverrideDefaultFromEnvar(EnvDNSUpstreamNameservers))
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
-		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of monitored directories and devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
+		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
+		cagentWatermarkWarning       = cagent.Flag("warning-watermark", "Usage percentage of monitored directories which will trigger a warning probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_WARNING").Uint64()
+		cagentWatermarkCritical      = cagent.Flag("critical-watermark", "Usage percentage of monitored directories which will trigger a critical probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_CRITICAL").Uint64()
 		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
@@ -353,6 +355,8 @@ func run() error {
 			DisableInterPodCheck:  disableInterPodCheck,
 			CloudProvider:         *cagentCloudProvider,
 			HighWatermark:         uint(*cagentHighWatermark),
+			WatermarkCritical:     uint(*cagentWatermarkCritical),
+			WatermarkWarning:      uint(*cagentWatermarkWarning),
 			NodeName:              *cagentNodeName,
 			HTTPTimeout:           *cagentHTTPTimeout,
 		}

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -167,7 +167,6 @@ func run() error {
 		cagentDNSUpstreamNameservers = List(cagent.Flag("nameservers", "List of additional upstream nameservers to add to DNS configuration as a comma-separated list of IPs").OverrideDefaultFromEnvar(EnvDNSUpstreamNameservers))
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
-		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
 		cagentWatermarkWarning       = cagent.Flag("warning-watermark", "Usage percentage of monitored directories which will trigger a warning probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_WARNING").Uint64()
 		cagentWatermarkCritical      = cagent.Flag("critical-watermark", "Usage percentage of monitored directories which will trigger a critical probe").OverrideDefaultFromEnvar("PLANET_WATERMARK_CRITICAL").Uint64()
 		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
@@ -354,7 +353,6 @@ func run() error {
 			ETCDConfig:            etcdConf,
 			DisableInterPodCheck:  disableInterPodCheck,
 			CloudProvider:         *cagentCloudProvider,
-			HighWatermark:         uint(*cagentHighWatermark),
 			WatermarkCritical:     uint(*cagentWatermarkCritical),
 			WatermarkWarning:      uint(*cagentWatermarkWarning),
 			NodeName:              *cagentNodeName,

--- a/vendor/github.com/gogo/protobuf/gogoproto/gogo.pb.go
+++ b/vendor/github.com/gogo/protobuf/gogoproto/gogo.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 var E_GoprotoEnumPrefix = &proto.ExtensionDesc{
 	ExtendedType:  (*descriptor.EnumOptions)(nil),

--- a/vendor/github.com/gogo/protobuf/proto/extensions.go
+++ b/vendor/github.com/gogo/protobuf/proto/extensions.go
@@ -527,6 +527,7 @@ func ExtensionDescs(pb Message) ([]*ExtensionDesc, error) {
 // SetExtension sets the specified extension of pb to the specified value.
 func SetExtension(pb Message, extension *ExtensionDesc, value interface{}) error {
 	if epb, ok := pb.(extensionsBytes); ok {
+		ClearExtension(pb, extension)
 		newb, err := encodeExtension(extension, value)
 		if err != nil {
 			return err

--- a/vendor/github.com/gogo/protobuf/proto/extensions_gogo.go
+++ b/vendor/github.com/gogo/protobuf/proto/extensions_gogo.go
@@ -154,6 +154,10 @@ func EncodeInternalExtension(m extendableProto, data []byte) (n int, err error) 
 	return EncodeExtensionMap(m.extensionsWrite(), data)
 }
 
+func EncodeInternalExtensionBackwards(m extendableProto, data []byte) (n int, err error) {
+	return EncodeExtensionMapBackwards(m.extensionsWrite(), data)
+}
+
 func EncodeExtensionMap(m map[int32]Extension, data []byte) (n int, err error) {
 	o := 0
 	for _, e := range m {
@@ -164,6 +168,23 @@ func EncodeExtensionMap(m map[int32]Extension, data []byte) (n int, err error) {
 		if n != len(e.enc) {
 			return 0, io.ErrShortBuffer
 		}
+		o += n
+	}
+	return o, nil
+}
+
+func EncodeExtensionMapBackwards(m map[int32]Extension, data []byte) (n int, err error) {
+	o := 0
+	end := len(data)
+	for _, e := range m {
+		if err := e.Encode(); err != nil {
+			return 0, err
+		}
+		n := copy(data[end-len(e.enc):], e.enc)
+		if n != len(e.enc) {
+			return 0, io.ErrShortBuffer
+		}
+		end -= n
 		o += n
 	}
 	return o, nil

--- a/vendor/github.com/gogo/protobuf/proto/lib.go
+++ b/vendor/github.com/gogo/protobuf/proto/lib.go
@@ -948,13 +948,19 @@ func isProto3Zero(v reflect.Value) bool {
 	return false
 }
 
-// ProtoPackageIsVersion2 is referenced from generated protocol buffer files
-// to assert that that code is compatible with this version of the proto package.
-const GoGoProtoPackageIsVersion2 = true
+const (
+	// ProtoPackageIsVersion3 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	GoGoProtoPackageIsVersion3 = true
 
-// ProtoPackageIsVersion1 is referenced from generated protocol buffer files
-// to assert that that code is compatible with this version of the proto package.
-const GoGoProtoPackageIsVersion1 = true
+	// ProtoPackageIsVersion2 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	GoGoProtoPackageIsVersion2 = true
+
+	// ProtoPackageIsVersion1 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	GoGoProtoPackageIsVersion1 = true
+)
 
 // InternalMessageInfo is a type used internally by generated .pb.go files.
 // This type is not intended to be used by non-generated code.

--- a/vendor/github.com/gogo/protobuf/proto/properties.go
+++ b/vendor/github.com/gogo/protobuf/proto/properties.go
@@ -400,6 +400,15 @@ func GetProperties(t reflect.Type) *StructProperties {
 	return sprop
 }
 
+type (
+	oneofFuncsIface interface {
+		XXX_OneofFuncs() (func(Message, *Buffer) error, func(Message, int, int, *Buffer) (bool, error), func(Message) int, []interface{})
+	}
+	oneofWrappersIface interface {
+		XXX_OneofWrappers() []interface{}
+	}
+)
+
 // getPropertiesLocked requires that propertiesMu is held.
 func getPropertiesLocked(t reflect.Type) *StructProperties {
 	if prop, ok := propertiesMap[t]; ok {
@@ -441,37 +450,40 @@ func getPropertiesLocked(t reflect.Type) *StructProperties {
 	// Re-order prop.order.
 	sort.Sort(prop)
 
-	type oneofMessage interface {
-		XXX_OneofFuncs() (func(Message, *Buffer) error, func(Message, int, int, *Buffer) (bool, error), func(Message) int, []interface{})
-	}
-	if om, ok := reflect.Zero(reflect.PtrTo(t)).Interface().(oneofMessage); isOneofMessage && ok {
+	if isOneofMessage {
 		var oots []interface{}
-		_, _, _, oots = om.XXX_OneofFuncs()
-
-		// Interpret oneof metadata.
-		prop.OneofTypes = make(map[string]*OneofProperties)
-		for _, oot := range oots {
-			oop := &OneofProperties{
-				Type: reflect.ValueOf(oot).Type(), // *T
-				Prop: new(Properties),
-			}
-			sft := oop.Type.Elem().Field(0)
-			oop.Prop.Name = sft.Name
-			oop.Prop.Parse(sft.Tag.Get("protobuf"))
-			// There will be exactly one interface field that
-			// this new value is assignable to.
-			for i := 0; i < t.NumField(); i++ {
-				f := t.Field(i)
-				if f.Type.Kind() != reflect.Interface {
-					continue
+		switch m := reflect.Zero(reflect.PtrTo(t)).Interface().(type) {
+		case oneofFuncsIface:
+			_, _, _, oots = m.XXX_OneofFuncs()
+		case oneofWrappersIface:
+			oots = m.XXX_OneofWrappers()
+		}
+		if len(oots) > 0 {
+			// Interpret oneof metadata.
+			prop.OneofTypes = make(map[string]*OneofProperties)
+			for _, oot := range oots {
+				oop := &OneofProperties{
+					Type: reflect.ValueOf(oot).Type(), // *T
+					Prop: new(Properties),
 				}
-				if !oop.Type.AssignableTo(f.Type) {
-					continue
+				sft := oop.Type.Elem().Field(0)
+				oop.Prop.Name = sft.Name
+				oop.Prop.Parse(sft.Tag.Get("protobuf"))
+				// There will be exactly one interface field that
+				// this new value is assignable to.
+				for i := 0; i < t.NumField(); i++ {
+					f := t.Field(i)
+					if f.Type.Kind() != reflect.Interface {
+						continue
+					}
+					if !oop.Type.AssignableTo(f.Type) {
+						continue
+					}
+					oop.Field = i
+					break
 				}
-				oop.Field = i
-				break
+				prop.OneofTypes[oop.Prop.OrigName] = oop
 			}
-			prop.OneofTypes[oop.Prop.OrigName] = oop
 		}
 	}
 

--- a/vendor/github.com/gogo/protobuf/proto/table_marshal.go
+++ b/vendor/github.com/gogo/protobuf/proto/table_marshal.go
@@ -389,8 +389,13 @@ func (u *marshalInfo) computeMarshalInfo() {
 	// get oneof implementers
 	var oneofImplementers []interface{}
 	// gogo: isOneofMessage is needed for embedded oneof messages, without a marshaler and unmarshaler
-	if m, ok := reflect.Zero(reflect.PtrTo(t)).Interface().(oneofMessage); ok && isOneofMessage {
-		_, _, _, oneofImplementers = m.XXX_OneofFuncs()
+	if isOneofMessage {
+		switch m := reflect.Zero(reflect.PtrTo(t)).Interface().(type) {
+		case oneofFuncsIface:
+			_, _, _, oneofImplementers = m.XXX_OneofFuncs()
+		case oneofWrappersIface:
+			oneofImplementers = m.XXX_OneofWrappers()
+		}
 	}
 
 	// normal fields
@@ -517,10 +522,6 @@ func (fi *marshalFieldInfo) computeOneofFieldInfo(f *reflect.StructField, oneofI
 			marshaler: marshalr,
 		}
 	}
-}
-
-type oneofMessage interface {
-	XXX_OneofFuncs() (func(Message, *Buffer) error, func(Message, int, int, *Buffer) (bool, error), func(Message) int, []interface{})
 }
 
 // wiretype returns the wire encoding of the type.

--- a/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/descriptor.pb.go
+++ b/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/descriptor.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FieldDescriptorProto_Type int32
 

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -36,32 +36,39 @@ type StorageConfig struct {
 	Filesystems []string
 	// MinFreeBytes define minimum free volume capacity
 	MinFreeBytes uint64
-	// WatermarkWarning is the disk occupancy percentage that will trigger a warning probe
-	WatermarkWarning uint
-	// WatermarkCritical is the disk occupancy percentage that will trigger a critical probe
-	WatermarkCritical uint
+	// LowWatermark is the disk occupancy percentage that will trigger a warning probe
+	LowWatermark uint
+	// HighWatermark is the disk occupancy percentage that will trigger a critical probe
+	HighWatermark uint
 }
 
+// CheckAndSetDefaults validates this configuration object.
+// Config values that were not specified will be set to their default values if
+// available.
 func (c *StorageConfig) CheckAndSetDefaults() error {
 	var errors []error
 	if c.Path == "" {
 		errors = append(errors, trace.BadParameter("volume path must be provided"))
 	}
 
-	if c.WatermarkWarning > 100 {
-		errors = append(errors, trace.BadParameter("warning watermark must be between 0 and 100"))
+	if c.LowWatermark > 100 {
+		errors = append(errors, trace.BadParameter("low watermark must be 0-100"))
 	}
 
-	if c.WatermarkCritical > 100 {
-		errors = append(errors, trace.BadParameter("critical watermark must be between 0 and 100"))
+	if c.HighWatermark > 100 {
+		errors = append(errors, trace.BadParameter("high watermark must be 0-100"))
 	}
 
-	if c.WatermarkWarning == 0 {
-		c.WatermarkWarning = DefaultWarningWatermark
+	if c.LowWatermark == 0 {
+		c.LowWatermark = DefaultLowWatermark
 	}
 
-	if c.WatermarkCritical == 0 {
-		c.WatermarkCritical = DefaultCriticalWatermark
+	if c.HighWatermark == 0 {
+		c.HighWatermark = DefaultHighWatermark
+	}
+
+	if c.LowWatermark > c.HighWatermark {
+		errors = append(errors, trace.BadParameter("low watermark (%v) cannot be higher than high watermark (%v)", c.LowWatermark, c.HighWatermark))
 	}
 
 	return trace.NewAggregate(errors...)
@@ -69,10 +76,10 @@ func (c *StorageConfig) CheckAndSetDefaults() error {
 
 // HighWatermarkCheckerData is attached to high watermark check results
 type HighWatermarkCheckerData struct {
-	// WatermarkWarning is the watermark warning percentage value
-	WatermarkWarning uint `json:"watermark_warning"`
-	// WatermarkCritical is the watermark critical percentage value
-	WatermarkCritical uint `json:"watermark_critical"`
+	// LowWatermark is the low watermark percentage value
+	LowWatermark uint `json:"low_watermark"`
+	// HighWatermark is the high watermark percentage value
+	HighWatermark uint `json:"high_watermark"`
 	// Path is the absolute path to check
 	Path string `json:"path"`
 	// TotalBytes is the total disk capacity
@@ -83,27 +90,27 @@ type HighWatermarkCheckerData struct {
 
 // WarningMessage returns warning watermark check message
 func (d HighWatermarkCheckerData) WarningMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
-		d.Path, d.WatermarkWarning, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+	return fmt.Sprintf("disk utilization on %s exceeds %v percent, cluster will degrade if usage exceeds %v percent (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // CriticalMessage returns critical watermark check message
 func (d HighWatermarkCheckerData) CriticalMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
-		d.Path, d.WatermarkCritical, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
 	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
-		d.Path, d.WatermarkCritical, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
 
-// DefaultWarningWatermark is the default warning disk usage percentage threshold.
-const DefaultWarningWatermark = 80
+// DefaultLowWatermark is the default low watermark percentage.
+const DefaultLowWatermark = 80
 
-// DefaultCriticalWatermark is the default critical disk usage percentage threshold.
-const DefaultCriticalWatermark = 90
+// DefaultHighWatermark is the default high watermark percentage.
+const DefaultHighWatermark = 90

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -19,6 +19,8 @@ package monitoring
 import (
 	"fmt"
 
+	"github.com/gravitational/trace"
+
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -34,14 +36,43 @@ type StorageConfig struct {
 	Filesystems []string
 	// MinFreeBytes define minimum free volume capacity
 	MinFreeBytes uint64
-	// HighWatermark is the disk occupancy percentage that is considered degrading
-	HighWatermark uint
+	// WatermarkWarning is the disk occupancy percentage that will trigger a warning probe
+	WatermarkWarning uint
+	// WatermarkCritical is the disk occupancy percentage that will trigger a critical probe
+	WatermarkCritical uint
+}
+
+func (c *StorageConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if c.Path == "" {
+		errors = append(errors, trace.BadParameter("volume path must be provided"))
+	}
+
+	if c.WatermarkWarning > 100 {
+		errors = append(errors, trace.BadParameter("warning watermark must be between 0 and 100"))
+	}
+
+	if c.WatermarkCritical > 100 {
+		errors = append(errors, trace.BadParameter("critical watermark must be between 0 and 100"))
+	}
+
+	if c.WatermarkWarning == 0 {
+		c.WatermarkWarning = DefaultWarningWatermark
+	}
+
+	if c.WatermarkCritical == 0 {
+		c.WatermarkCritical = DefaultCriticalWatermark
+	}
+
+	return trace.NewAggregate(errors...)
 }
 
 // HighWatermarkCheckerData is attached to high watermark check results
 type HighWatermarkCheckerData struct {
-	// HighWatermark is the watermark percentage value
-	HighWatermark uint `json:"high_watermark"`
+	// WatermarkWarning is the watermark warning percentage value
+	WatermarkWarning uint `json:"watermark_warning"`
+	// WatermarkCritical is the watermark critical percentage value
+	WatermarkCritical uint `json:"watermark_critical"`
 	// Path is the absolute path to check
 	Path string `json:"path"`
 	// TotalBytes is the total disk capacity
@@ -50,17 +81,29 @@ type HighWatermarkCheckerData struct {
 	AvailableBytes uint64 `json:"available_bytes"`
 }
 
-// FailureMessage returns failure watermark check message
-func (d HighWatermarkCheckerData) FailureMessage() string {
+// WarningMessage returns warning watermark check message
+func (d HighWatermarkCheckerData) WarningMessage() string {
 	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
-		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+		d.Path, d.WatermarkWarning, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+}
+
+// CriticalMessage returns critical watermark check message
+func (d HighWatermarkCheckerData) CriticalMessage() string {
+	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
+		d.Path, d.WatermarkCritical, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
 	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
-		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+		d.Path, d.WatermarkCritical, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// DefaultWarningWatermark is the default warning disk usage percentage threshold.
+const DefaultWarningWatermark = 80
+
+// DefaultCriticalWatermark is the default critical disk usage percentage threshold.
+const DefaultCriticalWatermark = 90

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -68,7 +68,7 @@ func (c *StorageConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.LowWatermark > c.HighWatermark {
-		errors = append(errors, trace.BadParameter("low watermark (%v) cannot be higher than high watermark (%v)", c.LowWatermark, c.HighWatermark))
+		c.LowWatermark = c.HighWatermark
 	}
 
 	return trace.NewAggregate(errors...)
@@ -90,19 +90,19 @@ type HighWatermarkCheckerData struct {
 
 // WarningMessage returns warning watermark check message
 func (d HighWatermarkCheckerData) WarningMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent, cluster will degrade if usage exceeds %v percent (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
-		d.Path, d.LowWatermark, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
 }
 
 // CriticalMessage returns critical watermark check message
 func (d HighWatermarkCheckerData) CriticalMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
-	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
+	return fmt.Sprintf("disk utilization on %s is below %v%% (%s is available out of %s)",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 

--- a/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
@@ -88,7 +88,7 @@ func (c *storageChecker) check(ctx context.Context, reporter health.Reporter) er
 
 	return trace.NewAggregate(c.checkFsType(ctx, reporter),
 		c.checkCapacity(ctx, reporter),
-		c.checkHighWatermark(ctx, reporter),
+		c.checkDiskUsage(ctx, reporter),
 		c.checkWriteSpeed(ctx, reporter))
 }
 
@@ -147,14 +147,15 @@ func (c *storageChecker) checkFsType(ctx context.Context, reporter health.Report
 	return nil
 }
 
-// checkHighWatermark checks the disk usage. A failed warning or critical probe
-// will be reported if the usage percentage is above the set thresholds.
-// If the WatermarkWarning percentage is higher than or equal to the
-// WatermarkCritical percentage, then the check will only ever report critical
-// probes.
-func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health.Reporter) error {
-	if c.WatermarkCritical == 0 {
+// checkDiskUsage checks the disk usage. A warning or critical probe will be
+// reported if the usage percentage is above the set thresholds.
+func (c *storageChecker) checkDiskUsage(ctx context.Context, reporter health.Reporter) error {
+	if c.HighWatermark == 0 {
 		return nil
+	}
+	if c.LowWatermark > c.HighWatermark {
+		return trace.BadParameter("low watermark (%v) cannot be higher than high watermark (%v)",
+			c.LowWatermark, c.HighWatermark)
 	}
 	availableBytes, totalBytes, err := c.diskCapacity(c.path)
 	if err != nil {
@@ -164,11 +165,11 @@ func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health
 		return trace.BadParameter("disk capacity at %v is 0", c.path)
 	}
 	checkerData := HighWatermarkCheckerData{
-		WatermarkCritical: c.WatermarkCritical,
-		WatermarkWarning:  c.WatermarkWarning,
-		Path:              c.Path,
-		TotalBytes:        totalBytes,
-		AvailableBytes:    availableBytes,
+		LowWatermark:   c.LowWatermark,
+		HighWatermark:  c.HighWatermark,
+		Path:           c.Path,
+		TotalBytes:     totalBytes,
+		AvailableBytes: availableBytes,
 	}
 	checkerDataBytes, err := json.Marshal(checkerData)
 	if err != nil {
@@ -177,7 +178,7 @@ func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health
 
 	diskUsagePercent := float64(totalBytes-availableBytes) / float64(totalBytes) * 100
 
-	if diskUsagePercent > float64(checkerData.WatermarkCritical) {
+	if diskUsagePercent > float64(checkerData.HighWatermark) {
 		reporter.Add(&pb.Probe{
 			Checker:     DiskSpaceCheckerID,
 			Detail:      checkerData.CriticalMessage(),
@@ -188,7 +189,7 @@ func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health
 		return nil
 	}
 
-	if diskUsagePercent > float64(checkerData.WatermarkWarning) {
+	if diskUsagePercent > float64(checkerData.LowWatermark) {
 		reporter.Add(&pb.Probe{
 			Checker:     DiskSpaceCheckerID,
 			Detail:      checkerData.WarningMessage(),

--- a/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
@@ -153,10 +153,6 @@ func (c *storageChecker) checkDiskUsage(ctx context.Context, reporter health.Rep
 	if c.HighWatermark == 0 {
 		return nil
 	}
-	if c.LowWatermark > c.HighWatermark {
-		return trace.BadParameter("low watermark (%v) cannot be higher than high watermark (%v)",
-			c.LowWatermark, c.HighWatermark)
-	}
 	availableBytes, totalBytes, err := c.diskCapacity(c.path)
 	if err != nil {
 		return trace.Wrap(err)

--- a/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
@@ -39,11 +39,15 @@ import (
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &storageChecker{
 		StorageConfig: config,
 		osInterface:   &realOS{},
-	}
+	}, nil
 }
 
 // storageChecker verifies volume requirements
@@ -143,8 +147,13 @@ func (c *storageChecker) checkFsType(ctx context.Context, reporter health.Report
 	return nil
 }
 
+// checkHighWatermark checks the disk usage. A failed warning or critical probe
+// will be reported if the usage percentage is above the set thresholds.
+// If the WatermarkWarning percentage is higher than or equal to the
+// WatermarkCritical percentage, then the check will only ever report critical
+// probes.
 func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health.Reporter) error {
-	if c.HighWatermark == 0 {
+	if c.WatermarkCritical == 0 {
 		return nil
 	}
 	availableBytes, totalBytes, err := c.diskCapacity(c.path)
@@ -155,30 +164,48 @@ func (c *storageChecker) checkHighWatermark(ctx context.Context, reporter health
 		return trace.BadParameter("disk capacity at %v is 0", c.path)
 	}
 	checkerData := HighWatermarkCheckerData{
-		HighWatermark:  c.HighWatermark,
-		Path:           c.Path,
-		TotalBytes:     totalBytes,
-		AvailableBytes: availableBytes,
+		WatermarkCritical: c.WatermarkCritical,
+		WatermarkWarning:  c.WatermarkWarning,
+		Path:              c.Path,
+		TotalBytes:        totalBytes,
+		AvailableBytes:    availableBytes,
 	}
 	checkerDataBytes, err := json.Marshal(checkerData)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if float64(totalBytes-availableBytes)/float64(totalBytes)*100 > float64(c.HighWatermark) {
+
+	diskUsagePercent := float64(totalBytes-availableBytes) / float64(totalBytes) * 100
+
+	if diskUsagePercent > float64(checkerData.WatermarkCritical) {
 		reporter.Add(&pb.Probe{
 			Checker:     DiskSpaceCheckerID,
-			Detail:      checkerData.FailureMessage(),
+			Detail:      checkerData.CriticalMessage(),
 			CheckerData: checkerDataBytes,
 			Status:      pb.Probe_Failed,
+			Severity:    pb.Probe_Critical,
 		})
-	} else {
+		return nil
+	}
+
+	if diskUsagePercent > float64(checkerData.WatermarkWarning) {
 		reporter.Add(&pb.Probe{
 			Checker:     DiskSpaceCheckerID,
-			Detail:      checkerData.SuccessMessage(),
+			Detail:      checkerData.WarningMessage(),
 			CheckerData: checkerDataBytes,
-			Status:      pb.Probe_Running,
+			Status:      pb.Probe_Failed,
+			Severity:    pb.Probe_Warning,
 		})
+		return nil
 	}
+
+	reporter.Add(&pb.Probe{
+		Checker:     DiskSpaceCheckerID,
+		Detail:      checkerData.SuccessMessage(),
+		CheckerData: checkerDataBytes,
+		Status:      pb.Probe_Running,
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
### Description
This PR bumps satellite to 5.5.18 and now provides two separate low and high watermark values to the storage check. The values are set with `low-watermark` and `high-watermark` flags. The defaults are set at `PLANET_LOW_WATERMARK` and `PLANET_HIGH_WATERMARK`.

### Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/225