### PR TITLE
(5.5) Update state directory checker to check uid/gid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,7 +365,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e310ffdbd5a2f0936023af96e95344babb2a86c08a89884b355baca68c7b3e05"
+  digest = "1:859861c28476a5986cedaa2f9c5d6d9342e4987ffc979160549d3578f9e1506a"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -387,8 +387,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "119e0df3db436e590cae1c5d2e5cac8398c88fe6"
-  version = "5.5.22"
+  revision = "4f1e28e8c0fa4369a425bd70c6d0224f4c36275d"
+  version = "5.5.24"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,132 +23,132 @@
 ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/*"]
 
 [prune]
-  go-tests = true
-  unused-packages = true
+go-tests = true
+unused-packages = true
 
 [[override]]
-  name = "github.com/coreos/go-systemd"
-  version = "v16"
+name = "github.com/coreos/go-systemd"
+version = "v16"
 
 [[override]]
-  name = "bitbucket.org/ww/goautoneg"
-  # Bitbucket doesn't support git protocol, which causes dep to timeout trying to connect
-  # force to https url instead
-  source = "https://bitbucket.org/ww/goautoneg.git"
+name = "bitbucket.org/ww/goautoneg"
+# Bitbucket doesn't support git protocol, which causes dep to timeout trying to connect
+# force to https url instead
+source = "https://bitbucket.org/ww/goautoneg.git"
 
 [[override]]
-  name = "github.com/hashicorp/serf"
-  revision = "11bb88abf7b17f0b794b51416a9107d781e95f35"
+name = "github.com/hashicorp/serf"
+revision = "11bb88abf7b17f0b794b51416a9107d781e95f35"
 
 [[override]]
-  # target codec version from etcd, since dep doesn't seem to grab it correctly
-  # https://github.com/coreos/etcd/issues/8715#issuecomment-377013707
-  name = "github.com/ugorji/go"
-  version = "v1.1.1"
+# target codec version from etcd, since dep doesn't seem to grab it correctly
+# https://github.com/coreos/etcd/issues/8715#issuecomment-377013707
+name = "github.com/ugorji/go"
+version = "v1.1.1"
 
 [[override]]
-  name = "golang.org/x/sys"
-  revision = "78d5f264b493f125018180c204871ecf58a2dce1"
+name = "golang.org/x/sys"
+revision = "78d5f264b493f125018180c204871ecf58a2dce1"
 
 [[override]]
-  name = "github.com/syndtr/gocapability"
-  revision = "33e07d32887e1e06b7c025f27ce52f62c7990bc0"
+name = "github.com/syndtr/gocapability"
+revision = "33e07d32887e1e06b7c025f27ce52f62c7990bc0"
 
 [[constraint]]
-  name = "github.com/containerd/console"
-  revision = "cb7008ab3d8359b78c5f464cb7cf160107ad5925"
+name = "github.com/containerd/console"
+revision = "cb7008ab3d8359b78c5f464cb7cf160107ad5925"
 
 [[constraint]]
-  name = "github.com/cenkalti/backoff"
-  version = "2.0.0"
+name = "github.com/cenkalti/backoff"
+version = "2.0.0"
 
 [[constraint]]
-  name = "github.com/coreos/etcd"
-  version = "3.3.3"
+name = "github.com/coreos/etcd"
+version = "3.3.3"
 
 [[constraint]]
-  name = "github.com/docker/docker"
-  version = "=1.9.1"
+name = "github.com/docker/docker"
+version = "=1.9.1"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/gravitational/configure"
+branch = "master"
+name = "github.com/gravitational/configure"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/gravitational/coordinate"
+branch = "master"
+name = "github.com/gravitational/coordinate"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/gravitational/go-udev"
+branch = "master"
+name = "github.com/gravitational/go-udev"
 
 [[constraint]]
-  name = "golang.org/x/net"
-  branch = "release-branch.go1.9"
+branch = "release-branch.go1.9"
+name = "golang.org/x/net"
 
 [[constraint]]
-  name = "github.com/gravitational/satellite"
-  version = "=5.5.22"
+name = "github.com/gravitational/satellite"
+version = "=5.5.24"
 
 [[constraint]]
-  name = "github.com/gravitational/trace"
-  version = "=1.1.10"
+name = "github.com/gravitational/trace"
+version = "=1.1.10"
 
 [[constraint]]
-  name = "github.com/julienschmidt/httprouter"
-  version = "1.1.0"
+name = "github.com/julienschmidt/httprouter"
+version = "1.1.0"
 
 [[constraint]]
-  name = "github.com/opencontainers/runc"
-  version = "v1.0.0-rc5"
+name = "github.com/opencontainers/runc"
+version = "v1.0.0-rc5"
 
 [[constraint]]
-  name = "github.com/prometheus/client_golang"
-  version = ">=0.7.0, <=64.0.0-g275368f"
+name = "github.com/prometheus/client_golang"
+version = ">=0.7.0, <=64.0.0-g275368f"
 
 [[constraint]]
-  name = "github.com/sirupsen/logrus"
-  source = "github.com/gravitational/logrus"
-  version = "1.0.6"
+name = "github.com/sirupsen/logrus"
+source = "github.com/gravitational/logrus"
+version = "1.0.6"
 
 [[constraint]]
-  name = "gopkg.in/alecthomas/kingpin.v2"
-  source = "github.com/gravitational/kingpin"
-  #version = "=v2.2.7"
-  branch = "telekube"
+name = "gopkg.in/alecthomas/kingpin.v2"
+source = "github.com/gravitational/kingpin"
+#version = "=v2.2.7"
+branch = "telekube"
 
 [[constraint]]
-  name = "k8s.io/client-go"
-  version = "=v10.0.0"
+name = "k8s.io/client-go"
+version = "=v10.0.0"
 
 [[constraint]]
-  name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.3"
+name = "k8s.io/apimachinery"
+version = "kubernetes-1.13.3"
 
 [[constraint]]
-  name = "k8s.io/api"
-  version = "kubernetes-1.13.3"
+name = "k8s.io/api"
+version = "kubernetes-1.13.3"
 
 [[constraint]]
-  name = "k8s.io/kubelet"
-  version = "kubernetes-1.13.3"
+name = "k8s.io/kubelet"
+version = "kubernetes-1.13.3"
 
 [[constraint]]
-  name = "github.com/fatih/color"
-  version = "v1.7.0"
+name = "github.com/fatih/color"
+version = "v1.7.0"
 
 [[constraint]]
-  name = "github.com/ghodss/yaml"
-  revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+name = "github.com/ghodss/yaml"
+revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 
 [[constraint]]
-  name = "github.com/mattn/go-isatty"
-  version = "=v0.0.9"
+name = "github.com/mattn/go-isatty"
+version = "=v0.0.9"
 
 [[constraint]]
-  version = "=0.0.2"
-  name = "github.com/gravitational/etcd-backup"
+name = "github.com/gravitational/etcd-backup"
+version = "=0.0.2"
 
 [[override]]
-  name = "github.com/json-iterator/go"
-  version = "1.1.5"
+name = "github.com/json-iterator/go"
+version = "1.1.5"

--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -351,6 +351,14 @@
             },
             {
                 "type": "String",
+                "name": "servicegid",
+                "env": "PLANET_SERVICE_GID",
+                "cli": {
+                    "name": "service-gid"
+                }
+            },
+            {
+                "type": "String",
                 "name": "gcenodetags",
                 "env": "PLANET_GCE_NODE_TAGS",
                 "cli": {

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,6 +73,10 @@ type Config struct {
 	LowWatermark uint
 	// HighWatermark is the disk usage critical limit percentage of monitored directories
 	HighWatermark uint
+	// ServiceUID is the UID of the service (planet) user.
+	ServiceUID string
+	// ServiceGID is the GID of the service (planet) user.
+	ServiceGID string
 	// HTTPTimeout specifies the HTTP timeout for checks
 	HTTPTimeout time.Duration
 }
@@ -120,6 +125,31 @@ func (c *Config) LocalTransport() (*http.Transport, error) {
 			MinVersion:   tls.VersionTLS10,
 			RootCAs:      roots,
 		}}, nil
+}
+
+// storageCheckerConfig returns checker config for the state directory.
+func (c *Config) storageCheckerConfig() (config *monitoring.StorageConfig, err error) {
+	config = &monitoring.StorageConfig{
+		Path:          constants.GravityDataDir,
+		LowWatermark:  c.LowWatermark,
+		HighWatermark: c.HighWatermark,
+	}
+	var uid, gid uint64
+	if c.ServiceUID != "" {
+		if uid, err = strconv.ParseUint(c.ServiceUID, 10, 32); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		uid32 := uint32(uid)
+		config.UID = &uid32
+	}
+	if c.ServiceGID != "" {
+		if gid, err = strconv.ParseUint(c.ServiceGID, 10, 32); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		gid32 := uint32(gid)
+		config.GID = &gid32
+	}
+	return config, nil
 }
 
 // GetKubeClient returns a Kubernetes client that uses kubectl certificate
@@ -215,13 +245,11 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 		"leader.telekube.local.",
 	}))
 
-	storageChecker, err := monitoring.NewStorageChecker(
-		monitoring.StorageConfig{
-			Path:          constants.GravityDataDir,
-			LowWatermark:  config.LowWatermark,
-			HighWatermark: config.HighWatermark,
-		},
-	)
+	storageCheckerConfig, err := config.storageCheckerConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	storageChecker, err := monitoring.NewStorageChecker(*storageCheckerConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -322,13 +350,11 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 	}))
 	node.AddChecker(monitoring.NewNodeStatusChecker(nodeConfig, config.NodeName))
 
-	storageChecker, err := monitoring.NewStorageChecker(
-		monitoring.StorageConfig{
-			Path:          constants.GravityDataDir,
-			LowWatermark:  config.LowWatermark,
-			HighWatermark: config.HighWatermark,
-		},
-	)
+	storageCheckerConfig, err := config.storageCheckerConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	storageChecker, err := monitoring.NewStorageChecker(*storageCheckerConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -161,6 +161,7 @@ func (cfg *Config) checkAndSetDefaults() (err error) {
 type serviceUser struct {
 	*user.User
 	UID string
+	GID string
 }
 
 func (cfg *Config) KubeDNSResolverIP() string {

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -191,7 +191,7 @@ const (
 	// timeout for monitoring checks
 	EnvPlanetAgentHTTPTimeout = "PLANET_AGENT_HTTP_TIMEOUT"
 
-	// EnvServiceGID names the environment variable that specifies the service user ID
+	// EnvServiceUID names the environment variable that specifies the service user ID
 	EnvServiceUID = "PLANET_SERVICE_UID"
 	// EnvServiceGID names the environment variable that specifies the service group ID
 	EnvServiceGID = "PLANET_SERVICE_GID"

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -110,7 +110,8 @@ func run() error {
 					OverrideDefaultFromEnvar(EnvPlanetFeatureGates).
 					String()
 		cstartVxlanPort               = cstart.Flag("vxlan-port", "overlay network port").Default(strconv.Itoa(DefaultVxlanPort)).OverrideDefaultFromEnvar(EnvVxlanPort).Int()
-		cstartServiceUID              = cstart.Flag("service-uid", "service user ID. Service user is used for services that do not require elevated permissions").OverrideDefaultFromEnvar(EnvServiceUID).String()
+		cstartServiceUID              = cstart.Flag("service-uid", "Service user ID. Service user is used for services that do not require elevated permissions").OverrideDefaultFromEnvar(EnvServiceUID).String()
+		cstartServiceGID              = cstart.Flag("service-gid", "Service user group ID").OverrideDefaultFromEnvar(EnvServiceGID).String()
 		cstartSelfTest                = cstart.Flag("self-test", "Run end-to-end tests on the started cluster").Bool()
 		cstartTestSpec                = cstart.Flag("test-spec", "Regexp of the test specs to run (self-test mode only)").Default("Networking|Pods").String()
 		cstartTestKubeRepoPath        = cstart.Flag("repo-path", "Path to either a k8s repository or a directory with test configuration files (self-test mode only)").String()
@@ -169,6 +170,8 @@ func run() error {
 		cagentCloudProvider          = cagent.Flag("cloud-provider", "Which cloud provider backend the cluster is using").OverrideDefaultFromEnvar(EnvCloudProvider).String()
 		cagentLowWatermark           = cagent.Flag("low-watermark", "Low disk usage percentage of monitored directories").Default(strconv.Itoa(LowWatermark)).OverrideDefaultFromEnvar("PLANET_LOW_WATERMARK").Uint64()
 		cagentHighWatermark          = cagent.Flag("high-watermark", "High disk usage percentage of monitored directories").Default(strconv.Itoa(HighWatermark)).OverrideDefaultFromEnvar("PLANET_HIGH_WATERMARK").Uint64()
+		cagentServiceUID             = cagent.Flag("service-uid", "UID of the service user (planet)").OverrideDefaultFromEnvar(EnvServiceUID).String()
+		cagentServiceGID             = cagent.Flag("service-gid", "GID of the service user (planet)").OverrideDefaultFromEnvar(EnvServiceGID).String()
 		cagentHTTPTimeout            = cagent.Flag("http-timeout", "Timeout for HTTP requests, formatted as Go duration.").OverrideDefaultFromEnvar(EnvPlanetAgentHTTPTimeout).Default(constants.HTTPTimeout.String()).Duration()
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
@@ -357,6 +360,8 @@ func run() error {
 			HighWatermark:         uint(*cagentHighWatermark),
 			NodeName:              *cagentNodeName,
 			HTTPTimeout:           *cagentHTTPTimeout,
+			ServiceUID:            *cagentServiceUID,
+			ServiceGID:            *cagentServiceGID,
 		}
 		leaderConf := &LeaderConfig{
 			PublicIP:        cagentPublicIP.String(),
@@ -430,6 +435,7 @@ func run() error {
 			InitialCluster:       *cstartInitialCluster,
 			ServiceUser: serviceUser{
 				UID: *cstartServiceUID,
+				GID: *cstartServiceGID,
 			},
 			EtcdProxy:               *cstartEtcdProxy,
 			EtcdMemberName:          *cstartEtcdMemberName,

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -161,6 +161,8 @@ func start(config *Config, monitorc chan<- bool) (*runtimeContext, error) {
 		box.EnvPair{Name: EnvElectionEnabled, Val: strconv.FormatBool(config.ElectionEnabled)},
 		box.EnvPair{Name: EnvDNSHosts, Val: config.DNS.Hosts.String()},
 		box.EnvPair{Name: EnvDNSZones, Val: config.DNS.Zones.String()},
+		box.EnvPair{Name: EnvServiceUID, Val: config.ServiceUser.UID},
+		box.EnvPair{Name: EnvServiceGID, Val: config.ServiceUser.GID},
 	)
 
 	// Setup http_proxy / no_proxy environment configuration

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import "fmt"
+
+// KernelVersion describes an abbreviated version of a Linux kernel.
+// It contains the kernel version (including major/minor components) and
+// patch number
+//
+// Example:
+//  $ uname -r
+//  $ 4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+type KernelVersion struct {
+	// Release specifies the release of the kernel
+	Release int
+	// Major specifies the major version component
+	Major int
+	// Minor specifies the minor version component
+	Minor int
+	// Patch specifies the patch or build number
+	Patch int
+}
+
+// String returns the kernel version formatted as Release.Major.Minor-Patch.
+func (r *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
@@ -17,39 +17,12 @@ limitations under the License.
 package monitoring
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/gravitational/trace"
 )
-
-// KernelVersion describes an abbreviated version of a Linux kernel.
-// It contains the kernel version (including major/minor components) and
-// patch number
-//
-// Example:
-//  $ uname -r
-//  $ 4.4.9-112-generic
-//
-// The result will be:
-//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
-type KernelVersion struct {
-	// Release specifies the release of the kernel
-	Release int
-	// Major specifies the major version component
-	Major int
-	// Minor specifies the minor version component
-	Minor int
-	// Patch specifies the patch or build number
-	Patch int
-}
-
-// String returns the kernel version formatted as Release.Major.Minor-Patch.
-func (r *KernelVersion) String() string {
-	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
-}
 
 // KernelConstraintFunc is a function to determine if the kernel version
 // satisfies a particular condition.

--- a/vendor/github.com/gravitational/satellite/monitoring/storage.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,6 +41,10 @@ type StorageConfig struct {
 	// HighWatermark is the disk occupancy percentage that will trigger a critical probe.
 	// Disk usage check will be skipped if HighWatermark is unspecified or 0.
 	HighWatermark uint
+	// UID is the expected user owner of the path.
+	UID *uint32
+	// GID is the expected group owner of the path.
+	GID *uint32
 }
 
 // CheckAndSetDefaults validates this configuration object.
@@ -101,3 +105,49 @@ func (d HighWatermarkCheckerData) SuccessMessage() string {
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// PathUIDCheckerData is attached to path UID check results.
+type PathUIDCheckerData struct {
+	// ExpectedUID is the expected path UID.
+	ExpectedUID uint32 `json:"expected_uid"`
+	// ActualUID is the actual path UID.
+	ActualUID uint32 `json:"actual_uid"`
+	// Path is the path being checked.
+	Path string
+}
+
+// SuccessMessage returns success UID check message.
+func (d PathUIDCheckerData) SuccessMessage() string {
+	return fmt.Sprintf("path %s owner UID is %v", d.Path, d.ActualUID)
+}
+
+// FailureMessage return failure UID check message.
+func (d PathUIDCheckerData) FailureMessage() string {
+	return fmt.Sprintf("path %s owner UID is %v but is expected to be %v", d.Path, d.ActualUID, d.ExpectedUID)
+}
+
+// PathGIDCheckerData is attached to path GID check results.
+type PathGIDCheckerData struct {
+	// ExpectedGID is the expected path GID.
+	ExpectedGID uint32 `json:"expected_gid"`
+	// ActualGID is the actual path GID.
+	ActualGID uint32 `json:"actual_gid"`
+	// Path is the path being checked.
+	Path string
+}
+
+// SuccessMessage returns success GID check message.
+func (d PathGIDCheckerData) SuccessMessage() string {
+	return fmt.Sprintf("path %s owner GID is %v", d.Path, d.ActualGID)
+}
+
+// FailureMessage return failure GID check message.
+func (d PathGIDCheckerData) FailureMessage() string {
+	return fmt.Sprintf("path %s owner GID is %v but is expected to be %v", d.Path, d.ActualGID, d.ExpectedGID)
+}
+
+// PathUIDCheckerID is the checker that verifies path owner UID.
+const PathUIDCheckerID = "path-uid"
+
+// PathGIDCheckerID is the checker that verifies path owner GID.
+const PathGIDCheckerID = "path-gid"

--- a/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/storage_linux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/satellite/agent/health"
@@ -34,7 +35,6 @@ import (
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
-	syscall "golang.org/x/sys/unix"
 )
 
 // NewStorageChecker creates a new instance of the volume checker
@@ -88,6 +88,7 @@ func (c *storageChecker) check(ctx context.Context, reporter health.Reporter) er
 
 	return trace.NewAggregate(c.checkFsType(ctx, reporter),
 		c.checkCapacity(ctx, reporter),
+		c.checkOwner(reporter),
 		c.checkDiskUsage(ctx, reporter),
 		c.checkWriteSpeed(ctx, reporter))
 }
@@ -144,6 +145,72 @@ func (c *storageChecker) checkFsType(ctx context.Context, reporter health.Report
 			c.Path, c.Filesystems, mnt.DirName, mnt.SysTypeName)
 	}
 	reporter.Add(probe)
+	return nil
+}
+
+// checkOwner verifies that the configured path is owned by the correct user/group.
+func (c *storageChecker) checkOwner(reporter health.Reporter) error {
+	if c.UID == nil && c.GID == nil {
+		return nil
+	}
+	uid, gid, err := c.osInterface.getUIDGID(c.Path)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if c.UID != nil {
+		data := PathUIDCheckerData{
+			Path:        c.Path,
+			ExpectedUID: *c.UID,
+			ActualUID:   uid,
+		}
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if *c.UID != uid {
+			reporter.Add(&pb.Probe{
+				Checker:     PathUIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Failed,
+				Severity:    pb.Probe_Warning,
+				Detail:      data.FailureMessage(),
+			})
+		} else {
+			reporter.Add(&pb.Probe{
+				Checker:     PathUIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Running,
+				Detail:      data.SuccessMessage(),
+			})
+		}
+	}
+	if c.GID != nil {
+		data := PathGIDCheckerData{
+			Path:        c.Path,
+			ExpectedGID: *c.GID,
+			ActualGID:   gid,
+		}
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if *c.GID != gid {
+			reporter.Add(&pb.Probe{
+				Checker:     PathGIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Failed,
+				Severity:    pb.Probe_Warning,
+				Detail:      data.FailureMessage(),
+			})
+		} else {
+			reporter.Add(&pb.Probe{
+				Checker:     PathGIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Running,
+				Detail:      data.SuccessMessage(),
+			})
+		}
+	}
 	return nil
 }
 
@@ -349,6 +416,22 @@ func (r realOS) diskCapacity(path string) (bytesAvail, bytesTotal uint64, err er
 	return bytesAvail, bytesTotal, nil
 }
 
+// getUIDGID returns the specified path's owner uid and gid.
+func (r realOS) getUIDGID(path string) (uid uint32, gid uint32, err error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, trace.Wrap(err)
+	}
+	if fi.Sys() == nil {
+		return 0, 0, trace.BadParameter("fileinfo is missing sysinfo: %v", fi)
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, trace.BadParameter("fileinfo unexpected sysinfo type: %[1]v %[1]T", fi.Sys())
+	}
+	return stat.Uid, stat.Gid, nil
+}
+
 func writeN(ctx context.Context, file *os.File, buf []byte, n int) error {
 	for i := 0; i < n; i++ {
 		_, err := file.Write(buf)
@@ -372,4 +455,5 @@ type osInterface interface {
 	mountInfo
 	diskSpeed(ctx context.Context, path, name string) (bps uint64, err error)
 	diskCapacity(path string) (bytesAvailable, bytesTotal uint64, err error)
+	getUIDGID(path string) (uid uint32, gid uint32, err error)
 }


### PR DESCRIPTION
This pull requests updates the existing storage checker that checks /var/lib/gravity directory to also check that its uid/gid are expected (match service user/group). Requires https://github.com/gravitational/satellite/pull/255. Refs https://github.com/gravitational/gravity/issues/2022.