### PR TITLE
enable etcd compactor and tune election timeouts

### DIFF
--- a/build.assets/makefiles/etcd/etcd.service
+++ b/build.assets/makefiles/etcd/etcd.service
@@ -32,6 +32,9 @@ ExecStart=/usr/bin/etcd \
         --peer-trusted-ca-file=/var/state/root.cert \
         --peer-client-cert-auth=true \
         --max-request-bytes=10485760 \
+        --auto-compaction-retention=24h \
+        --heartbeat-interval=250 \
+        --election-timeout=4000 \
         --enable-v2=true \
         $ETCD_OPTS
 User=planet


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2025

**Enable auto compaction**
etcd docs: https://etcd.io/docs/v3.4.0/op-guide/maintenance/

Set to 24 hours. This is certainly an arbitrary value, set to a sufficiently large value that we shouldn't be compacting anything that is needed. I'm not aware of anything that actually needs a sufficient revision window, accept for recovering watches, which I don't expect we'll have any stall for an hour, let alone 24 hours.

**Tune etcd elections**
etcd docs: https://etcd.io/docs/v3.4.0/tuning/

This tuning sort of steps away from the recommendations by etcd, by tuning elections to be a little more generous at the 
cost of fast detection of a failed node. We quite frequently run into customers experiencing problems with election stability by being unable or unwilling to dedicate disks to etcd. Fsync latency's block heartbeats, which cause a node waiting on fsync to appear to be down.

Using customer T's debug reports as a basis, I do see fsync latencies occur in the 1-4 second range about 0.1% of the time on one of the worst nodes and all nodes do see latencies in the 1-4s range. They also see fsync latencies in the 4-8 second range though, so this tuning wouldn't cause elections to remain stable through every fsync captured in the metrics. We could consider going to 5 or 6 seconds, but we'd still be well above client timeouts, and with large spikes like that we'd probably see problems in the clients regardless of election stability (IE the failover of the election becomes a small part of the interruption). What we give up, is if a node fails, it takes longer for etcd to detect this and failover. Our planet elections are 10s though, so we already don't really guarentee an HA time of less than 10 seconds. 

The counter argument to not tuning this, is that the fsync latencies are going to cause performance issues regardless of the stability of elections. The etcd elections create a clear indicator that the underlying IO is not performing within expectations, and the election timing may just mask the fact that etcd fails over on slow IO, but all the rest of the cluster symptoms remain. 

- Election Timeouts: 4s (default 1s)

The justification sort of is, we see somewhat routine spikes into the 1-4 second range within this customer, and it seems reasonable to assume this is the range we've also seen in other customers experiencing IO spikes. 4s chosen because higher numbers seem unlikely to really help the worst offenders for fsync latencies.

- Heartbeat Interval: 250ms (default 100ms)
Tuning the heartbeat interval doesn't matter as much to the election process, as long as it's atleast 1/10th the election timeout. Strictly speaking we may not want to back it off since 100ms is already quite long for any network we support, but I think it makes sense to back this off from 10/s to 4/s to spend slightly less time performing heartbeats, when we have a 4x election timeout. 


@r0mant @UnderGreen @a-palchikov Thoughts on the election tuning?

