### PR TITLE
(6.1) Bump helm to 2.15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 18.09.9
 # we currently use our own flannel fork: gravitational/flannel
 FLANNEL_VER := v0.10.1-gravitational
-HELM_VER := v2.14.3
+HELM_VER := v2.15.2
 COREDNS_VER := 1.7.0
 SERF_VER := v0.8.5
 


### PR DESCRIPTION
Upgrade helm binary in planet to 2.15.2. Refs https://github.com/gravitational/gravity/issues/2116.