### PR TITLE
[7.0.x] Update disk check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -422,8 +422,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/7.0.x/disk-check"
-  digest = "1:dbaef7be95a42f6739aad38c56bcf328aff14341ccb36e92492f2c8ccbcf40d8"
+  digest = "1:a7fa870bd4fa134960cb268e04b20be9fd4eb3c926c2817c8e9f04ca07eea023"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -443,7 +442,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "6871261912d2cd3b29c978df497c2b50b187196b"
+  revision = "bcf5cf9b9e3a05a7f557e7cad0526175434912c9"
+  version = "7.0.13"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -422,7 +422,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:dadcc963a4351005362d321709467b5afe37ac6eea365e882a463242a9e846ba"
+  branch = "bernard/7.0.x/disk-check"
+  digest = "1:dbaef7be95a42f6739aad38c56bcf328aff14341ccb36e92492f2c8ccbcf40d8"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -442,8 +443,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "c1a5e7b09c45fde4d70068f3441ab8c5870917d6"
-  version = "7.0.12"
+  revision = "6871261912d2cd3b29c978df497c2b50b187196b"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,8 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.12"
+  # version = "=7.0.12"
+  branch = "bernard/7.0.x/disk-check"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,8 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=7.0.12"
-  branch = "bernard/7.0.x/disk-check"
+  version = "=7.0.13"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -68,7 +68,9 @@ type Config struct {
 	CloudProvider string
 	// NodeName is the kubernetes name of this node
 	NodeName string
-	// HighWatermark is the usage limit percentage of monitored directories and devicemapper
+	// LowWatermark is the disk usage warning limit percentage of monitored directories
+	LowWatermark uint
+	// HighWatermark is the disk usage critical limit percentage of monitored directories
 	HighWatermark uint
 	// HTTPTimeout specifies the HTTP timeout for checks
 	HTTPTimeout time.Duration
@@ -76,9 +78,6 @@ type Config struct {
 
 // CheckAndSetDefaults validates monitoring configuration
 func (c *Config) CheckAndSetDefaults() error {
-	if c.HighWatermark > 100 {
-		return trace.BadParameter("high watermark percentage should be 0-100")
-	}
 	if c.HTTPTimeout == 0 {
 		c.HTTPTimeout = constants.HTTPTimeout
 	}
@@ -217,15 +216,18 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 			"leader.telekube.local.",
 		}, config.LocalNameservers...))
 	}
-	node.AddChecker(monitoring.NewStorageChecker(monitoring.StorageConfig{
-		Path:          constants.GravityDataDir,
-		HighWatermark: config.HighWatermark,
-	}))
-	// the following checker will be no-op if docker driver is not devicemapper
-	node.AddChecker(monitoring.NewDockerDevicemapperChecker(
-		monitoring.DockerDevicemapperConfig{
+
+	storageChecker, err := monitoring.NewStorageChecker(
+		monitoring.StorageConfig{
+			Path:          constants.GravityDataDir,
+			LowWatermark:  config.LowWatermark,
 			HighWatermark: config.HighWatermark,
-		}))
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	node.AddChecker(storageChecker)
 
 	pingChecker, err := monitoring.NewPingChecker(
 		monitoring.PingCheckerConfig{
@@ -314,15 +316,18 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 		NodeName:       config.NodeName,
 		CheckCondition: monitoring.CheckNodeCondition,
 	}))
-	node.AddChecker(monitoring.NewStorageChecker(monitoring.StorageConfig{
-		Path:          constants.GravityDataDir,
-		HighWatermark: config.HighWatermark,
-	}))
-	// the following checker will be no-op if docker driver is not devicemapper
-	node.AddChecker(monitoring.NewDockerDevicemapperChecker(
-		monitoring.DockerDevicemapperConfig{
+
+	storageChecker, err := monitoring.NewStorageChecker(
+		monitoring.StorageConfig{
+			Path:          constants.GravityDataDir,
+			LowWatermark:  config.LowWatermark,
 			HighWatermark: config.HighWatermark,
-		}))
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	node.AddChecker(storageChecker)
 
 	// Add checkers specific to cloud provider backend
 	switch strings.ToLower(config.CloudProvider) {

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -450,9 +450,6 @@ const (
 	// EtcdUpgradeTimeout is the amount of time to wait for operations during the etcd upgrade
 	EtcdUpgradeTimeout = 15 * time.Minute
 
-	// HighWatermark is the disk usage percentage that is considered degrading
-	HighWatermark = 80
-
 	// StateDir is a location within the planet container that can hold persistent state
 	StateDir = "/ext/state"
 )

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -165,7 +165,8 @@ func run() error {
 		cagentDNSLocalNameservers    = List(cagent.Flag("local-nameservers", "List of node-local nameserver addresses").OverrideDefaultFromEnvar(EnvDNSLocalNameservers).Default(DefaultDNSAddress))
 		cagentDNSZones               = DNSOverrides(cagent.Flag("dns-zones", "Comma-separated list of DNS zone to nameserver IP mappings as 'zone/nameserver' pairs").OverrideDefaultFromEnvar(EnvDNSZones))
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
-		cagentHighWatermark          = cagent.Flag("high-watermark", "Usage percentage of monitored directories and devicemapper which is considered degrading").Default(strconv.Itoa(HighWatermark)).Uint64()
+		cagentLowWatermark           = cagent.Flag("low-watermark", "Low disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_LOW_WATERMARK").Uint64()
+		cagentHighWatermark          = cagent.Flag("high-watermark", "High disk usage percentage of monitored directories").OverrideDefaultFromEnvar("PLANET_HIGH_WATERMARK").Uint64()
 		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
@@ -344,6 +345,7 @@ func run() error {
 			ETCDConfig:            etcdConf,
 			DisableInterPodCheck:  disableInterPodCheck,
 			CloudProvider:         *cagentCloudProvider,
+			LowWatermark:          uint(*cagentLowWatermark),
 			HighWatermark:         uint(*cagentHighWatermark),
 			NodeName:              *cagentNodeName,
 			HTTPTimeout:           *cagentHTTPTimeout,

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -19,6 +19,8 @@ package monitoring
 import (
 	"fmt"
 
+	"github.com/gravitational/trace"
+
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -34,13 +36,49 @@ type StorageConfig struct {
 	Filesystems []string
 	// MinFreeBytes define minimum free volume capacity
 	MinFreeBytes uint64
-	// HighWatermark is the disk occupancy percentage that is considered degrading
+	// LowWatermark is the disk occupancy percentage that will trigger a warning probe
+	LowWatermark uint
+	// HighWatermark is the disk occupancy percentage that will trigger a critical probe
 	HighWatermark uint
+}
+
+// CheckAndSetDefaults validates this configuration object.
+// Config values that were not specified will be set to their default values if
+// available.
+func (c *StorageConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if c.Path == "" {
+		errors = append(errors, trace.BadParameter("volume path must be provided"))
+	}
+
+	if c.LowWatermark > 100 {
+		errors = append(errors, trace.BadParameter("low watermark must be 0-100"))
+	}
+
+	if c.HighWatermark > 100 {
+		errors = append(errors, trace.BadParameter("high watermark must be 0-100"))
+	}
+
+	if c.LowWatermark == 0 {
+		c.LowWatermark = DefaultLowWatermark
+	}
+
+	if c.HighWatermark == 0 {
+		c.HighWatermark = DefaultHighWatermark
+	}
+
+	if c.LowWatermark > c.HighWatermark {
+		c.LowWatermark = c.HighWatermark
+	}
+
+	return trace.NewAggregate(errors...)
 }
 
 // HighWatermarkCheckerData is attached to high watermark check results
 type HighWatermarkCheckerData struct {
-	// HighWatermark is the watermark percentage value
+	// LowWatermark is the low watermark percentage value
+	LowWatermark uint `json:"low_watermark"`
+	// HighWatermark is the high watermark percentage value
 	HighWatermark uint `json:"high_watermark"`
 	// Path is the absolute path to check
 	Path string `json:"path"`
@@ -50,17 +88,29 @@ type HighWatermarkCheckerData struct {
 	AvailableBytes uint64 `json:"available_bytes"`
 }
 
-// FailureMessage returns failure watermark check message
-func (d HighWatermarkCheckerData) FailureMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
+// WarningMessage returns warning watermark check message
+func (d HighWatermarkCheckerData) WarningMessage() string {
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
+}
+
+// CriticalMessage returns critical watermark check message
+func (d HighWatermarkCheckerData) CriticalMessage() string {
+	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
-	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
+	return fmt.Sprintf("disk utilization on %s is below %v%% (%s is available out of %s)",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// DefaultLowWatermark is the default low watermark percentage.
+const DefaultLowWatermark = 80
+
+// DefaultHighWatermark is the default high watermark percentage.
+const DefaultHighWatermark = 90

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -90,14 +90,16 @@ type HighWatermarkCheckerData struct {
 
 // WarningMessage returns warning watermark check message
 func (d HighWatermarkCheckerData) WarningMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
-		d.Path, d.LowWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
+	diskUsage := float64(d.TotalBytes-d.AvailableBytes) / float64(d.TotalBytes) * 100
+	return fmt.Sprintf("disk utilization on %s exceeds %v%%, currently at %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, diskUsage, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
 }
 
 // CriticalMessage returns critical watermark check message
 func (d HighWatermarkCheckerData) CriticalMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
-		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+	diskUsage := float64(d.TotalBytes-d.AvailableBytes) / float64(d.TotalBytes) * 100
+	return fmt.Sprintf("disk utilization on %s exceeds %v%%, currently at %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.HighWatermark, diskUsage, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message


### PR DESCRIPTION
### Description
This PR bumps satellite to 7.0.13 and now provides two separate low and high watermark values to the storage check. The values are set with `low-watermark` and `high-watermark` flags. The defaults are set at `PLANET_LOW_WATERMARK` and `PLANET_HIGH_WATERMARK`.

### Linked tickets and PRs
* Requires gravitational/satellite#229
* Ports #672