### PR TITLE
[7.0.x] keep the package manifest in the resulting image

### DIFF
--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -60,6 +60,7 @@ planet-image:
 	sed -i "s/REPLACE_HELM_LATEST_VERSION/$(HELM_VER)/g" $(TARGETDIR)/orbit.manifest.json
 	sed -i "s/REPLACE_COREDNS_LATEST_VERSION/$(COREDNS_VER)/g" $(TARGETDIR)/orbit.manifest.json
 	sed -i "s/REPLACE_NODE_PROBLEM_DETECTOR_LATEST_VERSION/$(NODE_PROBLEM_DETECTOR_VER)/g" $(TARGETDIR)/orbit.manifest.json
+	cp $(TARGETDIR)/orbit.manifest.json $(ROOTFS)/etc/planet/
 	@echo -e "\n---> Creating Planet image...\n"
 	cd $(TARGETDIR) && fakeroot -- sh -c ' \
 		chown -R $(PLANET_UID):$(PLANET_GID) . ; \


### PR DESCRIPTION
Copy the package manifest into /etc/planet to keep it consistent as part of the docker image.
Since this is the location where the tele build will pull the manifest from when translating the image into a gravity package if a custom system container has been configured.

Ports https://github.com/gravitational/planet/pull/717.