### PR TITLE
[5.5] CVE-2020-8558

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.13.12
+KUBE_VER ?= v1.13.13-gravitational.0
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 18.06.2
 # we currently use our own flannel fork: gravitational/flannel

--- a/build.assets/makefiles/kubernetes/kubernetes.mk
+++ b/build.assets/makefiles/kubernetes/kubernetes.mk
@@ -1,7 +1,7 @@
 .PHONY: all
 
 CURL_OPTS := -s
-DOWNLOAD_URL := https://storage.googleapis.com/kubernetes-release/release/$(KUBE_VER)/bin/linux/amd64
+DOWNLOAD_URL := https://s3-us-west-2.amazonaws.com/dev.gravitational.io/kubernetes-release/release/$(KUBE_VER)/linux/amd64
 REPODIR := $(GOPATH)/src/github.com/kubernetes/kubernetes
 OUTPUTDIR := $(ASSETDIR)/k8s-$(KUBE_VER)
 BINARIES := kube-apiserver \


### PR DESCRIPTION
Customer backport request for CVE-2020-8558 to kubernetes 1.13

- Pull kubernetes binaries from forked builds
- Update kubernetes version to v1.13.13-gravitational.0