### PR TITLE
update iptables / satellite / flannel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ KUBE_VER ?= v1.17.9
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 19.03.12
 # we currently use our own flannel fork: gravitational/flannel
-FLANNEL_VER := v0.10.1-gravitational
+FLANNEL_VER := v0.10.2-gravitational
 HELM_VER := 2.15.0
 COREDNS_VER := 1.7.0
 NODE_PROBLEM_DETECTOR_VER := v0.6.4

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ COREDNS_VER := 1.7.0
 NODE_PROBLEM_DETECTOR_VER := v0.6.4
 CNI_VER := 0.8.6
 SERF_VER := v0.8.5
+IPTABLES_VER := v1.8.5
 
 # planet user to use inside the rootfs tarball. This serves as a placeholder
 # and the files will be owned by the actual planet user after extraction
@@ -185,7 +186,7 @@ os:
 base: os
 	@echo -e "\n---> Making Planet/Base Docker image based on Planet/OS...\n"
 	$(MAKE) -e BUILDIMAGE=$(PLANET_IMAGE) DOCKERFILE=base.dockerfile \
-		EXTRA_ARGS="--build-arg SECCOMP_VER=$(SECCOMP_VER) --build-arg PLANET_UID=$(PLANET_UID) --build-arg PLANET_GID=$(PLANET_GID) --build-arg PLANET_OS_IMAGE=$(PLANET_OS_IMAGE)" \
+		EXTRA_ARGS="--build-arg SECCOMP_VER=$(SECCOMP_VER) --build-arg IPTABLES_VER=$(IPTABLES_VER) --build-arg PLANET_UID=$(PLANET_UID) --build-arg PLANET_GID=$(PLANET_GID) --build-arg PLANET_OS_IMAGE=$(PLANET_OS_IMAGE)" \
 		make-docker-image
 
 # Build a container used for building the planet image

--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -2,6 +2,7 @@ ARG PLANET_OS_IMAGE=planet/os
 FROM $PLANET_OS_IMAGE
 
 ARG SECCOMP_VER
+ARG IPTABLES_VER
 ARG PLANET_UID
 ARG PLANET_GID
 
@@ -55,6 +56,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex && \
         && rm -rf /var/lib/apt/lists/*;
 
 # We need to use a newer version of iptables than debian has available
+# not ideal, but it's easier to run `make install` if we run this inline instead of a multi-stage build
 RUN export DEBIAN_FRONTEND=noninteractive && set -ex \
         && apt-get update \
         && apt-get install -q -y --allow-downgrades --no-install-recommends \
@@ -66,7 +68,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex \
         libmnl-dev \
         make \
         && mkdir /tmp/iptables.build \
-        && git clone git://git.netfilter.org/iptables.git --branch v1.6.2 --single-branch /tmp/iptables.build \
+        && git clone git://git.netfilter.org/iptables.git --branch ${IPTABLES_VER} --single-branch /tmp/iptables.build \
         && cd /tmp/iptables.build \
         && ./autogen.sh \
         && ./configure --disable-nftables \

--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -15,7 +15,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex && \
         bash-completion \
         kmod \
         libip4tc0=1.6.0+snapshot20161117-6 \
-        iptables \
         ebtables \
         libsqlite3-0 \
         e2fsprogs \
@@ -53,6 +52,35 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex && \
         strace \
         netbase \
         && apt-get -y autoclean && apt-get -y clean && apt-get autoremove \
+        && rm -rf /var/lib/apt/lists/*;
+
+# We need to use a newer version of iptables than debian has available
+RUN export DEBIAN_FRONTEND=noninteractive && set -ex \
+        && apt-get update \
+        && apt-get install -q -y --allow-downgrades --no-install-recommends \
+        git \
+        autoconf \
+        libtool \
+        automake \
+        pkg-config \
+        libmnl-dev \
+        make \
+        && mkdir /tmp/iptables.build \
+        && git clone git://git.netfilter.org/iptables.git --branch v1.6.2 --single-branch /tmp/iptables.build \
+        && cd /tmp/iptables.build \
+        && ./autogen.sh \
+        && ./configure --disable-nftables \
+        && make \
+        && make install \
+        && apt-get remove -y \
+        git \
+        autoconf \
+        libtool \
+        automake \
+        pkg-config \
+        libmnl-dev \
+        make \
+        && apt-get -y autoclean && apt-get -y clean && apt-get autoremove -y \
         && rm -rf /var/lib/apt/lists/*;
 
 RUN set -ex && \

--- a/build.assets/makefiles/base/network/network.mk
+++ b/build.assets/makefiles/base/network/network.mk
@@ -30,7 +30,7 @@ $(BINARIES): GOPATH := $(DIR)
 $(BINARIES):
 	mkdir -p $(DIR)/src/github.com/coreos
 	cd $(DIR)/src/github.com/coreos && git clone https://github.com/gravitational/flannel -b $(FLANNEL_VER) --depth 1
-	cd $(DIR)/src/github.com/coreos/flannel && go build -o flanneld .
+	cd $(DIR)/src/github.com/coreos/flannel && go build -mod=vendor -o flanneld .
 	cp $(DIR)/src/github.com/coreos/flannel/flanneld $@
 	rm -rf $(DIR)
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gravitational/coordinate v0.0.0-20200227044100-12af3c0f9593
 	github.com/gravitational/etcd-backup v0.0.0-20200227044745-5751e027911a
 	github.com/gravitational/go-udev v0.0.0-20160615210516-4cc8baba3689
-	github.com/gravitational/satellite v0.0.9-0.20200826203500-ad8030ab3ddb
+	github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485
 	github.com/gravitational/trace v1.1.11
 	github.com/gravitational/version v0.0.2-0.20170324200323-95d33ece5ce1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/gravitational/satellite v0.0.9-0.20200825155435-feccb39a021d h1:FBTLB
 github.com/gravitational/satellite v0.0.9-0.20200825155435-feccb39a021d/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200826203500-ad8030ab3ddb h1:XF4a8LC+T3e59ZczOkJopPL57p2/3zVmlfVcrneIOdc=
 github.com/gravitational/satellite v0.0.9-0.20200826203500-ad8030ab3ddb/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485 h1:P3y0wr2ctYUvS0034CWro5GUiixdoV14akmlMpNVBSg=
+github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/trace v1.1.11 h1:c+saoho5rBdj5lPEGzfHaYjh4Do4d+jX7hh4BgQtKc0=
 github.com/gravitational/trace v1.1.11/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d h1:vIgmA0qBCUgDSip4Gf0iqYCRv6fxsfHEJ2WHPVI35PQ=

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -330,7 +330,11 @@ func runAgent(conf *agent.Config, monitoringConf *monitoring.Config, leaderConf 
 
 	// only join to the initial seed list if not member already,
 	// as the initial peer could be gone
-	if !monitoringAgent.IsMember() && len(peers) > 0 {
+	isMember, err := monitoringAgent.IsMember()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !isMember && len(peers) > 0 {
 		log.Infof("joining the cluster: %v", peers)
 		err = monitoringAgent.Join(peers)
 		if err != nil {

--- a/vendor/github.com/gravitational/satellite/agent/agent.go
+++ b/vendor/github.com/gravitational/satellite/agent/agent.go
@@ -136,9 +136,6 @@ type agent struct {
 	// Config is the agent configuration.
 	Config
 
-	// ClusterMembership provides access to cluster membership service.
-	ClusterMembership membership.ClusterMembership
-
 	// ClusterTimeline keeps track of all timeline events in the cluster. This
 	// timeline is only used by members that have the role 'master'.
 	ClusterTimeline history.Timeline
@@ -180,6 +177,9 @@ type agent struct {
 	cancel context.CancelFunc
 	// g manages the internal agent's processes
 	g ctxgroup.Group
+
+	// newSerfClientFunc is used to create a serf client on demand.
+	newSerfClientFunc func() (membership.ClusterMembership, error)
 }
 
 // New creates an instance of an agent based on configuration options given in config.
@@ -188,13 +188,6 @@ func New(config *Config) (*agent, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	serfClient, err := initSerfClient(config.SerfConfig, config.Tags)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to initialize serf client")
-	}
-
-	// TODO: do we need to initialize metrics listener in constructor?
-	// Move to Start?
 	metricsListener, err := net.Listen("tcp", config.MetricsAddr)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to bind on %v to serve metrics", config.MetricsAddr)
@@ -234,7 +227,6 @@ func New(config *Config) (*agent, error) {
 	g := ctxgroup.WithContext(ctx)
 	agent := &agent{
 		Config:                  *config,
-		ClusterMembership:       serfClient,
 		ClusterTimeline:         clusterTimeline,
 		LocalTimeline:           localTimeline,
 		dialRPC:                 client.DefaultDialRPC(config.CAFile, config.CertFile, config.KeyFile),
@@ -246,25 +238,13 @@ func New(config *Config) (*agent, error) {
 		cancel:                  cancel,
 		g:                       g,
 	}
+	agent.newSerfClientFunc = agent.newSerfClient
 
 	agent.rpc, err = newRPCServer(agent, config.CAFile, config.CertFile, config.KeyFile, config.RPCAddrs)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to create RPC server")
 	}
 	return agent, nil
-}
-
-// initSerfClient initializes a new serf client and modifies the client with
-// the provided tags.
-func initSerfClient(config serf.Config, tags map[string]string) (*membership.RetryingClient, error) {
-	client, err := membership.NewSerfClient(config)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to connect to serf")
-	}
-	if err = client.UpdateTags(tags, nil); err != nil {
-		return nil, trace.Wrap(err, "failed to update serf agent tags")
-	}
-	return client, nil
 }
 
 // initTimeline initializes a new sqlite timeline. fileName specifies the
@@ -296,33 +276,41 @@ func (r *agent) Start() error {
 }
 
 // IsMember returns true if this agent is a member of the serf cluster
-func (r *agent) IsMember() bool {
-	members, err := r.ClusterMembership.Members()
+func (r *agent) IsMember() (ok bool, err error) {
+	client, err := r.newSerfClientFunc()
 	if err != nil {
-		log.WithError(err).Warn("Failed to retrieve members.")
-		return false
+		return false, trace.Wrap(err)
+	}
+	defer client.Close()
+	members, err := client.Members()
+	if err != nil {
+		return false, trace.Wrap(err, "failed to retrieve members")
 	}
 	// if we're the only one, consider that we're not in the cluster yet
 	// (cause more often than not there are more than 1 member)
 	if len(members) == 1 && members[0].Name() == r.Name {
-		return false
+		return false, nil
 	}
 	for _, member := range members {
 		if member.Name() == r.Name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // Join attempts to join a serf cluster identified by peers.
 func (r *agent) Join(peers []string) error {
-	noReplay := false
-	numJoined, err := r.ClusterMembership.Join(peers, noReplay)
+	client, err := r.newSerfClientFunc()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
+	defer client.Close()
+	noReplay := false
+	numJoined, err := client.Join(peers, noReplay)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	log.Infof("Joined %d nodes.", numJoined)
 	return nil
 }
@@ -333,9 +321,6 @@ func (r *agent) Close() (err error) {
 	r.cancel()
 	var errors []error
 	if err := r.g.Wait(); err != nil && !utils.IsContextCanceledError(err) {
-		errors = append(errors, err)
-	}
-	if err := r.ClusterMembership.Close(); err != nil {
 		errors = append(errors, err)
 	}
 	return trace.NewAggregate(errors...)
@@ -557,34 +542,54 @@ func (r *agent) statusUpdateLoop(ctx context.Context) error {
 func (r *agent) updateStatus(ctx context.Context) error {
 	ctxStatus, cancel := context.WithTimeout(ctx, r.statusQueryReplyTimeout)
 	defer cancel()
-	status, err := r.collectStatus(ctxStatus)
-	if err != nil {
-		return trace.Wrap(err, "error collecting system status")
-	}
-	if status == nil {
-		return nil
-	}
+	status := r.collectStatus(ctxStatus)
 	if err := r.Cache.UpdateStatus(status); err != nil {
 		return trace.Wrap(err, "error updating system status in cache")
 	}
 	return nil
 }
 
+func (r *agent) defaultUnknownStatus() *pb.NodeStatus {
+	return &pb.NodeStatus{
+		Name: r.Name,
+		MemberStatus: &pb.MemberStatus{
+			Name: r.Name,
+		},
+	}
+}
+
 // collectStatus obtains the cluster status by querying statuses of
 // known cluster members.
-func (r *agent) collectStatus(ctx context.Context) (systemStatus *pb.SystemStatus, err error) {
+func (r *agent) collectStatus(ctx context.Context) *pb.SystemStatus {
 	ctx, cancel := context.WithTimeout(ctx, StatusUpdateTimeout)
 	defer cancel()
 
-	systemStatus = &pb.SystemStatus{
-		Status:    pb.SystemStatus_Unknown,
-		Timestamp: pb.NewTimeToProto(r.Clock.Now()),
+	client, err := r.newSerfClientFunc()
+	if err != nil {
+		log.WithError(err).Error("Failed to create serf client.")
+		r.setLocalStatus(r.defaultUnknownStatus())
+		return &pb.SystemStatus{
+			Status:    pb.SystemStatus_Degraded,
+			Timestamp: pb.NewTimeToProto(r.Clock.Now()),
+			Summary:   fmt.Sprintf("failed to create serf client: %v", err),
+		}
+	}
+	defer client.Close()
+
+	members, err := client.Members()
+	if err != nil {
+		log.WithError(err).Error("Failed to query serf members.")
+		r.setLocalStatus(r.defaultUnknownStatus())
+		return &pb.SystemStatus{
+			Status:    pb.SystemStatus_Degraded,
+			Timestamp: pb.NewTimeToProto(r.Clock.Now()),
+			Summary:   fmt.Sprintf("failed to query serf members: %v", err),
+		}
 	}
 
-	members, err := r.ClusterMembership.Members()
-	if err != nil {
-		log.WithError(err).Warn("Failed to query serf members.")
-		return nil, trace.Wrap(err, "failed to query serf members")
+	systemStatus := &pb.SystemStatus{
+		Status:    pb.SystemStatus_Unknown,
+		Timestamp: pb.NewTimeToProto(r.Clock.Now()),
 	}
 
 	log.Debugf("Started collecting statuses from members %v.", members)
@@ -595,7 +600,7 @@ func (r *agent) collectStatus(ctx context.Context) (systemStatus *pb.SystemStatu
 	statusCh := make(chan *statusResponse, len(members))
 	for _, member := range members {
 		if r.Name == member.Name() {
-			go r.getLocalStatus(ctxNode, statusCh)
+			go r.getLocalStatus(ctxNode, statusCh, client)
 		} else {
 			go r.getStatusFrom(ctxNode, member, statusCh)
 		}
@@ -623,12 +628,12 @@ L:
 
 	setSystemStatus(systemStatus, members)
 
-	return systemStatus, nil
+	return systemStatus
 }
 
 // collectLocalStatus executes monitoring tests on the local node.
-func (r *agent) collectLocalStatus(ctx context.Context) (status *pb.NodeStatus, err error) {
-	local, err := r.ClusterMembership.FindMember(r.Name)
+func (r *agent) collectLocalStatus(ctx context.Context, client membership.ClusterMembership) (status *pb.NodeStatus, err error) {
+	local, err := client.FindMember(r.Name)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to query local serf member")
 	}
@@ -646,7 +651,7 @@ func (r *agent) collectLocalStatus(ctx context.Context) (status *pb.NodeStatus, 
 		return status, trace.Wrap(err, "failed to record local timeline events")
 	}
 
-	if err := r.notifyMasters(ctx); err != nil {
+	if err := r.notifyMasters(ctx, client); err != nil {
 		return status, trace.Wrap(err, "failed to notify master nodes of local timeline events")
 	}
 
@@ -654,15 +659,14 @@ func (r *agent) collectLocalStatus(ctx context.Context) (status *pb.NodeStatus, 
 }
 
 // getLocalStatus obtains local node status.
-func (r *agent) getLocalStatus(ctx context.Context, respc chan<- *statusResponse) {
+func (r *agent) getLocalStatus(ctx context.Context, respc chan<- *statusResponse, client membership.ClusterMembership) {
 	// TODO: restructure code so that local member is not needed here.
-	local, err := r.ClusterMembership.FindMember(r.Name)
+	local, err := client.FindMember(r.Name)
 	if err != nil {
 		respc <- &statusResponse{err: err}
 		return
 	}
-
-	status, err := r.collectLocalStatus(ctx)
+	status, err := r.collectLocalStatus(ctx, client)
 	resp := &statusResponse{
 		NodeStatus: status,
 		member:     local,
@@ -675,8 +679,8 @@ func (r *agent) getLocalStatus(ctx context.Context, respc chan<- *statusResponse
 }
 
 // notifyMasters pushes new timeline events to all master nodes in the cluster.
-func (r *agent) notifyMasters(ctx context.Context) error {
-	members, err := r.ClusterMembership.Members()
+func (r *agent) notifyMasters(ctx context.Context, client membership.ClusterMembership) error {
+	members, err := client.Members()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -760,6 +764,24 @@ func (r *agent) recentLocalStatus() *pb.NodeStatus {
 	r.Lock()
 	defer r.Unlock()
 	return r.localStatus
+}
+
+func (r *agent) setLocalStatus(status *pb.NodeStatus) {
+	r.Lock()
+	defer r.Unlock()
+	r.localStatus = status
+}
+
+// newSerfClient creates a new instance of the serf client.
+//
+// It is responsibility of the caller to close the returned client.
+func (r *agent) newSerfClient() (membership.ClusterMembership, error) {
+	client, err := membership.NewSerfClient(r.Config.SerfConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to connect to serf agent: %#v",
+			r.Config.SerfConfig)
+	}
+	return client, nil
 }
 
 // filterByTimestamp filters out events that occurred before the provided

--- a/vendor/github.com/gravitational/satellite/agent/server.go
+++ b/vendor/github.com/gravitational/satellite/agent/server.go
@@ -365,7 +365,7 @@ type Agent interface {
 	// RecordLocalEvents records the events into the local timeline.
 	RecordLocalEvents(ctx context.Context, events []*pb.TimelineEvent) error
 	// IsMember returns whether this agent is already a member of serf cluster
-	IsMember() bool
+	IsMember() (ok bool, err error)
 	// GetConfig returns the agent configuration.
 	GetConfig() Config
 	// CheckerRepository allows to add checks to the agent.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/gravitational/etcd-backup/lib/etcd
 github.com/gravitational/go-udev
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200825155435-feccb39a021d
+# github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/backend/inmemory
 github.com/gravitational/satellite/agent/cache


### PR DESCRIPTION
1. Updates flannel to v0.10.2-gravitational
2. Updates satellite to latest master
3. Updates iptables to v1.8.5 (latest available)

Notes:
- I can't say I'm a huge fan of the way iptables get's built here. Going to a multi-stage build would require carefully tracking all the file copies from `make install` and could change between versions. The biggest help would be using buildkit, but that can't be implemented until our build servers support buildkit. 
- I also just picked the latest iptables, not sure if we should be considering an older version for some reason.

Requires Backport

Updates https://github.com/gravitational/gravity/issues/2122