### PR TITLE
Remove duplicate --allocate-node-cidrs flag.

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
+++ b/build.assets/makefiles/master/k8s-master/kube-controller-manager.service
@@ -14,7 +14,6 @@ ExecStart=/usr/bin/kube-controller-manager \
         --master=https://${KUBE_APISERVER}:6443 \
         --logtostderr=true \
         --kubeconfig=/etc/kubernetes/scheduler.kubeconfig \
-        --allocate-node-cidrs=false \
         --profiling=false \
         --terminated-pod-gc-threshold=500 \
         --secure-port=0 \


### PR DESCRIPTION
This is set a couple lines later.  It looks like this was accidentally
ported in #393, which introduced the flag the 2nd time.

I noticed this while investigating a community question in #698

## Testing Done
None.  I trust that @a-palchikov or @knisbet will let me know if this is potentially dangerous.