### PR TITLE
(7.0) Add netbase package

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -51,6 +51,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex && \
         conntrack \
         open-iscsi \
         strace \
+        netbase \
         && apt-get -y autoclean && apt-get -y clean && apt-get autoremove \
         && rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
This package is required for nfs mounts (and potentially other things) to work. It was present in older versions (I checked).

Refs https://github.com/gravitational/gravity/issues/1718. See linked gravity PR for testing done.