### PR TITLE
[6.1.x] Update disk check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,7 +364,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/6.1.x/disk-check"
   digest = "1:b705cee840ff4705fd03efce96f85af7417b76a6ce6e8b0d37555b082968d1e1"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -385,7 +384,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "fe61fb3e57c282c0f657d5944d558c44fabb0d67"
+  revision = "7672dd22975e414b01879d4d2545f87072c91913"
+  version = "6.1.11"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -364,7 +364,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6c23d9679e4ebe082cad54b926b6d8b8a67c4818ca5b4f735856add17e9b52ba"
+  branch = "bernard/6.1.x/disk-check"
+  digest = "1:b705cee840ff4705fd03efce96f85af7417b76a6ce6e8b0d37555b082968d1e1"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -384,8 +385,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "17e9515705bceb5f0fed9e63770f3c9d447e7975"
-  version = "6.1.10"
+  revision = "fe61fb3e57c282c0f657d5944d558c44fabb0d67"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,8 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=6.1.10"
-  branch = "bernard/6.1.x/disk-check"
+  version = "=6.1.11"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,8 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.10"
+  # version = "=6.1.10"
+  branch = "bernard/6.1.x/disk-check"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -278,10 +278,6 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
-	err := monitoringConf.Check()
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	if conf.Tags == nil {
 		conf.Tags = make(map[string]string)
 	}

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -443,9 +443,6 @@ const (
 	// EtcdUpgradeTimeout is the amount of time to wait for operations during the etcd upgrade
 	EtcdUpgradeTimeout = 15 * time.Minute
 
-	// HighWatermark is the disk usage percentage that is considered degrading
-	HighWatermark = 80
-
 	// StateDir is a location within the planet container that can hold persistent state
 	StateDir = "/ext/state"
 )

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -167,7 +167,8 @@ func run() error {
 		cagentDNSLocalNameservers    = List(cagent.Flag("local-nameservers", "List of node-local nameserver addresses").OverrideDefaultFromEnvar(EnvDNSLocalNameservers).Default(DefaultDNSAddress))
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
-		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of monitored directories and devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
+		cagentLowWatermark           = cagent.Flag("low-watermark", "Low disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_LOW_WATERMARK").Uint64()
+		cagentHighWatermark          = cagent.Flag("high-watermark", "High disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_HIGH_WATERMARK").Uint64()
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
 
@@ -340,6 +341,7 @@ func run() error {
 			ETCDConfig:            etcdConf,
 			DisableInterPodCheck:  disableInterPodCheck,
 			CloudProvider:         *cagentCloudProvider,
+			LowWatermark:          uint(*cagentLowWatermark),
 			HighWatermark:         uint(*cagentHighWatermark),
 			NodeName:              *cagentNodeName,
 		}

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -19,6 +19,8 @@ package monitoring
 import (
 	"fmt"
 
+	"github.com/gravitational/trace"
+
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -34,13 +36,49 @@ type StorageConfig struct {
 	Filesystems []string
 	// MinFreeBytes define minimum free volume capacity
 	MinFreeBytes uint64
-	// HighWatermark is the disk occupancy percentage that is considered degrading
+	// LowWatermark is the disk occupancy percentage that will trigger a warning probe
+	LowWatermark uint
+	// HighWatermark is the disk occupancy percentage that will trigger a critical probe
 	HighWatermark uint
+}
+
+// CheckAndSetDefaults validates this configuration object.
+// Config values that were not specified will be set to their default values if
+// available.
+func (c *StorageConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if c.Path == "" {
+		errors = append(errors, trace.BadParameter("volume path must be provided"))
+	}
+
+	if c.LowWatermark > 100 {
+		errors = append(errors, trace.BadParameter("low watermark must be 0-100"))
+	}
+
+	if c.HighWatermark > 100 {
+		errors = append(errors, trace.BadParameter("high watermark must be 0-100"))
+	}
+
+	if c.LowWatermark == 0 {
+		c.LowWatermark = DefaultLowWatermark
+	}
+
+	if c.HighWatermark == 0 {
+		c.HighWatermark = DefaultHighWatermark
+	}
+
+	if c.LowWatermark > c.HighWatermark {
+		c.LowWatermark = c.HighWatermark
+	}
+
+	return trace.NewAggregate(errors...)
 }
 
 // HighWatermarkCheckerData is attached to high watermark check results
 type HighWatermarkCheckerData struct {
-	// HighWatermark is the watermark percentage value
+	// LowWatermark is the low watermark percentage value
+	LowWatermark uint `json:"low_watermark"`
+	// HighWatermark is the high watermark percentage value
 	HighWatermark uint `json:"high_watermark"`
 	// Path is the absolute path to check
 	Path string `json:"path"`
@@ -50,17 +88,29 @@ type HighWatermarkCheckerData struct {
 	AvailableBytes uint64 `json:"available_bytes"`
 }
 
-// FailureMessage returns failure watermark check message
-func (d HighWatermarkCheckerData) FailureMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
+// WarningMessage returns warning watermark check message
+func (d HighWatermarkCheckerData) WarningMessage() string {
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
+}
+
+// CriticalMessage returns critical watermark check message
+func (d HighWatermarkCheckerData) CriticalMessage() string {
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
-	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
+	return fmt.Sprintf("disk utilization on %s is below %v%% (%s is available out of %s)",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// DefaultLowWatermark is the default low watermark percentage.
+const DefaultLowWatermark = 80
+
+// DefaultHighWatermark is the default high watermark percentage.
+const DefaultHighWatermark = 90


### PR DESCRIPTION
### Description
This PR bumps satellite to 6.1.11 and now provides two separate low and high watermark values to the storage check. The values are set with `low-watermark` and `high-watermark` flags. The defaults are set at `PLANET_LOW_WATERMARK` and `PLANET_HIGH_WATERMARK`.

### Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/228
* Ports https://github.com/gravitational/planet/pull/672