### PR TITLE
(7.0) Increase default systemd max files

### DIFF
--- a/build.assets/makefiles/base/systemd/Makefile
+++ b/build.assets/makefiles/base/systemd/Makefile
@@ -3,3 +3,5 @@
 all:
 	mkdir -p $(ROOTFS)/lib/systemd/system/systemd-journald.service.d/
 	cp -af ./journald.conf $(ROOTFS)/lib/systemd/system/systemd-journald.service.d/
+	mkdir -p $(ROOTFS)/etc/systemd/system.conf.d/
+	cp -af ./system.conf $(ROOTFS)/etc/systemd/system.conf.d/

--- a/build.assets/makefiles/base/systemd/system.conf
+++ b/build.assets/makefiles/base/systemd/system.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE=655350:655350


### PR DESCRIPTION
Ran into the issue with kube-apiserver exhausting max number of open files today since the default soft limit is low (1024). This PR increases it. Refs https://github.com/gravitational/gravity/issues/2020.