### PR TITLE
bump embedded CoreDNS to 1.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ DOCKER_VER ?= 18.09.9
 # we currently use our own flannel fork: gravitational/flannel
 FLANNEL_VER := v0.10.1-gravitational
 HELM_VER := 2.15.0
-COREDNS_VER := 1.3.1
+COREDNS_VER := 1.7.0
 NODE_PROBLEM_DETECTOR_VER := v0.6.4
 CNI_VER := 0.8.6
 SERF_VER := v0.8.5


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Update CoreDNS to latest available release.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
- https://github.com/gravitational/gravity/issues/1875
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

```
kevin-test1:/$ dig registry.local

; <<>> DiG 9.10.3-P4-Debian <<>> registry.local
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 27640
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;registry.local.			IN	A

;; ANSWER SECTION:
registry.local.		3600	IN	A	10.162.0.7

;; Query time: 0 msec
;; SERVER: 127.0.0.2#53(127.0.0.2)
;; WHEN: Wed Jul 15 01:34:52 UTC 2020
;; MSG SIZE  rcvd: 73

kevin-test1:/$ dig registry.local AAAA

; <<>> DiG 9.10.3-P4-Debian <<>> registry.local AAAA
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 64069
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;registry.local.			IN	AAAA

;; Query time: 0 msec
;; SERVER: 127.0.0.2#53(127.0.0.2)
;; WHEN: Wed Jul 15 01:34:54 UTC 2020
;; MSG SIZE  rcvd: 43
```

`status: NOERROR answer: 0` is the expected response on the AAAA query, indicating the problem is fixed.

## Additional information
<!--Optional. Anything else that may be relevant.-->
See https://github.com/gravitational/gravity/issues/1875 for a full description of the issue.