### PR TITLE
Check etcd process state based on the PID from systemd unit

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -260,7 +260,7 @@ func startUnits(ctx context.Context) error {
 	var errors []error
 	for _, unit := range controlPlaneUnits {
 		logger := log.WithField("unit", unit)
-		err := systemctlCmd(ctx, "start", unit)
+		_, err := systemctlCmd(ctx, "start", unit)
 		if err != nil {
 			errors = append(errors, err)
 			// Instead of failing immediately, complete start of other units
@@ -275,7 +275,7 @@ func stopUnits(ctx context.Context) error {
 	var errors []error
 	for _, unit := range controlPlaneUnits {
 		logger := log.WithField("unit", unit)
-		err := systemctlCmd(ctx, "stop", unit)
+		_, err := systemctlCmd(ctx, "stop", unit)
 		if err != nil {
 			errors = append(errors, err)
 			// Instead of failing immediately, complete stop of other units
@@ -284,9 +284,11 @@ func stopUnits(ctx context.Context) error {
 		// Even if 'systemctl stop' did not fail, the service could have failed stopping
 		// even though 'stop' is blocking, it does not return an error upon service failing.
 		// See github.com/gravitational/gravity/issues/1209 for more details
-		if err := systemctlCmd(ctx, "is-failed", unit); err == nil {
+		_, err = systemctlCmd(ctx, "is-failed", unit)
+		if err == nil {
 			logger.Info("Reset failed unit.")
-			if err := systemctlCmd(ctx, "reset-failed", unit); err != nil {
+			_, err := systemctlCmd(ctx, "reset-failed", unit)
+			if err != nil {
 				logger.WithError(err).Warn("Failed to reset failed unit.")
 			}
 		}

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -260,7 +260,7 @@ func startUnits(ctx context.Context) error {
 	var errors []error
 	for _, unit := range controlPlaneUnits {
 		logger := log.WithField("unit", unit)
-		_, err := systemctlCmd(ctx, "start", unit)
+		err := systemctlCmd(ctx, "start", unit)
 		if err != nil {
 			errors = append(errors, err)
 			// Instead of failing immediately, complete start of other units
@@ -275,7 +275,7 @@ func stopUnits(ctx context.Context) error {
 	var errors []error
 	for _, unit := range controlPlaneUnits {
 		logger := log.WithField("unit", unit)
-		_, err := systemctlCmd(ctx, "stop", unit)
+		err := systemctlCmd(ctx, "stop", unit)
 		if err != nil {
 			errors = append(errors, err)
 			// Instead of failing immediately, complete stop of other units
@@ -284,10 +284,10 @@ func stopUnits(ctx context.Context) error {
 		// Even if 'systemctl stop' did not fail, the service could have failed stopping
 		// even though 'stop' is blocking, it does not return an error upon service failing.
 		// See github.com/gravitational/gravity/issues/1209 for more details
-		_, err = systemctlCmd(ctx, "is-failed", unit)
+		err = systemctlCmd(ctx, "is-failed", unit)
 		if err == nil {
 			logger.Info("Reset failed unit.")
-			_, err := systemctlCmd(ctx, "reset-failed", unit)
+			err := systemctlCmd(ctx, "reset-failed", unit)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to reset failed unit.")
 			}

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -47,6 +47,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	etcd "go.etcd.io/etcd/client"
 	etcdv3 "go.etcd.io/etcd/clientv3"
+	"strconv"
 )
 
 var (
@@ -173,7 +174,7 @@ func etcdDisable(upgradeService, stopAPIServer bool) error {
 	// the API server as well (passed as flag from gravity to prevent accidental usage).
 	// TODO: This fix needs to be revisited to include a permanent solution.
 	if stopAPIServer {
-		err := systemctl(ctx, "stop", APIServerServiceName)
+		_, err := systemctl(ctx, "stop", APIServerServiceName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -492,7 +493,7 @@ func (e *etcdGateway) resyncEtcdMasters(ctx context.Context, client *etcdv3.Clie
 		return trace.Wrap(err, "failed to update etcd environment file").AddField("file", DefaultEtcdSyncedEnvFile)
 	}
 
-	err = systemctl(ctx, "restart", ETCDServiceName)
+	_, err = systemctl(ctx, "restart", ETCDServiceName)
 	if err != nil {
 		return trace.Wrap(err, "failed to restart etcd service").AddField("service", ETCDServiceName)
 	}
@@ -738,11 +739,11 @@ func convertError(err error) error {
 // systemctl runs a local systemctl command in non-blocking mode.
 // TODO(knisbet): I'm using systemctl here, because using go-systemd and dbus appears to be unreliable, with
 // masking unit files not working. Ideally, this will use dbus at some point in the future.
-func systemctl(ctx context.Context, operation, service string) error {
+func systemctl(ctx context.Context, operation, service string) (string, error) {
 	return systemctlCmd(ctx, operation, service, "--no-block")
 }
 
-func systemctlCmd(ctx context.Context, operation, service string, args ...string) error {
+func systemctlCmd(ctx context.Context, operation, service string, args ...string) (string, error) {
 	args = append([]string{operation, service}, args...)
 	out, err := exec.CommandContext(ctx, "/bin/systemctl", args...).CombinedOutput()
 	log.WithFields(log.Fields{
@@ -751,12 +752,38 @@ func systemctlCmd(ctx context.Context, operation, service string, args ...string
 		"service":   service,
 	}).Info("Execute systemctl.")
 	if err != nil {
-		return trace.Wrap(err, "failed to execute systemctl: %s", out).AddFields(map[string]interface{}{
+		return "", trace.Wrap(err, "failed to execute systemctl: %s", out).AddFields(map[string]interface{}{
 			"operation": operation,
 			"service":   service,
 		})
 	}
-	return nil
+	return out
+}
+
+// systemctlGetPropertyValue returns the value of the systemctl unit/job/manager property
+// https://www.freedesktop.org/software/systemd/man/systemctl.html#-p
+// Note(Sergei): from the source code looks like the return code is always 0
+func systemctlGetPropertyValue(ctx context.Context, property, service string) (string, error) {
+	out, err := systemctl(ctx, "show", "--property", property, "--value", service)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return out, nil
+	
+}
+
+// systemctlGetPID returns the PID of the service
+// Note(Sergei): from manual testing for a stopped process MainPID is always 0
+func systemctlGetPID(ctx context.Context, service string) (int, error) {
+	out, err := systemctlGetPropertyValue(ctx, "MainPID", "etcd")
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	mainPID, err := strconv.Atoi(string(out))
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return mainPID, nil
 }
 
 // waitForEtcdStopped waits for etcd to not be present in the process list
@@ -773,14 +800,12 @@ loop:
 		case <-ticker.C:
 		}
 
-		procs, err := ps.Processes()
+		pid, err := systemctlGetPID(ctx, "etcd")
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		for _, proc := range procs {
-			if proc.Executable() == "etcd" {
-				continue loop
-			}
+		if pid > 0 {
+			continue loop
 		}
 		return nil
 	}
@@ -789,18 +814,18 @@ loop:
 // tryResetService will request for systemd to restart a system service
 func tryResetService(ctx context.Context, service string) {
 	// ignoring error results is intentional
-	err := systemctl(ctx, "restart", service)
+	_, err := systemctl(ctx, "restart", service)
 	if err != nil {
 		log.Warn("error attempting to restart service", err)
 	}
 }
 
 func disableService(ctx context.Context, service string) error {
-	err := systemctl(ctx, "mask", service)
+	_, err := systemctl(ctx, "mask", service)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = systemctl(ctx, "stop", service)
+	_, err = systemctl(ctx, "stop", service)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -808,11 +833,12 @@ func disableService(ctx context.Context, service string) error {
 }
 
 func enableService(ctx context.Context, service string) error {
-	err := systemctl(ctx, "unmask", service)
+	_, err := systemctl(ctx, "unmask", service)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(systemctl(ctx, "start", service))
+	_, err = systemctl(ctx, "start", service)
+	return trace.Wrap(err)
 }
 
 func getServiceStatus(service string) (string, error) {

--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -42,7 +42,6 @@ import (
 	etcdconf "github.com/gravitational/coordinate/config"
 	backup "github.com/gravitational/etcd-backup/lib/etcd"
 	"github.com/gravitational/trace"
-	ps "github.com/mitchellh/go-ps"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	etcd "go.etcd.io/etcd/client"
@@ -757,14 +756,14 @@ func systemctlCmd(ctx context.Context, operation, service string, args ...string
 			"service":   service,
 		})
 	}
-	return out
+	return string(out), nil
 }
 
 // systemctlGetPropertyValue returns the value of the systemctl unit/job/manager property
 // https://www.freedesktop.org/software/systemd/man/systemctl.html#-p
 // Note(Sergei): from the source code looks like the return code is always 0
 func systemctlGetPropertyValue(ctx context.Context, property, service string) (string, error) {
-	out, err := systemctl(ctx, "show", "--property", property, "--value", service)
+	out, err := systemctlCmd(ctx, "show", service, "--no-block", "--property", property, "--value")
 	if err != nil {
 		return "", trace.Wrap(err)
 	}


### PR DESCRIPTION
The current implementation of `waitForEtcdStopped` could hang forever if there are any etcd processes running on the cluster, i.e. inside pods. This implementation takes information about our main etcd PID from the systemd.