### PR TITLE
(6.1) Disable CSIMigration feature gate

### DIFF
--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -416,7 +416,7 @@ const (
 	DefaultVxlanPort = 8472
 
 	// DefaultFeatureGates is the default set of component feature gates
-	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIDriverRegistry=false,CSINodeInfo=false,KubeletPodResources=false"
+	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIDriverRegistry=false,CSINodeInfo=false,CSIMigration=false,KubeletPodResources=false"
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"


### PR DESCRIPTION
Explicitly disable the `CSIMigration` feature gate. Otherwise, Kubernetes translates provisioner names from old in-tree plugin names (e.g. `kubernetes.io/gce-pd`) to new CSI plugin names (e.g. `pd.csi.storage.gke.io`) when creating PVCs, which doesn't work because it requires the CSI driver to be deployed in the cluster.

We will re-enable this when CSI framework is GA and in-tree plugins are removed (roughly, K8s v1.21). Also, FWIW this feature gate is also disabled in 7.0.