### PR TITLE
always use latest version of etcd when starting gateway (#738)

### DIFF
--- a/tool/planet/etcd.go
+++ b/tool/planet/etcd.go
@@ -75,6 +75,18 @@ func etcdInit() error {
 			currentVersion = desiredVersion
 		}
 	}
+
+	env, err := box.ReadEnvironment(ContainerEnvironmentFile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// The etcd gateway is not version dependent (it's an L4 load balancer). We can always use the latest version when
+	// planet rolls.
+	if env.Get(EnvEtcdProxy) == EtcdProxyOn {
+		currentVersion = desiredVersion
+	}
+
 	log.Info("Current etcd version: ", currentVersion)
 
 	// symlink /usr/bin/etcd to the version we expect to be running


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2068
Ports https://github.com/gravitational/planet/pull/738

Fixes an oversight that crept in at some point, where the upgrade steps of etcd skip upgrading etcd when in gateway mode, but the gateway also doesn't just update when planet restart. Just make sure to use the latest version of etcd when in gateway mode (a worker) during startup.