### PR TITLE
bump docker to avoid containerd-shim hangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ OUTPUTDIR := $(BUILDDIR)/planet
 
 KUBE_VER ?= v1.17.9
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
-DOCKER_VER ?= 18.09.9
+DOCKER_VER ?= 19.03.12
 # we currently use our own flannel fork: gravitational/flannel
 FLANNEL_VER := v0.10.1-gravitational
 HELM_VER := 2.15.0


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/1842

Update to latest docker within kubernetes test matrix to avoid containerd-shim hangs.