### PR TITLE
[6.1.x] keep the package manifest in the resulting image

### DIFF
--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -52,6 +52,7 @@ planet-image:
 	sed -i "s/REPLACE_DOCKER_LATEST_VERSION/$(DOCKER_VER)/g" $(TARGETDIR)/orbit.manifest.json
 	sed -i "s/REPLACE_HELM_LATEST_VERSION/$(HELM_VER)/g" $(TARGETDIR)/orbit.manifest.json
 	sed -i "s/REPLACE_COREDNS_LATEST_VERSION/$(COREDNS_VER)/g" $(TARGETDIR)/orbit.manifest.json
+	cp $(TARGETDIR)/orbit.manifest.json $(ROOTFS)/etc/planet/
 	@echo -e "\n---> Creating Planet image...\n"
 	cd $(TARGETDIR) && fakeroot -- sh -c ' \
 		chown -R 1000:1000 . ; \


### PR DESCRIPTION
Copy the package manifest into `/etc/planet` to keep it consistent as part of the docker image.
Since this is the location where the `tele build` will pull the manifest from when translating the image into a gravity package if a custom system container has been configured.