### PR TITLE
[5.5.x] Kernel check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ae727b234440a7ebc3c7cff3a1f1c3be8c0ee25f5687ce1158deff547dba456f"
+  branch = "bernard/5.5.x/kernel-check"
+  digest = "1:e310ffdbd5a2f0936023af96e95344babb2a86c08a89884b355baca68c7b3e05"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -387,8 +388,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "8f71a1951f393c15eebddeb8a48b00baff20f960"
-  version = "5.5.21"
+  revision = "4924d6833d39e6de3bfcee1b9a0e07863b42cc7b"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/5.5.x/kernel-check"
   digest = "1:e310ffdbd5a2f0936023af96e95344babb2a86c08a89884b355baca68c7b3e05"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -388,7 +387,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "4924d6833d39e6de3bfcee1b9a0e07863b42cc7b"
+  revision = "119e0df3db436e590cae1c5d2e5cac8398c88fe6"
+  version = "5.5.22"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,8 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.21"
+  # version = "=5.5.21"
+  branch = "bernard/5.5.x/kernel-check"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,8 +88,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=5.5.21"
-  branch = "bernard/5.5.x/kernel-check"
+  version = "=5.5.22"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package constants
 
-import "time"
+import (
+	"time"
+
+	"github.com/gravitational/satellite/monitoring"
+)
 
 const (
 	// KubectlConfigPath is the path to kubectl configuration file
@@ -79,4 +83,18 @@ const (
 
 	// DumpProfileTimeout specifies the time limit for dumping agent debug internals
 	DumpProfileTimeout = 1 * time.Minute
+)
+
+var (
+	// MinKernelVersion is the minimum supported Linux kernel version -- 3.10.0-1127.
+	//
+	// Some clusters running on an older CentOS/RHEL kernel have experienced
+	// instability and memory allocation failures.
+	// See https://github.com/gravitational/gravity/issues/1818 for more information.
+	MinKernelVersion = monitoring.KernelVersion{
+		Release: 3,
+		Major:   10,
+		Minor:   0,
+		Patch:   1127,
+	}
 )

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -290,6 +290,8 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 	}
 	node.AddChecker(systemPodsChecker)
 
+	node.AddChecker(monitoring.NewKernelChecker(constants.MinKernelVersion))
+
 	return nil
 }
 
@@ -359,6 +361,8 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 		return trace.Wrap(err)
 	}
 	node.AddChecker(systemPodsChecker)
+
+	node.AddChecker(monitoring.NewKernelChecker(constants.MinKernelVersion))
 
 	return nil
 }

--- a/vendor/github.com/gravitational/satellite/agent/agent.go
+++ b/vendor/github.com/gravitational/satellite/agent/agent.go
@@ -604,7 +604,7 @@ L:
 			log.Debugf("Retrieved status from %v: %v.", status.member, status.NodeStatus)
 			nodeStatus := status.NodeStatus
 			if status.err != nil {
-				log.Warnf("Failed to query node %s(%v) status: %v.",
+				log.Debugf("Failed to query node %s(%v) status: %v.",
 					status.member.Name(), status.member.Addr(), status.err)
 				nodeStatus = unknownNodeStatus(status.member)
 			}
@@ -688,7 +688,7 @@ func (r *agent) notifyMasters(ctx context.Context) error {
 			continue
 		}
 		if err := r.notifyMaster(ctx, member, events); err != nil {
-			log.WithError(err).Warnf("Failed to notify %s of new timeline events.", member.Name())
+			log.WithError(err).Debugf("Failed to notify %s of new timeline events.", member.Name())
 		}
 	}
 

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults.go
@@ -77,3 +77,8 @@ func NewStorageChecker(config StorageConfig) (health.Checker, error) {
 func NewDNSChecker(questionA []string) health.Checker {
 	return noopChecker{}
 }
+
+// NewKernelChecker returns a new instance of kernel checker.
+func NewKernelChecker(version KernelVersion) health.Checker {
+	return noopChecker{}
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/fs_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/fs_linux.go
@@ -75,7 +75,7 @@ func (r dtypeChecker) check(ctx context.Context, reporter health.Reporter) error
 	reporter.Add(&pb.Probe{
 		Checker: r.Name(),
 		Detail: fmt.Sprintf("filesystem on %v does not support d_type, "+
-			"see https://www.gravitational.com/docs/faq/#d_type-support-in-filesystem", string(r)),
+			"see https://www.gravitational.com/gravity/docs/faq/#d_type-support-in-filesystem", string(r)),
 		Status: pb.Probe_Failed,
 	})
 	return nil

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel_checker_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel_checker_linux.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	kernelCheckerID = "kernel-check"
+)
+
+// kernelChecker is a checker that verifies that the linux kernel version is
+// supported by Gravity.
+type kernelChecker struct {
+	// MinKernelVersion specifies the minimum supported kernel version.
+	MinKernelVersion KernelVersion
+	// kernelVersionReader specifies the kernel version reader function.
+	kernelVersionReader
+}
+
+// NewKernelChecker returns a new instance of kernel checker.
+func NewKernelChecker(version KernelVersion) health.Checker {
+	return &kernelChecker{
+		MinKernelVersion:    version,
+		kernelVersionReader: realKernelVersionReader,
+	}
+}
+
+// Name returns the checker name.
+// Implements health.Checker.
+func (r *kernelChecker) Name() string {
+	return kernelCheckerID
+}
+
+// Check verifies kernel version.
+// Implements health.Checker.
+func (r *kernelChecker) Check(ctx context.Context, reporter health.Reporter) {
+	if err := r.check(ctx, reporter); err != nil {
+		log.WithError(err).Debug("Failed to verify kernel version.")
+		return
+	}
+}
+
+func (r *kernelChecker) check(_ context.Context, reporter health.Reporter) error {
+	release, err := r.kernelVersionReader()
+	if err != nil {
+		return trace.Wrap(err, "failed to read kernel version")
+	}
+
+	kernelVersion, err := parseKernelVersion(release)
+	if err != nil {
+		return trace.Wrap(err, "failed to determine kernel version: %s", release)
+	}
+
+	if !r.isSupportedVersion(*kernelVersion) {
+		reporter.Add(r.warningProbe(release))
+		return nil
+	}
+
+	reporter.Add(r.successProbe(release))
+	return nil
+}
+
+func (r *kernelChecker) successProbe(installedVersion string) *pb.Probe {
+	return &pb.Probe{
+		Checker: r.Name(),
+		Detail:  fmt.Sprintf("Installed Linux kernel is supported: %s.", installedVersion),
+		Status:  pb.Probe_Running,
+	}
+}
+
+func (r *kernelChecker) warningProbe(installedVersion string) *pb.Probe {
+	return &pb.Probe{
+		Checker: r.Name(),
+		Detail: fmt.Sprintf("Minimum recommended kernel version is %s (%s is installed).",
+			r.MinKernelVersion.String(), installedVersion),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
+}
+
+// isSupportedVersion returns true if the provided linux kernel version is
+// supported by Gravity.
+func (r *kernelChecker) isSupportedVersion(version KernelVersion) bool {
+	return !KernelVersionLessThan(r.MinKernelVersion)(version)
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+// KernelVersion describes an abbreviated version of a Linux kernel.
+// It contains the kernel version (including major/minor components) and
+// patch number
+//
+// Example:
+//  $ uname -r
+//  $ 4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+type KernelVersion struct {
+	// Release specifies the release of the kernel
+	Release int
+	// Major specifies the major version component
+	Major int
+	// Minor specifies the minor version component
+	Minor int
+	// Patch specifies the patch or build number
+	Patch int
+}
+
+// String returns the kernel version formatted as Release.Major.Minor-Patch.
+func (r *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
+}
+
+// KernelConstraintFunc is a function to determine if the kernel version
+// satisfies a particular condition.
+type KernelConstraintFunc func(KernelVersion) bool
+
+// KernelVersionLessThan is a kernel constraint checker
+// that determines if the specified testVersion is less than
+// the actual version.
+func KernelVersionLessThan(version KernelVersion) KernelConstraintFunc {
+	return func(testVersion KernelVersion) bool {
+		if testVersion.Release != version.Release {
+			return testVersion.Release < version.Release
+		}
+
+		if testVersion.Major != version.Major {
+			return testVersion.Major < version.Major
+		}
+
+		if testVersion.Minor != version.Minor {
+			return testVersion.Minor < version.Minor
+		}
+
+		return testVersion.Patch < version.Patch
+	}
+}
+
+// kernelVersionReader returns the textual kernel version.
+type kernelVersionReader func() (version string, err error)
+
+// realKernelVersionReader reads and returns the currently installed Linux
+// kernel version.
+func realKernelVersionReader() (version string, err error) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return int8string(uname.Release[:]), nil
+}
+
+// parseKernelVersion parses the input string into a KernelVersion struct. The
+// input is expected to be a valid Linux kernel version in the format
+// Release.Major.Minor-Patch... trailing components will be ignored.
+//
+// Example:
+//  4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+func parseKernelVersion(input string) (*KernelVersion, error) {
+	// componentsLength defines the expected number of kernel version components.
+	const componentsLength = 4
+
+	parts := strings.FieldsFunc(input, func(r rune) bool {
+		return r == '.' || r == '-'
+	})
+	if len(parts) < componentsLength {
+		return nil, trace.BadParameter("invalid kernel version input: %q", input)
+	}
+
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version: %v, expected a number",
+			input)
+	}
+
+	major, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version major: %v, expected a number",
+			input)
+	}
+
+	minor, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version minor: %v, expected a number",
+			input)
+	}
+
+	patch, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version patch: %v, expected a number",
+			input)
+	}
+
+	return &KernelVersion{
+		Release: version,
+		Major:   major,
+		Minor:   minor,
+		Patch:   patch,
+	}, nil
+}
+
+// int8string converts the bytes into a string.
+func int8string(bytes []int8) string {
+	result := make([]byte, 0, len(bytes))
+
+	for _, b := range bytes {
+		if b == 0 {
+			break
+		}
+
+		result = append(result, byte(b))
+	}
+
+	return string(result)
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/sysctl_checkers.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/sysctl_checkers.go
@@ -23,7 +23,7 @@ func NewIPForwardChecker() *SysctlChecker {
 		Param:           "net.ipv4.ip_forward",
 		Expected:        "1",
 		OnMissing:       "ipv4 forwarding status unknown",
-		OnValueMismatch: "ipv4 forwarding is off, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 	}
 }
 
@@ -33,8 +33,8 @@ func NewBridgeNetfilterChecker() *SysctlChecker {
 		CheckerName:     NetfilterCheckerID,
 		Param:           "net.bridge.bridge-nf-call-iptables",
 		Expected:        "1",
-		OnMissing:       "br_netfilter module is either not loaded, or sysctl net.bridge.bridge-nf-call-iptables is not set, see https://www.gravitational.com/docs/faq/#bridge-driver",
-		OnValueMismatch: "kubernetes requires net.bridge.bridge-nf-call-iptables sysctl set to 1, https://www.gravitational.com/docs/faq/#bridge-driver",
+		OnMissing:       "br_netfilter module is either not loaded, or sysctl net.bridge.bridge-nf-call-iptables is not set, see https://www.gravitational.com/gravity/docs/faq/#bridge-driver",
+		OnValueMismatch: "kubernetes requires net.bridge.bridge-nf-call-iptables sysctl set to 1, https://www.gravitational.com/gravity/docs/faq/#bridge-driver",
 	}
 }
 
@@ -48,7 +48,7 @@ func NewMayDetachMountsChecker() *SysctlChecker {
 		CheckerName:     MountsCheckerID,
 		Param:           "fs.may_detach_mounts",
 		Expected:        "1",
-		OnValueMismatch: "fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state, see https://www.gravitational.com/docs/faq/#kubernetes-pods-stuck-in-terminating-state",
+		OnValueMismatch: "fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state, see https://www.gravitational.com/gravity/docs/faq/#kubernetes-pods-stuck-in-terminating-state",
 		SkipNotFound:    true, // It appears that this setting may not appear in non RHEL or older kernels, so don't fire the alert if we don't find the setting
 	}
 }

--- a/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
@@ -136,7 +136,8 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 	for _, node := range nodes {
 		drift, err := c.getTimeDrift(ctx, node)
 		if err != nil {
-			return trace.Wrap(err)
+			log.WithError(err).Debug("Failed to get time drift.")
+			continue
 		}
 		if isDriftHigh(drift) {
 			r.Add(c.failureProbe(node, drift))


### PR DESCRIPTION
### Description
Add a kernel version check with the minimum supported kernel version specified at `3.10.0-1127`.

### Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/249