### PR TITLE
[master] scale tuning

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -56,6 +56,8 @@ ExecStart=/usr/bin/kube-apiserver \
         --audit-log-maxage=30 \
         --audit-log-maxbackup=10 \
         --audit-log-maxsize=100 \
+        --max-requests-inflight=2000 \
+        --max-mutating-requests-inflight=1000 \
         $KUBE_APISERVER_FLAGS \
         $KUBE_CLOUD_FLAGS \
         $KUBE_COMPONENT_FLAGS

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gravitational/coordinate v0.0.0-20200227044100-12af3c0f9593
 	github.com/gravitational/etcd-backup v0.0.0-20200227044745-5751e027911a
 	github.com/gravitational/go-udev v0.0.0-20160615210516-4cc8baba3689
-	github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922
+	github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1
 	github.com/gravitational/trace v1.1.11
 	github.com/gravitational/version v0.0.2-0.20170324200323-95d33ece5ce1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gravitational/coordinate v0.0.0-20200227044100-12af3c0f9593
 	github.com/gravitational/etcd-backup v0.0.0-20200227044745-5751e027911a
 	github.com/gravitational/go-udev v0.0.0-20160615210516-4cc8baba3689
-	github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77
+	github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922
 	github.com/gravitational/trace v1.1.11
 	github.com/gravitational/version v0.0.2-0.20170324200323-95d33ece5ce1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gravitational/coordinate v0.0.0-20200227044100-12af3c0f9593
 	github.com/gravitational/etcd-backup v0.0.0-20200227044745-5751e027911a
 	github.com/gravitational/go-udev v0.0.0-20160615210516-4cc8baba3689
-	github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485
+	github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77
 	github.com/gravitational/trace v1.1.11
 	github.com/gravitational/version v0.0.2-0.20170324200323-95d33ece5ce1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gravitational/coordinate v0.0.0-20200227044100-12af3c0f9593
 	github.com/gravitational/etcd-backup v0.0.0-20200227044745-5751e027911a
 	github.com/gravitational/go-udev v0.0.0-20160615210516-4cc8baba3689
-	github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1
+	github.com/gravitational/satellite v0.0.9-0.20200922194151-c87e17725fd6
 	github.com/gravitational/trace v1.1.11
 	github.com/gravitational/version v0.0.2-0.20170324200323-95d33ece5ce1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/gravitational/satellite v0.0.9-0.20200826203500-ad8030ab3ddb h1:XF4a8
 github.com/gravitational/satellite v0.0.9-0.20200826203500-ad8030ab3ddb/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485 h1:P3y0wr2ctYUvS0034CWro5GUiixdoV14akmlMpNVBSg=
 github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77 h1:Rc28MFXnReqS+xo4abUqLUxHW5W+qPOj14bRna1S/rk=
+github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/trace v1.1.11 h1:c+saoho5rBdj5lPEGzfHaYjh4Do4d+jX7hh4BgQtKc0=
 github.com/gravitational/trace v1.1.11/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d h1:vIgmA0qBCUgDSip4Gf0iqYCRv6fxsfHEJ2WHPVI35PQ=

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77 h1:Rc28M
 github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922 h1:Sit9CQPcMAf9F1PzWJuA2C2E6QTADDqToHkB8cijRn4=
 github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1 h1:O5f+9O1Qd/mO7GQt8M8zfHTNLGP1LlxDlhnMlF9Q+A4=
+github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/trace v1.1.11 h1:c+saoho5rBdj5lPEGzfHaYjh4Do4d+jX7hh4BgQtKc0=
 github.com/gravitational/trace v1.1.11/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d h1:vIgmA0qBCUgDSip4Gf0iqYCRv6fxsfHEJ2WHPVI35PQ=

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922 h1:Sit9C
 github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1 h1:O5f+9O1Qd/mO7GQt8M8zfHTNLGP1LlxDlhnMlF9Q+A4=
 github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200922194151-c87e17725fd6 h1:2qQLZxQaLmuE9slA51PF/i0hrvT1kqONpZRLTPm4ksw=
+github.com/gravitational/satellite v0.0.9-0.20200922194151-c87e17725fd6/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/trace v1.1.11 h1:c+saoho5rBdj5lPEGzfHaYjh4Do4d+jX7hh4BgQtKc0=
 github.com/gravitational/trace v1.1.11/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d h1:vIgmA0qBCUgDSip4Gf0iqYCRv6fxsfHEJ2WHPVI35PQ=

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485 h1:P3y0w
 github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77 h1:Rc28MFXnReqS+xo4abUqLUxHW5W+qPOj14bRna1S/rk=
 github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922 h1:Sit9CQPcMAf9F1PzWJuA2C2E6QTADDqToHkB8cijRn4=
+github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/trace v1.1.11 h1:c+saoho5rBdj5lPEGzfHaYjh4Do4d+jX7hh4BgQtKc0=
 github.com/gravitational/trace v1.1.11/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d h1:vIgmA0qBCUgDSip4Gf0iqYCRv6fxsfHEJ2WHPVI35PQ=

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -311,7 +311,6 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 
 	systemPodsChecker, err := monitoring.NewSystemPodsChecker(
 		monitoring.SystemPodsConfig{
-			NodeName:   config.NodeName,
 			KubeConfig: &kubeConfig,
 		},
 	)

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -385,17 +385,6 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 	}
 	node.AddChecker(nethealthChecker)
 
-	systemPodsChecker, err := monitoring.NewSystemPodsChecker(
-		monitoring.SystemPodsConfig{
-			NodeName:   config.NodeName,
-			KubeConfig: &nodeConfig,
-		},
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	node.AddChecker(systemPodsChecker)
-
 	node.AddChecker(monitoring.NewKernelChecker(constants.MinKernelVersion))
 
 	return nil

--- a/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
@@ -1,0 +1,624 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nethealth implements a daemonset that when deployed to a kubernetes cluster, will locate and send ICMP echos
+// (pings) to the nethealth pod on every other node in the cluster. This will give an indication into whether the
+// overlay network is functional for pod -> pod communications, and also record packet loss on the network.
+package nethealth
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"reflect"
+	"sort"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// heartbeatInterval is the duration between sending heartbeats to each peer. Any heartbeat that takes more
+	// than one interval to respond will also be considered timed out.
+	heartbeatInterval = 1 * time.Second
+
+	// resyncInterval is the duration between full resyncs of local state with kubernetes. If a node is deleted it
+	// may not be detected until the full resync completes.
+	resyncInterval = 15 * time.Minute
+
+	// dnsDiscoveryInterval is the duration of time for doing DNS based service discovery for pod changes. This is a
+	// lightweight test for whether there is a change to the nethealth pods within the cluster.
+	dnsDiscoveryInterval = 10 * time.Second
+
+	// Default selector to use for finding nethealth pods
+	DefaultSelector = "k8s-app=nethealth"
+
+	// DefaultServiceDiscoveryQuery is the default name to query for service discovery changes
+	DefaultServiceDiscoveryQuery = "any.nethealth"
+
+	// RxQueueSize is the size of queued ping responses to process
+	// Main processing occurs in a single goroutine, so we need a large enough processing queue to hold onto all ping
+	// responses while the routine is working on other operations.
+	// 2000 is chosen as double the maximum supported cluster size (1k)
+	RxQueueSize = 2000
+
+	// DefaultNethealthSocket is the default location of a unix domain socket that contains the prometheus metrics
+	DefaultNethealthSocket = "/run/nethealth/nethealth.sock"
+)
+
+const (
+	// Init is peer state that we've found the node but don't know anything about it yet.
+	Init = "init"
+	// Up is a peer state that the peer is currently reachable
+	Up = "up"
+	// Timeout is a peer state that the peer is currently timing out to pings
+	Timeout = "timeout"
+)
+
+type Config struct {
+	// PrometheusPort is the port to bind to for serving prometheus metrics
+	PrometheusPort uint32
+
+	// Namespace is the kubernetes namespace to monitor for other nethealth instances
+	Namespace string
+	// NodeName is the node this instance is running on
+	NodeName string
+	// Selector is a kubernetes selector to find all the nethealth pods in the configured namespace
+	Selector string
+	// ServiceDiscoveryQuery is a DNS name that will be used for lightweight service discovery checks. A query to
+	// any.<service>.default.svc.cluster.local will return a list of pods for the service. If the list of pods
+	// changes we know to resync with the kubernetes API. This method uses significantly less resources than running a
+	// kubernetes watcher on the API. Defaults to any.nethealth which will utilize the search path from resolv.conf.
+	ServiceDiscoveryQuery string
+}
+
+// New creates a new server to ping each peer.
+func (c Config) New() (*Server, error) {
+
+	promPeerRTT := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "nethealth",
+		Subsystem: "echo",
+		Name:      "duration_seconds",
+		Help:      "The round trip time to reach the peer",
+		Buckets: []float64{
+			0.0001, // 0.1 ms
+			0.0002, // 0.2 ms
+			0.0003, // 0.3 ms
+			0.0004, // 0.4 ms
+			0.0005, // 0.5 ms
+			0.0006, // 0.6 ms
+			0.0007, // 0.7 ms
+			0.0008, // 0.8 ms
+			0.0009, // 0.9 ms
+			0.001,  // 1ms
+			0.0015, // 1.5ms
+			0.002,  // 2ms
+			0.003,  // 3ms
+			0.004,  // 4ms
+			0.005,  // 5ms
+			0.01,   // 10ms
+			0.02,   // 20ms
+			0.04,   // 40ms
+			0.08,   // 80ms
+		},
+	}, []string{"node_name", "peer_name"})
+	promPeerTimeout := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "nethealth",
+		Subsystem: "echo",
+		Name:      "timeout_total",
+		Help:      "The number of echo requests that have timed out",
+	}, []string{"node_name", "peer_name"})
+	promPeerRequest := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "nethealth",
+		Subsystem: "echo",
+		Name:      "request_total",
+		Help:      "The number of echo requests that have been sent",
+	}, []string{"node_name", "peer_name"})
+
+	prometheus.MustRegister(
+		promPeerRTT,
+		promPeerTimeout,
+		promPeerRequest,
+	)
+
+	selector := DefaultSelector
+	if c.Selector != "" {
+		selector = c.Selector
+	}
+
+	labelSelector, err := labels.Parse(selector)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if c.ServiceDiscoveryQuery == "" {
+		c.ServiceDiscoveryQuery = DefaultServiceDiscoveryQuery
+	}
+
+	return &Server{
+		config:          c,
+		FieldLogger:     logrus.WithField(trace.Component, "nethealth"),
+		promPeerRTT:     promPeerRTT,
+		promPeerTimeout: promPeerTimeout,
+		promPeerRequest: promPeerRequest,
+		selector:        labelSelector,
+		triggerResync:   make(chan bool, 1),
+		rxMessage:       make(chan messageWrapper, RxQueueSize),
+		peers:           make(map[string]*peer),
+		addrToPeer:      make(map[string]string),
+	}, nil
+}
+
+// Server is an instance of nethealth that is running on each node responsible for sending and responding to heartbeats.
+type Server struct {
+	logrus.FieldLogger
+
+	config     Config
+	clock      clockwork.Clock
+	conn       *icmp.PacketConn
+	httpServer *http.Server
+	selector   labels.Selector
+
+	// rxMessage is a processing queue of received echo responses
+	rxMessage     chan messageWrapper
+	triggerResync chan bool
+
+	peers      map[string]*peer
+	addrToPeer map[string]string
+
+	client kubernetes.Interface
+
+	promPeerRTT     *prometheus.HistogramVec
+	promPeerTimeout *prometheus.CounterVec
+	promPeerRequest *prometheus.CounterVec
+}
+
+type peer struct {
+	name        string
+	addr        net.Addr
+	echoCounter int
+	echoTime    time.Time
+	echoTimeout bool
+
+	status           string
+	lastStatusChange time.Time
+}
+
+type messageWrapper struct {
+	message  *icmp.Message
+	rxTime   time.Time
+	peerAddr net.Addr
+}
+
+// Start sets up the server and begins normal operation
+func (s *Server) Start() error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	s.client, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.conn, err = icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.clock = clockwork.NewRealClock()
+	go s.loop()
+	go s.loopServiceDiscovery()
+	go s.serve()
+
+	mux := http.ServeMux{}
+	mux.Handle("/metrics", promhttp.Handler())
+	s.httpServer = &http.Server{Addr: fmt.Sprint(":", s.config.PrometheusPort), Handler: &mux}
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != http.ErrServerClosed {
+			s.Fatalf("ListenAndServe(): %s", err)
+		}
+	}()
+	go func() {
+		_ = os.Remove(DefaultNethealthSocket)
+
+		unixListener, err := net.Listen("unix", DefaultNethealthSocket)
+		if err != nil {
+			panic(err)
+		}
+
+		if err := s.httpServer.Serve(unixListener); err != http.ErrServerClosed {
+			s.Fatalf("Unix Listen(): %s", err)
+		}
+	}()
+
+	s.Info("Started nethealth with config:")
+	s.Info("  PrometheusPort: ", s.config.PrometheusPort)
+	s.Info("  Namespace: ", s.config.Namespace)
+	s.Info("  NodeName: ", s.config.NodeName)
+	s.Info("  Selector: ", s.selector)
+	s.Info("  ServiceDiscoveryQuery: ", s.config.ServiceDiscoveryQuery)
+
+	return nil
+}
+
+// loop is the main processing loop for sending/receiving heartbeats.
+func (s *Server) loop() {
+	heartbeatTicker := s.clock.NewTicker(heartbeatInterval)
+	defer heartbeatTicker.Stop()
+
+	resyncTicker := s.clock.NewTicker(resyncInterval)
+	defer resyncTicker.Stop()
+
+	for {
+		select {
+		//
+		// Re-sync cluster peers
+		//
+		case <-resyncTicker.Chan():
+			err := s.resyncPeerList()
+			if err != nil {
+				s.WithError(err).Error("Unexpected error re-syncing the list of peer nodes.")
+			}
+
+			err = s.resyncNethealthPods()
+			if err != nil {
+				s.WithError(err).Error("Unexpected error re-syncing the list of peer pods.")
+			}
+		case <-s.triggerResync:
+			err := s.resyncPeerList()
+			if err != nil {
+				s.WithError(err).Error("Unexpected error re-syncing the list of peer nodes.")
+			}
+
+			err = s.resyncNethealthPods()
+			if err != nil {
+				s.WithError(err).Error("Unexpected error re-syncing the list of peer pods.")
+			}
+
+		//
+		// Send a heartbeat to each peer we know about
+		// Check for peers that are timing out / down
+		//
+		case <-heartbeatTicker.Chan():
+			s.checkTimeouts()
+			for _, peer := range s.peers {
+				s.sendHeartbeat(peer)
+			}
+
+		//
+		// Rx heartbeats responses from peers
+		//
+		case rx := <-s.rxMessage:
+			err := s.processAck(rx)
+			if err != nil {
+				s.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"peer_addr":     rx.peerAddr,
+					"rx_time":       rx.rxTime,
+					"message":       rx.message,
+				}).Error("Error processing icmp message.")
+			}
+		}
+	}
+}
+
+// loopServiceDiscovery uses cluster-dns service discovery as a lightweight check for pod changes
+// and will trigger a resync if the cluster DNS service discovery changes
+func (s *Server) loopServiceDiscovery() {
+	s.Info("Starting DNS service discovery for nethealth pod.")
+	ticker := s.clock.NewTicker(dnsDiscoveryInterval)
+	defer ticker.Stop()
+	query := s.config.ServiceDiscoveryQuery
+
+	previousNames := []string{}
+
+	for {
+		<-ticker.Chan()
+
+		s.Debugf("Querying %v for service discovery", query)
+		names, err := net.LookupHost(query)
+		if err != nil {
+			s.WithError(err).WithField("query", query).Error("Error querying service discovery.")
+			continue
+		}
+
+		sort.Strings(names)
+		if reflect.DeepEqual(names, previousNames) {
+			continue
+		}
+		previousNames = names
+		s.Info("Triggering peer resync due to service discovery change")
+
+		select {
+		case s.triggerResync <- true:
+		default:
+			// Don't block
+		}
+	}
+}
+
+// resyncPeerList contacts the kubernetes API to sync the list of kubernetes nodes
+func (s *Server) resyncPeerList() error {
+	nodes, err := s.client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	peerMap := make(map[string]bool)
+	for _, node := range nodes.Items {
+		// Don't add our own node as a peer
+		if node.Name == s.config.NodeName {
+			continue
+		}
+
+		peerMap[node.Name] = true
+		if _, ok := s.peers[node.Name]; !ok {
+			s.peers[node.Name] = &peer{
+				name:             node.Name,
+				lastStatusChange: s.clock.Now(),
+				addr:             &net.IPAddr{},
+			}
+			s.WithField("peer", node.Name).Info("Adding peer.")
+			// Initialize the peer so it shows up in prometheus with a 0 count
+			s.promPeerTimeout.WithLabelValues(s.config.NodeName, node.Name).Add(0)
+			s.promPeerRequest.WithLabelValues(s.config.NodeName, node.Name).Add(0)
+		}
+	}
+
+	// check for peers that have been deleted
+	for key := range s.peers {
+		if _, ok := peerMap[key]; !ok {
+			s.WithField("peer", key).Info("Deleting peer.")
+			delete(s.peers, key)
+			s.promPeerRTT.DeleteLabelValues(s.config.NodeName, key)
+			s.promPeerRequest.DeleteLabelValues(s.config.NodeName, key)
+			s.promPeerTimeout.DeleteLabelValues(s.config.NodeName, key)
+		}
+	}
+
+	return nil
+}
+
+// resyncNethealthPods contacts the kubernetes API to sync the list of pods running the nethealth daemon
+func (s *Server) resyncNethealthPods() error {
+	list, err := s.client.CoreV1().Pods(s.config.Namespace).List(metav1.ListOptions{
+		LabelSelector: s.selector.String(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, pod := range list.Items {
+		// skip our own pod
+		if pod.Spec.NodeName == s.config.NodeName {
+			continue
+		}
+
+		// skip if the peer object can't be located
+		if peer, ok := s.peers[pod.Spec.NodeName]; !ok {
+			continue
+		} else {
+			newAddr := &net.IPAddr{
+				IP: net.ParseIP(pod.Status.PodIP),
+			}
+
+			if peer.addr.String() != newAddr.String() {
+				s.WithFields(logrus.Fields{
+					"peer":          peer.name,
+					"new_peer_addr": newAddr,
+					"old_peer_addr": peer.addr,
+				}).Info("Updating peer pod IP address.")
+				peer.addr = newAddr
+				s.addrToPeer[peer.addr.String()] = pod.Spec.NodeName
+			}
+		}
+	}
+
+	// Free entries in the lookup table that no longer point to a valid object
+	for key, value := range s.addrToPeer {
+		if _, ok := s.peers[value]; !ok {
+			delete(s.addrToPeer, key)
+		}
+	}
+
+	return nil
+}
+
+// serve monitors for incoming icmp messages
+func (s *Server) serve() {
+	buf := make([]byte, 256)
+
+	for {
+		n, peerAddr, err := s.conn.ReadFrom(buf)
+		rxTime := s.clock.Now()
+		log := s.WithFields(logrus.Fields{
+			"peer_addr": peerAddr,
+			"node":      s.config.NodeName,
+			"length":    n,
+		})
+		if err != nil {
+			log.WithError(err).Error("Error in udp socket read.")
+			continue
+		}
+
+		// The ICMP package doesn't export the protocol numbers
+		// 1 - ICMP
+		// 58 - ICMPv6
+		// https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+		msg, err := icmp.ParseMessage(1, buf[:n])
+		if err != nil {
+			log.WithError(err).Error("Error parsing icmp message.")
+			continue
+		}
+
+		select {
+		case s.rxMessage <- messageWrapper{
+			message:  msg,
+			rxTime:   rxTime,
+			peerAddr: peerAddr,
+		}:
+		default:
+			// Don't block
+			log.Warn("Dropped icmp message due to full rxMessage queue")
+		}
+	}
+}
+
+func (s *Server) lookupPeer(addr string) (*peer, error) {
+	peerName, ok := s.addrToPeer[addr]
+	if !ok {
+		return nil, trace.BadParameter("address not found in address table").AddField("address", addr)
+	}
+
+	p, ok := s.peers[peerName]
+	if !ok {
+		return nil, trace.BadParameter("peer not found in peer table").AddField("peer_name", peerName)
+	}
+	return p, nil
+}
+
+// processAck processes a received ICMP Ack message
+func (s *Server) processAck(e messageWrapper) error {
+	switch e.message.Type {
+	case ipv4.ICMPTypeEchoReply:
+		// ok
+	case ipv4.ICMPTypeEcho:
+		// nothing to do with echo requests
+		return nil
+	default:
+		//unexpected / unknown
+		return trace.BadParameter("received unexpected icmp message type").AddField("type", e.message.Type)
+	}
+
+	switch pkt := e.message.Body.(type) {
+	case *icmp.Echo:
+		peer, err := s.lookupPeer(e.peerAddr.String())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if uint16(pkt.Seq) != uint16(peer.echoCounter) {
+			return trace.BadParameter("response sequence doesn't match latest request.").
+				AddField("expected", uint16(peer.echoCounter)).
+				AddField("received", uint16(pkt.Seq))
+		}
+
+		rtt := e.rxTime.Sub(peer.echoTime)
+		s.promPeerRTT.WithLabelValues(s.config.NodeName, peer.name).Observe(rtt.Seconds())
+		s.updatePeerStatus(peer, Up)
+		peer.echoTimeout = false
+
+		s.WithFields(logrus.Fields{
+			"peer_name": peer.name,
+			"peer_addr": peer.addr,
+			"counter":   peer.echoCounter,
+			"seq":       uint16(peer.echoCounter),
+			"rtt":       rtt,
+		}).Debug("Ack.")
+	default:
+		s.WithFields(logrus.Fields{
+			"peer_addr": e.peerAddr.String(),
+		}).Warn("Unexpected icmp message")
+	}
+	return nil
+}
+
+func (s *Server) sendHeartbeat(peer *peer) {
+	peer.echoCounter++
+	log := s.WithFields(logrus.Fields{
+		"peer_name": peer.name,
+		"peer_addr": peer.addr,
+		"id":        peer.echoCounter,
+	})
+
+	// If we don't know the pod IP address of the peer, we still want to generate a timeout, but not actually send
+	// a heartbeat
+	peer.echoTimeout = true
+	if peer.addr == nil || peer.addr.String() == "" || peer.addr.String() == "0.0.0.0" {
+		return
+	}
+
+	msg := icmp.Message{
+		Type: ipv4.ICMPTypeEcho,
+		Code: 0,
+		Body: &icmp.Echo{
+			ID:  1,
+			Seq: peer.echoCounter,
+		},
+	}
+	buf, err := msg.Marshal(nil)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal ping.")
+		return
+	}
+
+	peer.echoTime = s.clock.Now()
+	_, err = s.conn.WriteTo(buf, peer.addr)
+	if err != nil {
+		log.WithError(err).Warn("Failed to send ping.")
+		return
+	}
+	s.promPeerRequest.WithLabelValues(s.config.NodeName, peer.name).Inc()
+
+	log.Debug("Sent echo request.")
+}
+
+// checkTimeouts iterates over each peer, and checks whether our last heartbeat has timed out
+func (s *Server) checkTimeouts() {
+	s.Debug("checking for timeouts")
+	for _, peer := range s.peers {
+		// if the echoTimeout flag is set, it means we didn't receive a response to our last request
+		if peer.echoTimeout {
+			s.WithFields(logrus.Fields{
+				"peer_name": peer.name,
+				"peer_addr": peer.addr,
+				"id":        peer.echoCounter,
+			}).Debug("echo timeout")
+			s.promPeerTimeout.WithLabelValues(s.config.NodeName, peer.name).Inc()
+			s.updatePeerStatus(peer, Timeout)
+		}
+	}
+}
+
+func (s *Server) updatePeerStatus(peer *peer, status string) {
+	if peer.status == status {
+		return
+	}
+
+	s.WithFields(logrus.Fields{
+		"peer_name":  peer.name,
+		"peer_addr":  peer.addr,
+		"duration":   s.clock.Now().Sub(peer.lastStatusChange),
+		"old_status": peer.status,
+		"new_status": status,
+	}).Info("Peer status changed.")
+
+	peer.status = status
+	peer.lastStatusChange = s.clock.Now()
+
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/nethealth"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/trace"
@@ -40,10 +41,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-)
-
-const (
-	DefaultNethealthSocket = "/run/nethealth/nethealth.sock"
 )
 
 // NethealthConfig specifies configuration for a nethealth checker.
@@ -328,28 +325,10 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 // fetchNethealthMetrics collects the network metrics from the nethealth pod
 // specified by addr. Returns the resp as an array of bytes.
 func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byte, err error) {
-	/*if c.cachedNethealthAddress != "" {
-		c.cachedNethealthAddress, err = c.getNethealthAddr()
-		if trace.IsNotFound(err) {
-			log.Debug("Nethealth pod was not found.")
-			return nil, nil // pod was not found, log and treat gracefully
-		}
-
-		if err != nil {
-			return nil, trace.Wrap(err) // received unexpected error, maybe network-related, will add error probe above
-		}
-	}*/
-	/*
-		client, err := roundtrip.NewClient(c.cachedNethealthAddress, "")
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to connect to nethealth service at %s.", c.cachedNethealthAddress)
-		}
-	*/
-
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", DefaultNethealthSocket)
+				return net.Dial("unix", nethealth.DefaultNethealthSocket)
 			},
 		},
 	}
@@ -365,7 +344,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	//      # TYPE nethealth_echo_timeout_total counter
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "unix/metrics", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix/metrics", nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -385,7 +364,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		return buffer, nil
 	}
 
-	return nil, trace.BadParameter("unexpected response from %s: %v", DefaultNethealthSocket, resp.Status)
+	return nil, trace.BadParameter("unexpected response from %s: %v", nethealth.DefaultNethealthSocket, resp.Status)
 }
 
 // parseMetrics parses the provided data and returns the structured network

--- a/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
@@ -355,11 +355,15 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	}
 	defer resp.Body.Close()
 
+	log.Warn("nethealth got response: ", resp.Status)
+
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
+
+		log.Warn("response: ", string(buffer))
 
 		return buffer, nil
 	}

--- a/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
@@ -29,13 +29,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 )
 
 // SystemPodsConfig specifies configuration for a system pods checker.
 type SystemPodsConfig struct {
-	// NodeName specifies the kubernetes name of this node.
-	NodeName string
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
 }
@@ -44,9 +41,6 @@ type SystemPodsConfig struct {
 // value defaults where necessary.
 func (r *SystemPodsConfig) checkAndSetDefaults() error {
 	var errors []error
-	if r.NodeName == "" {
-		errors = append(errors, trace.BadParameter("node name must be provided"))
-	}
 	if r.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
 	}
@@ -107,7 +101,6 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", r.NodeName).String(),
 	}
 	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
 	if err != nil {

--- a/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/timedrift.go
@@ -210,8 +210,7 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 		return 0, trace.Wrap(err)
 	}
 
-	// Obtain this node's local timestamp.
-	t1Start := c.Clock.Now().UTC()
+	queryStart := c.Clock.Now().UTC()
 
 	// if the RPC call takes a long duration it will result in an inaccurate comparison. Timeout the RPC
 	// call to reduce false positives on a slow server.
@@ -219,7 +218,7 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	defer cancel()
 
 	// Send "time" request to the specified node.
-	t2Response, err := agentClient.Time(ctx, &pb.TimeRequest{})
+	peerResponse, err := agentClient.Time(ctx, &pb.TimeRequest{})
 	if err != nil {
 		// If the agent we're making request to is of an older version,
 		// it may not support Time() method yet. This can happen, e.g.,
@@ -231,21 +230,21 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 		return 0, trace.Wrap(err)
 	}
 
-	// Calculate how much time has elapsed since T1Start. This value will
-	// roughly be the request roundtrip time, so the latency b/w the nodes
-	// is half that.
-	latency := c.Clock.Now().UTC().Sub(t1Start) / 2
+	queryEnd := c.Clock.Now().UTC()
 
-	// Finally calculate the time drift between this and the specified node
-	// using formula: t2 - now + latency.
-	//
-	// Example for 1ms difference: t2 = 0, now = 16ms, latency = 15 ms
-	// 0 - 16 = -16; -16 + 15 = -1 ms.
-	t2 := t2Response.GetTimestamp().ToTime()
-	drift := t2.Sub(c.Clock.Now().UTC()) + latency
+	// The request / response will take some time to perform over the network
+	// Use an adjustment of half the RTT time under the assumption that the request / response consume
+	// equal delays.
+	latencyAdjustment := queryEnd.Sub(queryStart) / 2
 
-	c.WithField("node", node.Name).Debugf("T1Start: %v; T2: %v; Latency: %v; Drift: %v.",
-		t1Start, t2, latency, drift)
+	adjustedPeerTime := peerResponse.GetTimestamp().ToTime().Add(latencyAdjustment)
+
+	// drift is relative to the current nodes time.
+	// if peer time > node time, return a positive duration
+	// if peer time < node time, return a negative duration
+	drift := adjustedPeerTime.Sub(queryEnd)
+	c.WithField("node", node.Name).Debugf("queryStart: %v; queryEnd: %v; peerTime: %v; adjustedPeerTime: %v drift: %v.",
+		queryStart, queryEnd, peerResponse.GetTimestamp().ToTime(), adjustedPeerTime, drift)
 	return drift, nil
 }
 

--- a/vendor/golang.org/x/net/icmp/dstunreach.go
+++ b/vendor/golang.org/x/net/icmp/dstunreach.go
@@ -1,0 +1,59 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// A DstUnreach represents an ICMP destination unreachable message
+// body.
+type DstUnreach struct {
+	Data       []byte      // data, known as original datagram field
+	Extensions []Extension // extensions
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *DstUnreach) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	l, _ := multipartMessageBodyDataLen(proto, true, p.Data, p.Extensions)
+	return l
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *DstUnreach) Marshal(proto int) ([]byte, error) {
+	var typ Type
+	switch proto {
+	case iana.ProtocolICMP:
+		typ = ipv4.ICMPTypeDestinationUnreachable
+	case iana.ProtocolIPv6ICMP:
+		typ = ipv6.ICMPTypeDestinationUnreachable
+	default:
+		return nil, errInvalidProtocol
+	}
+	if !validExtensions(typ, p.Extensions) {
+		return nil, errInvalidExtension
+	}
+	return marshalMultipartMessageBody(proto, true, p.Data, p.Extensions)
+}
+
+// parseDstUnreach parses b as an ICMP destination unreachable message
+// body.
+func parseDstUnreach(proto int, typ Type, b []byte) (MessageBody, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &DstUnreach{}
+	var err error
+	p.Data, p.Extensions, err = parseMultipartMessageBody(proto, typ, b)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/vendor/golang.org/x/net/icmp/echo.go
+++ b/vendor/golang.org/x/net/icmp/echo.go
@@ -1,0 +1,173 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// An Echo represents an ICMP echo request or reply message body.
+type Echo struct {
+	ID   int    // identifier
+	Seq  int    // sequence number
+	Data []byte // data
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *Echo) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	return 4 + len(p.Data)
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *Echo) Marshal(proto int) ([]byte, error) {
+	b := make([]byte, 4+len(p.Data))
+	binary.BigEndian.PutUint16(b[:2], uint16(p.ID))
+	binary.BigEndian.PutUint16(b[2:4], uint16(p.Seq))
+	copy(b[4:], p.Data)
+	return b, nil
+}
+
+// parseEcho parses b as an ICMP echo request or reply message body.
+func parseEcho(proto int, _ Type, b []byte) (MessageBody, error) {
+	bodyLen := len(b)
+	if bodyLen < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &Echo{ID: int(binary.BigEndian.Uint16(b[:2])), Seq: int(binary.BigEndian.Uint16(b[2:4]))}
+	if bodyLen > 4 {
+		p.Data = make([]byte, bodyLen-4)
+		copy(p.Data, b[4:])
+	}
+	return p, nil
+}
+
+// An ExtendedEchoRequest represents an ICMP extended echo request
+// message body.
+type ExtendedEchoRequest struct {
+	ID         int         // identifier
+	Seq        int         // sequence number
+	Local      bool        // must be true when identifying by name or index
+	Extensions []Extension // extensions
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *ExtendedEchoRequest) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	l, _ := multipartMessageBodyDataLen(proto, false, nil, p.Extensions)
+	return l
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *ExtendedEchoRequest) Marshal(proto int) ([]byte, error) {
+	var typ Type
+	switch proto {
+	case iana.ProtocolICMP:
+		typ = ipv4.ICMPTypeExtendedEchoRequest
+	case iana.ProtocolIPv6ICMP:
+		typ = ipv6.ICMPTypeExtendedEchoRequest
+	default:
+		return nil, errInvalidProtocol
+	}
+	if !validExtensions(typ, p.Extensions) {
+		return nil, errInvalidExtension
+	}
+	b, err := marshalMultipartMessageBody(proto, false, nil, p.Extensions)
+	if err != nil {
+		return nil, err
+	}
+	binary.BigEndian.PutUint16(b[:2], uint16(p.ID))
+	b[2] = byte(p.Seq)
+	if p.Local {
+		b[3] |= 0x01
+	}
+	return b, nil
+}
+
+// parseExtendedEchoRequest parses b as an ICMP extended echo request
+// message body.
+func parseExtendedEchoRequest(proto int, typ Type, b []byte) (MessageBody, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &ExtendedEchoRequest{ID: int(binary.BigEndian.Uint16(b[:2])), Seq: int(b[2])}
+	if b[3]&0x01 != 0 {
+		p.Local = true
+	}
+	var err error
+	_, p.Extensions, err = parseMultipartMessageBody(proto, typ, b)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// An ExtendedEchoReply represents an ICMP extended echo reply message
+// body.
+type ExtendedEchoReply struct {
+	ID     int  // identifier
+	Seq    int  // sequence number
+	State  int  // 3-bit state working together with Message.Code
+	Active bool // probed interface is active
+	IPv4   bool // probed interface runs IPv4
+	IPv6   bool // probed interface runs IPv6
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *ExtendedEchoReply) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	return 4
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *ExtendedEchoReply) Marshal(proto int) ([]byte, error) {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint16(b[:2], uint16(p.ID))
+	b[2] = byte(p.Seq)
+	b[3] = byte(p.State<<5) & 0xe0
+	if p.Active {
+		b[3] |= 0x04
+	}
+	if p.IPv4 {
+		b[3] |= 0x02
+	}
+	if p.IPv6 {
+		b[3] |= 0x01
+	}
+	return b, nil
+}
+
+// parseExtendedEchoReply parses b as an ICMP extended echo reply
+// message body.
+func parseExtendedEchoReply(proto int, _ Type, b []byte) (MessageBody, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &ExtendedEchoReply{
+		ID:    int(binary.BigEndian.Uint16(b[:2])),
+		Seq:   int(b[2]),
+		State: int(b[3]) >> 5,
+	}
+	if b[3]&0x04 != 0 {
+		p.Active = true
+	}
+	if b[3]&0x02 != 0 {
+		p.IPv4 = true
+	}
+	if b[3]&0x01 != 0 {
+		p.IPv6 = true
+	}
+	return p, nil
+}

--- a/vendor/golang.org/x/net/icmp/endpoint.go
+++ b/vendor/golang.org/x/net/icmp/endpoint.go
@@ -1,0 +1,113 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"net"
+	"runtime"
+	"time"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+var _ net.PacketConn = &PacketConn{}
+
+// A PacketConn represents a packet network endpoint that uses either
+// ICMPv4 or ICMPv6.
+type PacketConn struct {
+	c  net.PacketConn
+	p4 *ipv4.PacketConn
+	p6 *ipv6.PacketConn
+}
+
+func (c *PacketConn) ok() bool { return c != nil && c.c != nil }
+
+// IPv4PacketConn returns the ipv4.PacketConn of c.
+// It returns nil when c is not created as the endpoint for ICMPv4.
+func (c *PacketConn) IPv4PacketConn() *ipv4.PacketConn {
+	if !c.ok() {
+		return nil
+	}
+	return c.p4
+}
+
+// IPv6PacketConn returns the ipv6.PacketConn of c.
+// It returns nil when c is not created as the endpoint for ICMPv6.
+func (c *PacketConn) IPv6PacketConn() *ipv6.PacketConn {
+	if !c.ok() {
+		return nil
+	}
+	return c.p6
+}
+
+// ReadFrom reads an ICMP message from the connection.
+func (c *PacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if !c.ok() {
+		return 0, nil, errInvalidConn
+	}
+	// Please be informed that ipv4.NewPacketConn enables
+	// IP_STRIPHDR option by default on Darwin.
+	// See golang.org/issue/9395 for further information.
+	if runtime.GOOS == "darwin" && c.p4 != nil {
+		n, _, peer, err := c.p4.ReadFrom(b)
+		return n, peer, err
+	}
+	return c.c.ReadFrom(b)
+}
+
+// WriteTo writes the ICMP message b to dst.
+// The provided dst must be net.UDPAddr when c is a non-privileged
+// datagram-oriented ICMP endpoint.
+// Otherwise it must be net.IPAddr.
+func (c *PacketConn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if !c.ok() {
+		return 0, errInvalidConn
+	}
+	return c.c.WriteTo(b, dst)
+}
+
+// Close closes the endpoint.
+func (c *PacketConn) Close() error {
+	if !c.ok() {
+		return errInvalidConn
+	}
+	return c.c.Close()
+}
+
+// LocalAddr returns the local network address.
+func (c *PacketConn) LocalAddr() net.Addr {
+	if !c.ok() {
+		return nil
+	}
+	return c.c.LocalAddr()
+}
+
+// SetDeadline sets the read and write deadlines associated with the
+// endpoint.
+func (c *PacketConn) SetDeadline(t time.Time) error {
+	if !c.ok() {
+		return errInvalidConn
+	}
+	return c.c.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline associated with the
+// endpoint.
+func (c *PacketConn) SetReadDeadline(t time.Time) error {
+	if !c.ok() {
+		return errInvalidConn
+	}
+	return c.c.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline associated with the
+// endpoint.
+func (c *PacketConn) SetWriteDeadline(t time.Time) error {
+	if !c.ok() {
+		return errInvalidConn
+	}
+	return c.c.SetWriteDeadline(t)
+}

--- a/vendor/golang.org/x/net/icmp/extension.go
+++ b/vendor/golang.org/x/net/icmp/extension.go
@@ -1,0 +1,170 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// An Extension represents an ICMP extension.
+type Extension interface {
+	// Len returns the length of ICMP extension.
+	// The provided proto must be either the ICMPv4 or ICMPv6
+	// protocol number.
+	Len(proto int) int
+
+	// Marshal returns the binary encoding of ICMP extension.
+	// The provided proto must be either the ICMPv4 or ICMPv6
+	// protocol number.
+	Marshal(proto int) ([]byte, error)
+}
+
+const extensionVersion = 2
+
+func validExtensionHeader(b []byte) bool {
+	v := int(b[0]&0xf0) >> 4
+	s := binary.BigEndian.Uint16(b[2:4])
+	if s != 0 {
+		s = checksum(b)
+	}
+	if v != extensionVersion || s != 0 {
+		return false
+	}
+	return true
+}
+
+// parseExtensions parses b as a list of ICMP extensions.
+// The length attribute l must be the length attribute field in
+// received icmp messages.
+//
+// It will return a list of ICMP extensions and an adjusted length
+// attribute that represents the length of the padded original
+// datagram field. Otherwise, it returns an error.
+func parseExtensions(typ Type, b []byte, l int) ([]Extension, int, error) {
+	// Still a lot of non-RFC 4884 compliant implementations are
+	// out there. Set the length attribute l to 128 when it looks
+	// inappropriate for backwards compatibility.
+	//
+	// A minimal extension at least requires 8 octets; 4 octets
+	// for an extension header, and 4 octets for a single object
+	// header.
+	//
+	// See RFC 4884 for further information.
+	switch typ {
+	case ipv4.ICMPTypeExtendedEchoRequest, ipv6.ICMPTypeExtendedEchoRequest:
+		if len(b) < 8 || !validExtensionHeader(b) {
+			return nil, -1, errNoExtension
+		}
+		l = 0
+	default:
+		if 128 > l || l+8 > len(b) {
+			l = 128
+		}
+		if l+8 > len(b) {
+			return nil, -1, errNoExtension
+		}
+		if !validExtensionHeader(b[l:]) {
+			if l == 128 {
+				return nil, -1, errNoExtension
+			}
+			l = 128
+			if !validExtensionHeader(b[l:]) {
+				return nil, -1, errNoExtension
+			}
+		}
+	}
+	var exts []Extension
+	for b = b[l+4:]; len(b) >= 4; {
+		ol := int(binary.BigEndian.Uint16(b[:2]))
+		if 4 > ol || ol > len(b) {
+			break
+		}
+		switch b[2] {
+		case classMPLSLabelStack:
+			ext, err := parseMPLSLabelStack(b[:ol])
+			if err != nil {
+				return nil, -1, err
+			}
+			exts = append(exts, ext)
+		case classInterfaceInfo:
+			ext, err := parseInterfaceInfo(b[:ol])
+			if err != nil {
+				return nil, -1, err
+			}
+			exts = append(exts, ext)
+		case classInterfaceIdent:
+			ext, err := parseInterfaceIdent(b[:ol])
+			if err != nil {
+				return nil, -1, err
+			}
+			exts = append(exts, ext)
+		default:
+			ext := &RawExtension{Data: make([]byte, ol)}
+			copy(ext.Data, b[:ol])
+			exts = append(exts, ext)
+		}
+		b = b[ol:]
+	}
+	return exts, l, nil
+}
+
+func validExtensions(typ Type, exts []Extension) bool {
+	switch typ {
+	case ipv4.ICMPTypeDestinationUnreachable, ipv4.ICMPTypeTimeExceeded, ipv4.ICMPTypeParameterProblem,
+		ipv6.ICMPTypeDestinationUnreachable, ipv6.ICMPTypeTimeExceeded:
+		for i := range exts {
+			switch exts[i].(type) {
+			case *MPLSLabelStack, *InterfaceInfo, *RawExtension:
+			default:
+				return false
+			}
+		}
+		return true
+	case ipv4.ICMPTypeExtendedEchoRequest, ipv6.ICMPTypeExtendedEchoRequest:
+		var n int
+		for i := range exts {
+			switch exts[i].(type) {
+			case *InterfaceIdent:
+				n++
+			case *RawExtension:
+			default:
+				return false
+			}
+		}
+		// Not a single InterfaceIdent object or a combo of
+		// RawExtension and InterfaceIdent objects is not
+		// allowed.
+		if n == 1 && len(exts) > 1 {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// A RawExtension represents a raw extension.
+//
+// A raw extension is excluded from message processing and can be used
+// to construct applications such as protocol conformance testing.
+type RawExtension struct {
+	Data []byte // data
+}
+
+// Len implements the Len method of Extension interface.
+func (p *RawExtension) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	return len(p.Data)
+}
+
+// Marshal implements the Marshal method of Extension interface.
+func (p *RawExtension) Marshal(proto int) ([]byte, error) {
+	return p.Data, nil
+}

--- a/vendor/golang.org/x/net/icmp/helper_posix.go
+++ b/vendor/golang.org/x/net/icmp/helper_posix.go
@@ -1,0 +1,75 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris windows
+
+package icmp
+
+import (
+	"net"
+	"strconv"
+	"syscall"
+)
+
+func sockaddr(family int, address string) (syscall.Sockaddr, error) {
+	switch family {
+	case syscall.AF_INET:
+		a, err := net.ResolveIPAddr("ip4", address)
+		if err != nil {
+			return nil, err
+		}
+		if len(a.IP) == 0 {
+			a.IP = net.IPv4zero
+		}
+		if a.IP = a.IP.To4(); a.IP == nil {
+			return nil, net.InvalidAddrError("non-ipv4 address")
+		}
+		sa := &syscall.SockaddrInet4{}
+		copy(sa.Addr[:], a.IP)
+		return sa, nil
+	case syscall.AF_INET6:
+		a, err := net.ResolveIPAddr("ip6", address)
+		if err != nil {
+			return nil, err
+		}
+		if len(a.IP) == 0 {
+			a.IP = net.IPv6unspecified
+		}
+		if a.IP.Equal(net.IPv4zero) {
+			a.IP = net.IPv6unspecified
+		}
+		if a.IP = a.IP.To16(); a.IP == nil || a.IP.To4() != nil {
+			return nil, net.InvalidAddrError("non-ipv6 address")
+		}
+		sa := &syscall.SockaddrInet6{ZoneId: zoneToUint32(a.Zone)}
+		copy(sa.Addr[:], a.IP)
+		return sa, nil
+	default:
+		return nil, net.InvalidAddrError("unexpected family")
+	}
+}
+
+func zoneToUint32(zone string) uint32 {
+	if zone == "" {
+		return 0
+	}
+	if ifi, err := net.InterfaceByName(zone); err == nil {
+		return uint32(ifi.Index)
+	}
+	n, err := strconv.Atoi(zone)
+	if err != nil {
+		return 0
+	}
+	return uint32(n)
+}
+
+func last(s string, b byte) int {
+	i := len(s)
+	for i--; i >= 0; i-- {
+		if s[i] == b {
+			break
+		}
+	}
+	return i
+}

--- a/vendor/golang.org/x/net/icmp/interface.go
+++ b/vendor/golang.org/x/net/icmp/interface.go
@@ -1,0 +1,322 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+
+	"golang.org/x/net/internal/iana"
+)
+
+const (
+	classInterfaceInfo = 2
+)
+
+const (
+	attrMTU = 1 << iota
+	attrName
+	attrIPAddr
+	attrIfIndex
+)
+
+// An InterfaceInfo represents interface and next-hop identification.
+type InterfaceInfo struct {
+	Class     int // extension object class number
+	Type      int // extension object sub-type
+	Interface *net.Interface
+	Addr      *net.IPAddr
+}
+
+func (ifi *InterfaceInfo) nameLen() int {
+	if len(ifi.Interface.Name) > 63 {
+		return 64
+	}
+	l := 1 + len(ifi.Interface.Name)
+	return (l + 3) &^ 3
+}
+
+func (ifi *InterfaceInfo) attrsAndLen(proto int) (attrs, l int) {
+	l = 4
+	if ifi.Interface != nil && ifi.Interface.Index > 0 {
+		attrs |= attrIfIndex
+		l += 4
+		if len(ifi.Interface.Name) > 0 {
+			attrs |= attrName
+			l += ifi.nameLen()
+		}
+		if ifi.Interface.MTU > 0 {
+			attrs |= attrMTU
+			l += 4
+		}
+	}
+	if ifi.Addr != nil {
+		switch proto {
+		case iana.ProtocolICMP:
+			if ifi.Addr.IP.To4() != nil {
+				attrs |= attrIPAddr
+				l += 4 + net.IPv4len
+			}
+		case iana.ProtocolIPv6ICMP:
+			if ifi.Addr.IP.To16() != nil && ifi.Addr.IP.To4() == nil {
+				attrs |= attrIPAddr
+				l += 4 + net.IPv6len
+			}
+		}
+	}
+	return
+}
+
+// Len implements the Len method of Extension interface.
+func (ifi *InterfaceInfo) Len(proto int) int {
+	_, l := ifi.attrsAndLen(proto)
+	return l
+}
+
+// Marshal implements the Marshal method of Extension interface.
+func (ifi *InterfaceInfo) Marshal(proto int) ([]byte, error) {
+	attrs, l := ifi.attrsAndLen(proto)
+	b := make([]byte, l)
+	if err := ifi.marshal(proto, b, attrs, l); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (ifi *InterfaceInfo) marshal(proto int, b []byte, attrs, l int) error {
+	binary.BigEndian.PutUint16(b[:2], uint16(l))
+	b[2], b[3] = classInterfaceInfo, byte(ifi.Type)
+	for b = b[4:]; len(b) > 0 && attrs != 0; {
+		switch {
+		case attrs&attrIfIndex != 0:
+			b = ifi.marshalIfIndex(proto, b)
+			attrs &^= attrIfIndex
+		case attrs&attrIPAddr != 0:
+			b = ifi.marshalIPAddr(proto, b)
+			attrs &^= attrIPAddr
+		case attrs&attrName != 0:
+			b = ifi.marshalName(proto, b)
+			attrs &^= attrName
+		case attrs&attrMTU != 0:
+			b = ifi.marshalMTU(proto, b)
+			attrs &^= attrMTU
+		}
+	}
+	return nil
+}
+
+func (ifi *InterfaceInfo) marshalIfIndex(proto int, b []byte) []byte {
+	binary.BigEndian.PutUint32(b[:4], uint32(ifi.Interface.Index))
+	return b[4:]
+}
+
+func (ifi *InterfaceInfo) parseIfIndex(b []byte) ([]byte, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	ifi.Interface.Index = int(binary.BigEndian.Uint32(b[:4]))
+	return b[4:], nil
+}
+
+func (ifi *InterfaceInfo) marshalIPAddr(proto int, b []byte) []byte {
+	switch proto {
+	case iana.ProtocolICMP:
+		binary.BigEndian.PutUint16(b[:2], uint16(iana.AddrFamilyIPv4))
+		copy(b[4:4+net.IPv4len], ifi.Addr.IP.To4())
+		b = b[4+net.IPv4len:]
+	case iana.ProtocolIPv6ICMP:
+		binary.BigEndian.PutUint16(b[:2], uint16(iana.AddrFamilyIPv6))
+		copy(b[4:4+net.IPv6len], ifi.Addr.IP.To16())
+		b = b[4+net.IPv6len:]
+	}
+	return b
+}
+
+func (ifi *InterfaceInfo) parseIPAddr(b []byte) ([]byte, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	afi := int(binary.BigEndian.Uint16(b[:2]))
+	b = b[4:]
+	switch afi {
+	case iana.AddrFamilyIPv4:
+		if len(b) < net.IPv4len {
+			return nil, errMessageTooShort
+		}
+		ifi.Addr.IP = make(net.IP, net.IPv4len)
+		copy(ifi.Addr.IP, b[:net.IPv4len])
+		b = b[net.IPv4len:]
+	case iana.AddrFamilyIPv6:
+		if len(b) < net.IPv6len {
+			return nil, errMessageTooShort
+		}
+		ifi.Addr.IP = make(net.IP, net.IPv6len)
+		copy(ifi.Addr.IP, b[:net.IPv6len])
+		b = b[net.IPv6len:]
+	}
+	return b, nil
+}
+
+func (ifi *InterfaceInfo) marshalName(proto int, b []byte) []byte {
+	l := byte(ifi.nameLen())
+	b[0] = l
+	copy(b[1:], []byte(ifi.Interface.Name))
+	return b[l:]
+}
+
+func (ifi *InterfaceInfo) parseName(b []byte) ([]byte, error) {
+	if 4 > len(b) || len(b) < int(b[0]) {
+		return nil, errMessageTooShort
+	}
+	l := int(b[0])
+	if l%4 != 0 || 4 > l || l > 64 {
+		return nil, errInvalidExtension
+	}
+	var name [63]byte
+	copy(name[:], b[1:l])
+	ifi.Interface.Name = strings.Trim(string(name[:]), "\000")
+	return b[l:], nil
+}
+
+func (ifi *InterfaceInfo) marshalMTU(proto int, b []byte) []byte {
+	binary.BigEndian.PutUint32(b[:4], uint32(ifi.Interface.MTU))
+	return b[4:]
+}
+
+func (ifi *InterfaceInfo) parseMTU(b []byte) ([]byte, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	ifi.Interface.MTU = int(binary.BigEndian.Uint32(b[:4]))
+	return b[4:], nil
+}
+
+func parseInterfaceInfo(b []byte) (Extension, error) {
+	ifi := &InterfaceInfo{
+		Class: int(b[2]),
+		Type:  int(b[3]),
+	}
+	if ifi.Type&(attrIfIndex|attrName|attrMTU) != 0 {
+		ifi.Interface = &net.Interface{}
+	}
+	if ifi.Type&attrIPAddr != 0 {
+		ifi.Addr = &net.IPAddr{}
+	}
+	attrs := ifi.Type & (attrIfIndex | attrIPAddr | attrName | attrMTU)
+	for b = b[4:]; len(b) > 0 && attrs != 0; {
+		var err error
+		switch {
+		case attrs&attrIfIndex != 0:
+			b, err = ifi.parseIfIndex(b)
+			attrs &^= attrIfIndex
+		case attrs&attrIPAddr != 0:
+			b, err = ifi.parseIPAddr(b)
+			attrs &^= attrIPAddr
+		case attrs&attrName != 0:
+			b, err = ifi.parseName(b)
+			attrs &^= attrName
+		case attrs&attrMTU != 0:
+			b, err = ifi.parseMTU(b)
+			attrs &^= attrMTU
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if ifi.Interface != nil && ifi.Interface.Name != "" && ifi.Addr != nil && ifi.Addr.IP.To16() != nil && ifi.Addr.IP.To4() == nil {
+		ifi.Addr.Zone = ifi.Interface.Name
+	}
+	return ifi, nil
+}
+
+const (
+	classInterfaceIdent    = 3
+	typeInterfaceByName    = 1
+	typeInterfaceByIndex   = 2
+	typeInterfaceByAddress = 3
+)
+
+// An InterfaceIdent represents interface identification.
+type InterfaceIdent struct {
+	Class int    // extension object class number
+	Type  int    // extension object sub-type
+	Name  string // interface name
+	Index int    // interface index
+	AFI   int    // address family identifier; see address family numbers in IANA registry
+	Addr  []byte // address
+}
+
+// Len implements the Len method of Extension interface.
+func (ifi *InterfaceIdent) Len(_ int) int {
+	switch ifi.Type {
+	case typeInterfaceByName:
+		l := len(ifi.Name)
+		if l > 255 {
+			l = 255
+		}
+		return 4 + (l+3)&^3
+	case typeInterfaceByIndex:
+		return 4 + 4
+	case typeInterfaceByAddress:
+		return 4 + 4 + (len(ifi.Addr)+3)&^3
+	default:
+		return 4
+	}
+}
+
+// Marshal implements the Marshal method of Extension interface.
+func (ifi *InterfaceIdent) Marshal(proto int) ([]byte, error) {
+	b := make([]byte, ifi.Len(proto))
+	if err := ifi.marshal(proto, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (ifi *InterfaceIdent) marshal(proto int, b []byte) error {
+	l := ifi.Len(proto)
+	binary.BigEndian.PutUint16(b[:2], uint16(l))
+	b[2], b[3] = classInterfaceIdent, byte(ifi.Type)
+	switch ifi.Type {
+	case typeInterfaceByName:
+		copy(b[4:], ifi.Name)
+	case typeInterfaceByIndex:
+		binary.BigEndian.PutUint32(b[4:4+4], uint32(ifi.Index))
+	case typeInterfaceByAddress:
+		binary.BigEndian.PutUint16(b[4:4+2], uint16(ifi.AFI))
+		b[4+2] = byte(len(ifi.Addr))
+		copy(b[4+4:], ifi.Addr)
+	}
+	return nil
+}
+
+func parseInterfaceIdent(b []byte) (Extension, error) {
+	ifi := &InterfaceIdent{
+		Class: int(b[2]),
+		Type:  int(b[3]),
+	}
+	switch ifi.Type {
+	case typeInterfaceByName:
+		ifi.Name = strings.Trim(string(b[4:]), "\x00")
+	case typeInterfaceByIndex:
+		if len(b[4:]) < 4 {
+			return nil, errInvalidExtension
+		}
+		ifi.Index = int(binary.BigEndian.Uint32(b[4 : 4+4]))
+	case typeInterfaceByAddress:
+		if len(b[4:]) < 4 {
+			return nil, errInvalidExtension
+		}
+		ifi.AFI = int(binary.BigEndian.Uint16(b[4 : 4+2]))
+		l := int(b[4+2])
+		if len(b[4+4:]) < l {
+			return nil, errInvalidExtension
+		}
+		ifi.Addr = make([]byte, l)
+		copy(ifi.Addr, b[4+4:])
+	}
+	return ifi, nil
+}

--- a/vendor/golang.org/x/net/icmp/ipv4.go
+++ b/vendor/golang.org/x/net/icmp/ipv4.go
@@ -1,0 +1,69 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"encoding/binary"
+	"net"
+	"runtime"
+
+	"golang.org/x/net/internal/socket"
+	"golang.org/x/net/ipv4"
+)
+
+// freebsdVersion is set in sys_freebsd.go.
+// See http://www.freebsd.org/doc/en/books/porters-handbook/freebsd-versions.html.
+var freebsdVersion uint32
+
+// ParseIPv4Header returns the IPv4 header of the IPv4 packet that
+// triggered an ICMP error message.
+// This is found in the Data field of the ICMP error message body.
+//
+// The provided b must be in the format used by a raw ICMP socket on
+// the local system.
+// This may differ from the wire format, and the format used by a raw
+// IP socket, depending on the system.
+//
+// To parse an IPv6 header, use ipv6.ParseHeader.
+func ParseIPv4Header(b []byte) (*ipv4.Header, error) {
+	if len(b) < ipv4.HeaderLen {
+		return nil, errHeaderTooShort
+	}
+	hdrlen := int(b[0]&0x0f) << 2
+	if hdrlen > len(b) {
+		return nil, errBufferTooShort
+	}
+	h := &ipv4.Header{
+		Version:  int(b[0] >> 4),
+		Len:      hdrlen,
+		TOS:      int(b[1]),
+		ID:       int(binary.BigEndian.Uint16(b[4:6])),
+		FragOff:  int(binary.BigEndian.Uint16(b[6:8])),
+		TTL:      int(b[8]),
+		Protocol: int(b[9]),
+		Checksum: int(binary.BigEndian.Uint16(b[10:12])),
+		Src:      net.IPv4(b[12], b[13], b[14], b[15]),
+		Dst:      net.IPv4(b[16], b[17], b[18], b[19]),
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		h.TotalLen = int(socket.NativeEndian.Uint16(b[2:4]))
+	case "freebsd":
+		if freebsdVersion >= 1000000 {
+			h.TotalLen = int(binary.BigEndian.Uint16(b[2:4]))
+		} else {
+			h.TotalLen = int(socket.NativeEndian.Uint16(b[2:4]))
+		}
+	default:
+		h.TotalLen = int(binary.BigEndian.Uint16(b[2:4]))
+	}
+	h.Flags = ipv4.HeaderFlags(h.FragOff&0xe000) >> 13
+	h.FragOff = h.FragOff & 0x1fff
+	if hdrlen-ipv4.HeaderLen > 0 {
+		h.Options = make([]byte, hdrlen-ipv4.HeaderLen)
+		copy(h.Options, b[ipv4.HeaderLen:])
+	}
+	return h, nil
+}

--- a/vendor/golang.org/x/net/icmp/ipv6.go
+++ b/vendor/golang.org/x/net/icmp/ipv6.go
@@ -1,0 +1,23 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"net"
+
+	"golang.org/x/net/internal/iana"
+)
+
+const ipv6PseudoHeaderLen = 2*net.IPv6len + 8
+
+// IPv6PseudoHeader returns an IPv6 pseudo header for checksum
+// calculation.
+func IPv6PseudoHeader(src, dst net.IP) []byte {
+	b := make([]byte, ipv6PseudoHeaderLen)
+	copy(b, src.To16())
+	copy(b[net.IPv6len:], dst.To16())
+	b[len(b)-1] = byte(iana.ProtocolIPv6ICMP)
+	return b
+}

--- a/vendor/golang.org/x/net/icmp/listen_posix.go
+++ b/vendor/golang.org/x/net/icmp/listen_posix.go
@@ -1,0 +1,103 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris windows
+
+package icmp
+
+import (
+	"net"
+	"os"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const sysIP_STRIPHDR = 0x17 // for now only darwin supports this option
+
+// ListenPacket listens for incoming ICMP packets addressed to
+// address. See net.Dial for the syntax of address.
+//
+// For non-privileged datagram-oriented ICMP endpoints, network must
+// be "udp4" or "udp6". The endpoint allows to read, write a few
+// limited ICMP messages such as echo request and echo reply.
+// Currently only Darwin and Linux support this.
+//
+// Examples:
+//	ListenPacket("udp4", "192.168.0.1")
+//	ListenPacket("udp4", "0.0.0.0")
+//	ListenPacket("udp6", "fe80::1%en0")
+//	ListenPacket("udp6", "::")
+//
+// For privileged raw ICMP endpoints, network must be "ip4" or "ip6"
+// followed by a colon and an ICMP protocol number or name.
+//
+// Examples:
+//	ListenPacket("ip4:icmp", "192.168.0.1")
+//	ListenPacket("ip4:1", "0.0.0.0")
+//	ListenPacket("ip6:ipv6-icmp", "fe80::1%en0")
+//	ListenPacket("ip6:58", "::")
+func ListenPacket(network, address string) (*PacketConn, error) {
+	var family, proto int
+	switch network {
+	case "udp4":
+		family, proto = syscall.AF_INET, iana.ProtocolICMP
+	case "udp6":
+		family, proto = syscall.AF_INET6, iana.ProtocolIPv6ICMP
+	default:
+		i := last(network, ':')
+		if i < 0 {
+			i = len(network)
+		}
+		switch network[:i] {
+		case "ip4":
+			proto = iana.ProtocolICMP
+		case "ip6":
+			proto = iana.ProtocolIPv6ICMP
+		}
+	}
+	var cerr error
+	var c net.PacketConn
+	switch family {
+	case syscall.AF_INET, syscall.AF_INET6:
+		s, err := syscall.Socket(family, syscall.SOCK_DGRAM, proto)
+		if err != nil {
+			return nil, os.NewSyscallError("socket", err)
+		}
+		if runtime.GOOS == "darwin" && family == syscall.AF_INET {
+			if err := syscall.SetsockoptInt(s, iana.ProtocolIP, sysIP_STRIPHDR, 1); err != nil {
+				syscall.Close(s)
+				return nil, os.NewSyscallError("setsockopt", err)
+			}
+		}
+		sa, err := sockaddr(family, address)
+		if err != nil {
+			syscall.Close(s)
+			return nil, err
+		}
+		if err := syscall.Bind(s, sa); err != nil {
+			syscall.Close(s)
+			return nil, os.NewSyscallError("bind", err)
+		}
+		f := os.NewFile(uintptr(s), "datagram-oriented icmp")
+		c, cerr = net.FilePacketConn(f)
+		f.Close()
+	default:
+		c, cerr = net.ListenPacket(network, address)
+	}
+	if cerr != nil {
+		return nil, cerr
+	}
+	switch proto {
+	case iana.ProtocolICMP:
+		return &PacketConn{c: c, p4: ipv4.NewPacketConn(c)}, nil
+	case iana.ProtocolIPv6ICMP:
+		return &PacketConn{c: c, p6: ipv6.NewPacketConn(c)}, nil
+	default:
+		return &PacketConn{c: c}, nil
+	}
+}

--- a/vendor/golang.org/x/net/icmp/listen_stub.go
+++ b/vendor/golang.org/x/net/icmp/listen_stub.go
@@ -1,0 +1,33 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows
+
+package icmp
+
+// ListenPacket listens for incoming ICMP packets addressed to
+// address. See net.Dial for the syntax of address.
+//
+// For non-privileged datagram-oriented ICMP endpoints, network must
+// be "udp4" or "udp6". The endpoint allows to read, write a few
+// limited ICMP messages such as echo request and echo reply.
+// Currently only Darwin and Linux support this.
+//
+// Examples:
+//	ListenPacket("udp4", "192.168.0.1")
+//	ListenPacket("udp4", "0.0.0.0")
+//	ListenPacket("udp6", "fe80::1%en0")
+//	ListenPacket("udp6", "::")
+//
+// For privileged raw ICMP endpoints, network must be "ip4" or "ip6"
+// followed by a colon and an ICMP protocol number or name.
+//
+// Examples:
+//	ListenPacket("ip4:icmp", "192.168.0.1")
+//	ListenPacket("ip4:1", "0.0.0.0")
+//	ListenPacket("ip6:ipv6-icmp", "fe80::1%en0")
+//	ListenPacket("ip6:58", "::")
+func ListenPacket(network, address string) (*PacketConn, error) {
+	return nil, errNotImplemented
+}

--- a/vendor/golang.org/x/net/icmp/message.go
+++ b/vendor/golang.org/x/net/icmp/message.go
@@ -1,0 +1,162 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package icmp provides basic functions for the manipulation of
+// messages used in the Internet Control Message Protocols,
+// ICMPv4 and ICMPv6.
+//
+// ICMPv4 and ICMPv6 are defined in RFC 792 and RFC 4443.
+// Multi-part message support for ICMP is defined in RFC 4884.
+// ICMP extensions for MPLS are defined in RFC 4950.
+// ICMP extensions for interface and next-hop identification are
+// defined in RFC 5837.
+// PROBE: A utility for probing interfaces is defined in RFC 8335.
+package icmp // import "golang.org/x/net/icmp"
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"runtime"
+
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// BUG(mikio): This package is not implemented on JS, NaCl and Plan 9.
+
+var (
+	errInvalidConn      = errors.New("invalid connection")
+	errInvalidProtocol  = errors.New("invalid protocol")
+	errMessageTooShort  = errors.New("message too short")
+	errHeaderTooShort   = errors.New("header too short")
+	errBufferTooShort   = errors.New("buffer too short")
+	errInvalidBody      = errors.New("invalid body")
+	errNoExtension      = errors.New("no extension")
+	errInvalidExtension = errors.New("invalid extension")
+	errNotImplemented   = errors.New("not implemented on " + runtime.GOOS + "/" + runtime.GOARCH)
+)
+
+func checksum(b []byte) uint16 {
+	csumcv := len(b) - 1 // checksum coverage
+	s := uint32(0)
+	for i := 0; i < csumcv; i += 2 {
+		s += uint32(b[i+1])<<8 | uint32(b[i])
+	}
+	if csumcv&1 == 0 {
+		s += uint32(b[csumcv])
+	}
+	s = s>>16 + s&0xffff
+	s = s + s>>16
+	return ^uint16(s)
+}
+
+// A Type represents an ICMP message type.
+type Type interface {
+	Protocol() int
+}
+
+// A Message represents an ICMP message.
+type Message struct {
+	Type     Type        // type, either ipv4.ICMPType or ipv6.ICMPType
+	Code     int         // code
+	Checksum int         // checksum
+	Body     MessageBody // body
+}
+
+// Marshal returns the binary encoding of the ICMP message m.
+//
+// For an ICMPv4 message, the returned message always contains the
+// calculated checksum field.
+//
+// For an ICMPv6 message, the returned message contains the calculated
+// checksum field when psh is not nil, otherwise the kernel will
+// compute the checksum field during the message transmission.
+// When psh is not nil, it must be the pseudo header for IPv6.
+func (m *Message) Marshal(psh []byte) ([]byte, error) {
+	var mtype byte
+	switch typ := m.Type.(type) {
+	case ipv4.ICMPType:
+		mtype = byte(typ)
+	case ipv6.ICMPType:
+		mtype = byte(typ)
+	default:
+		return nil, errInvalidProtocol
+	}
+	b := []byte{mtype, byte(m.Code), 0, 0}
+	proto := m.Type.Protocol()
+	if proto == iana.ProtocolIPv6ICMP && psh != nil {
+		b = append(psh, b...)
+	}
+	if m.Body != nil && m.Body.Len(proto) != 0 {
+		mb, err := m.Body.Marshal(proto)
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, mb...)
+	}
+	if proto == iana.ProtocolIPv6ICMP {
+		if psh == nil { // cannot calculate checksum here
+			return b, nil
+		}
+		off, l := 2*net.IPv6len, len(b)-len(psh)
+		binary.BigEndian.PutUint32(b[off:off+4], uint32(l))
+	}
+	s := checksum(b)
+	// Place checksum back in header; using ^= avoids the
+	// assumption the checksum bytes are zero.
+	b[len(psh)+2] ^= byte(s)
+	b[len(psh)+3] ^= byte(s >> 8)
+	return b[len(psh):], nil
+}
+
+var parseFns = map[Type]func(int, Type, []byte) (MessageBody, error){
+	ipv4.ICMPTypeDestinationUnreachable: parseDstUnreach,
+	ipv4.ICMPTypeTimeExceeded:           parseTimeExceeded,
+	ipv4.ICMPTypeParameterProblem:       parseParamProb,
+
+	ipv4.ICMPTypeEcho:                parseEcho,
+	ipv4.ICMPTypeEchoReply:           parseEcho,
+	ipv4.ICMPTypeExtendedEchoRequest: parseExtendedEchoRequest,
+	ipv4.ICMPTypeExtendedEchoReply:   parseExtendedEchoReply,
+
+	ipv6.ICMPTypeDestinationUnreachable: parseDstUnreach,
+	ipv6.ICMPTypePacketTooBig:           parsePacketTooBig,
+	ipv6.ICMPTypeTimeExceeded:           parseTimeExceeded,
+	ipv6.ICMPTypeParameterProblem:       parseParamProb,
+
+	ipv6.ICMPTypeEchoRequest:         parseEcho,
+	ipv6.ICMPTypeEchoReply:           parseEcho,
+	ipv6.ICMPTypeExtendedEchoRequest: parseExtendedEchoRequest,
+	ipv6.ICMPTypeExtendedEchoReply:   parseExtendedEchoReply,
+}
+
+// ParseMessage parses b as an ICMP message.
+// The provided proto must be either the ICMPv4 or ICMPv6 protocol
+// number.
+func ParseMessage(proto int, b []byte) (*Message, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	var err error
+	m := &Message{Code: int(b[1]), Checksum: int(binary.BigEndian.Uint16(b[2:4]))}
+	switch proto {
+	case iana.ProtocolICMP:
+		m.Type = ipv4.ICMPType(b[0])
+	case iana.ProtocolIPv6ICMP:
+		m.Type = ipv6.ICMPType(b[0])
+	default:
+		return nil, errInvalidProtocol
+	}
+	if fn, ok := parseFns[m.Type]; !ok {
+		m.Body, err = parseRawBody(proto, b[4:])
+	} else {
+		m.Body, err = fn(proto, m.Type, b[4:])
+	}
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/vendor/golang.org/x/net/icmp/messagebody.go
+++ b/vendor/golang.org/x/net/icmp/messagebody.go
@@ -1,0 +1,52 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+// A MessageBody represents an ICMP message body.
+type MessageBody interface {
+	// Len returns the length of ICMP message body.
+	// The provided proto must be either the ICMPv4 or ICMPv6
+	// protocol number.
+	Len(proto int) int
+
+	// Marshal returns the binary encoding of ICMP message body.
+	// The provided proto must be either the ICMPv4 or ICMPv6
+	// protocol number.
+	Marshal(proto int) ([]byte, error)
+}
+
+// A RawBody represents a raw message body.
+//
+// A raw message body is excluded from message processing and can be
+// used to construct applications such as protocol conformance
+// testing.
+type RawBody struct {
+	Data []byte // data
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *RawBody) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	return len(p.Data)
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *RawBody) Marshal(proto int) ([]byte, error) {
+	return p.Data, nil
+}
+
+// parseRawBody parses b as an ICMP message body.
+func parseRawBody(proto int, b []byte) (MessageBody, error) {
+	p := &RawBody{Data: make([]byte, len(b))}
+	copy(p.Data, b)
+	return p, nil
+}
+
+// A DefaultMessageBody represents the default message body.
+//
+// Deprecated: Use RawBody instead.
+type DefaultMessageBody = RawBody

--- a/vendor/golang.org/x/net/icmp/mpls.go
+++ b/vendor/golang.org/x/net/icmp/mpls.go
@@ -1,0 +1,77 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import "encoding/binary"
+
+// MPLSLabel represents an MPLS label stack entry.
+type MPLSLabel struct {
+	Label int  // label value
+	TC    int  // traffic class; formerly experimental use
+	S     bool // bottom of stack
+	TTL   int  // time to live
+}
+
+const (
+	classMPLSLabelStack        = 1
+	typeIncomingMPLSLabelStack = 1
+)
+
+// MPLSLabelStack represents an MPLS label stack.
+type MPLSLabelStack struct {
+	Class  int // extension object class number
+	Type   int // extension object sub-type
+	Labels []MPLSLabel
+}
+
+// Len implements the Len method of Extension interface.
+func (ls *MPLSLabelStack) Len(proto int) int {
+	return 4 + (4 * len(ls.Labels))
+}
+
+// Marshal implements the Marshal method of Extension interface.
+func (ls *MPLSLabelStack) Marshal(proto int) ([]byte, error) {
+	b := make([]byte, ls.Len(proto))
+	if err := ls.marshal(proto, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (ls *MPLSLabelStack) marshal(proto int, b []byte) error {
+	l := ls.Len(proto)
+	binary.BigEndian.PutUint16(b[:2], uint16(l))
+	b[2], b[3] = classMPLSLabelStack, typeIncomingMPLSLabelStack
+	off := 4
+	for _, ll := range ls.Labels {
+		b[off], b[off+1], b[off+2] = byte(ll.Label>>12), byte(ll.Label>>4&0xff), byte(ll.Label<<4&0xf0)
+		b[off+2] |= byte(ll.TC << 1 & 0x0e)
+		if ll.S {
+			b[off+2] |= 0x1
+		}
+		b[off+3] = byte(ll.TTL)
+		off += 4
+	}
+	return nil
+}
+
+func parseMPLSLabelStack(b []byte) (Extension, error) {
+	ls := &MPLSLabelStack{
+		Class: int(b[2]),
+		Type:  int(b[3]),
+	}
+	for b = b[4:]; len(b) >= 4; b = b[4:] {
+		ll := MPLSLabel{
+			Label: int(b[0])<<12 | int(b[1])<<4 | int(b[2])>>4,
+			TC:    int(b[2]&0x0e) >> 1,
+			TTL:   int(b[3]),
+		}
+		if b[2]&0x1 != 0 {
+			ll.S = true
+		}
+		ls.Labels = append(ls.Labels, ll)
+	}
+	return ls, nil
+}

--- a/vendor/golang.org/x/net/icmp/multipart.go
+++ b/vendor/golang.org/x/net/icmp/multipart.go
@@ -1,0 +1,129 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import "golang.org/x/net/internal/iana"
+
+// multipartMessageBodyDataLen takes b as an original datagram and
+// exts as extensions, and returns a required length for message body
+// and a required length for a padded original datagram in wire
+// format.
+func multipartMessageBodyDataLen(proto int, withOrigDgram bool, b []byte, exts []Extension) (bodyLen, dataLen int) {
+	bodyLen = 4 // length of leading octets
+	var extLen int
+	var rawExt bool // raw extension may contain an empty object
+	for _, ext := range exts {
+		extLen += ext.Len(proto)
+		if _, ok := ext.(*RawExtension); ok {
+			rawExt = true
+		}
+	}
+	if extLen > 0 && withOrigDgram {
+		dataLen = multipartMessageOrigDatagramLen(proto, b)
+	} else {
+		dataLen = len(b)
+	}
+	if extLen > 0 || rawExt {
+		bodyLen += 4 // length of extension header
+	}
+	bodyLen += dataLen + extLen
+	return bodyLen, dataLen
+}
+
+// multipartMessageOrigDatagramLen takes b as an original datagram,
+// and returns a required length for a padded orignal datagram in wire
+// format.
+func multipartMessageOrigDatagramLen(proto int, b []byte) int {
+	roundup := func(b []byte, align int) int {
+		// According to RFC 4884, the padded original datagram
+		// field must contain at least 128 octets.
+		if len(b) < 128 {
+			return 128
+		}
+		r := len(b)
+		return (r + align - 1) &^ (align - 1)
+	}
+	switch proto {
+	case iana.ProtocolICMP:
+		return roundup(b, 4)
+	case iana.ProtocolIPv6ICMP:
+		return roundup(b, 8)
+	default:
+		return len(b)
+	}
+}
+
+// marshalMultipartMessageBody takes data as an original datagram and
+// exts as extesnsions, and returns a binary encoding of message body.
+// It can be used for non-multipart message bodies when exts is nil.
+func marshalMultipartMessageBody(proto int, withOrigDgram bool, data []byte, exts []Extension) ([]byte, error) {
+	bodyLen, dataLen := multipartMessageBodyDataLen(proto, withOrigDgram, data, exts)
+	b := make([]byte, bodyLen)
+	copy(b[4:], data)
+	if len(exts) > 0 {
+		b[4+dataLen] = byte(extensionVersion << 4)
+		off := 4 + dataLen + 4 // leading octets, data, extension header
+		for _, ext := range exts {
+			switch ext := ext.(type) {
+			case *MPLSLabelStack:
+				if err := ext.marshal(proto, b[off:]); err != nil {
+					return nil, err
+				}
+				off += ext.Len(proto)
+			case *InterfaceInfo:
+				attrs, l := ext.attrsAndLen(proto)
+				if err := ext.marshal(proto, b[off:], attrs, l); err != nil {
+					return nil, err
+				}
+				off += ext.Len(proto)
+			case *InterfaceIdent:
+				if err := ext.marshal(proto, b[off:]); err != nil {
+					return nil, err
+				}
+				off += ext.Len(proto)
+			case *RawExtension:
+				copy(b[off:], ext.Data)
+				off += ext.Len(proto)
+			}
+		}
+		s := checksum(b[4+dataLen:])
+		b[4+dataLen+2] ^= byte(s)
+		b[4+dataLen+3] ^= byte(s >> 8)
+		if withOrigDgram {
+			switch proto {
+			case iana.ProtocolICMP:
+				b[1] = byte(dataLen / 4)
+			case iana.ProtocolIPv6ICMP:
+				b[0] = byte(dataLen / 8)
+			}
+		}
+	}
+	return b, nil
+}
+
+// parseMultipartMessageBody parses b as either a non-multipart
+// message body or a multipart message body.
+func parseMultipartMessageBody(proto int, typ Type, b []byte) ([]byte, []Extension, error) {
+	var l int
+	switch proto {
+	case iana.ProtocolICMP:
+		l = 4 * int(b[1])
+	case iana.ProtocolIPv6ICMP:
+		l = 8 * int(b[0])
+	}
+	if len(b) == 4 {
+		return nil, nil, nil
+	}
+	exts, l, err := parseExtensions(typ, b[4:], l)
+	if err != nil {
+		l = len(b) - 4
+	}
+	var data []byte
+	if l > 0 {
+		data = make([]byte, l)
+		copy(data, b[4:])
+	}
+	return data, exts, nil
+}

--- a/vendor/golang.org/x/net/icmp/packettoobig.go
+++ b/vendor/golang.org/x/net/icmp/packettoobig.go
@@ -1,0 +1,43 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import "encoding/binary"
+
+// A PacketTooBig represents an ICMP packet too big message body.
+type PacketTooBig struct {
+	MTU  int    // maximum transmission unit of the nexthop link
+	Data []byte // data, known as original datagram field
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *PacketTooBig) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	return 4 + len(p.Data)
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *PacketTooBig) Marshal(proto int) ([]byte, error) {
+	b := make([]byte, 4+len(p.Data))
+	binary.BigEndian.PutUint32(b[:4], uint32(p.MTU))
+	copy(b[4:], p.Data)
+	return b, nil
+}
+
+// parsePacketTooBig parses b as an ICMP packet too big message body.
+func parsePacketTooBig(proto int, _ Type, b []byte) (MessageBody, error) {
+	bodyLen := len(b)
+	if bodyLen < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &PacketTooBig{MTU: int(binary.BigEndian.Uint32(b[:4]))}
+	if bodyLen > 4 {
+		p.Data = make([]byte, bodyLen-4)
+		copy(p.Data, b[4:])
+	}
+	return p, nil
+}

--- a/vendor/golang.org/x/net/icmp/paramprob.go
+++ b/vendor/golang.org/x/net/icmp/paramprob.go
@@ -1,0 +1,72 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+)
+
+// A ParamProb represents an ICMP parameter problem message body.
+type ParamProb struct {
+	Pointer    uintptr     // offset within the data where the error was detected
+	Data       []byte      // data, known as original datagram field
+	Extensions []Extension // extensions
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *ParamProb) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	l, _ := multipartMessageBodyDataLen(proto, true, p.Data, p.Extensions)
+	return l
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *ParamProb) Marshal(proto int) ([]byte, error) {
+	switch proto {
+	case iana.ProtocolICMP:
+		if !validExtensions(ipv4.ICMPTypeParameterProblem, p.Extensions) {
+			return nil, errInvalidExtension
+		}
+		b, err := marshalMultipartMessageBody(proto, true, p.Data, p.Extensions)
+		if err != nil {
+			return nil, err
+		}
+		b[0] = byte(p.Pointer)
+		return b, nil
+	case iana.ProtocolIPv6ICMP:
+		b := make([]byte, p.Len(proto))
+		binary.BigEndian.PutUint32(b[:4], uint32(p.Pointer))
+		copy(b[4:], p.Data)
+		return b, nil
+	default:
+		return nil, errInvalidProtocol
+	}
+}
+
+// parseParamProb parses b as an ICMP parameter problem message body.
+func parseParamProb(proto int, typ Type, b []byte) (MessageBody, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &ParamProb{}
+	if proto == iana.ProtocolIPv6ICMP {
+		p.Pointer = uintptr(binary.BigEndian.Uint32(b[:4]))
+		p.Data = make([]byte, len(b)-4)
+		copy(p.Data, b[4:])
+		return p, nil
+	}
+	p.Pointer = uintptr(b[0])
+	var err error
+	p.Data, p.Extensions, err = parseMultipartMessageBody(proto, typ, b)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/vendor/golang.org/x/net/icmp/sys_freebsd.go
+++ b/vendor/golang.org/x/net/icmp/sys_freebsd.go
@@ -1,0 +1,11 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import "syscall"
+
+func init() {
+	freebsdVersion, _ = syscall.SysctlUint32("kern.osreldate")
+}

--- a/vendor/golang.org/x/net/icmp/timeexceeded.go
+++ b/vendor/golang.org/x/net/icmp/timeexceeded.go
@@ -1,0 +1,57 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package icmp
+
+import (
+	"golang.org/x/net/internal/iana"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// A TimeExceeded represents an ICMP time exceeded message body.
+type TimeExceeded struct {
+	Data       []byte      // data, known as original datagram field
+	Extensions []Extension // extensions
+}
+
+// Len implements the Len method of MessageBody interface.
+func (p *TimeExceeded) Len(proto int) int {
+	if p == nil {
+		return 0
+	}
+	l, _ := multipartMessageBodyDataLen(proto, true, p.Data, p.Extensions)
+	return l
+}
+
+// Marshal implements the Marshal method of MessageBody interface.
+func (p *TimeExceeded) Marshal(proto int) ([]byte, error) {
+	var typ Type
+	switch proto {
+	case iana.ProtocolICMP:
+		typ = ipv4.ICMPTypeTimeExceeded
+	case iana.ProtocolIPv6ICMP:
+		typ = ipv6.ICMPTypeTimeExceeded
+	default:
+		return nil, errInvalidProtocol
+	}
+	if !validExtensions(typ, p.Extensions) {
+		return nil, errInvalidExtension
+	}
+	return marshalMultipartMessageBody(proto, true, p.Data, p.Extensions)
+}
+
+// parseTimeExceeded parses b as an ICMP time exceeded message body.
+func parseTimeExceeded(proto int, typ Type, b []byte) (MessageBody, error) {
+	if len(b) < 4 {
+		return nil, errMessageTooShort
+	}
+	p := &TimeExceeded{}
+	var err error
+	p.Data, p.Extensions, err = parseMultipartMessageBody(proto, typ, b)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/gravitational/etcd-backup/lib/etcd
 github.com/gravitational/go-udev
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1
+# github.com/gravitational/satellite v0.0.9-0.20200922194151-c87e17725fd6
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/backend/inmemory
 github.com/gravitational/satellite/agent/cache

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/gravitational/etcd-backup/lib/etcd
 github.com/gravitational/go-udev
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200912031740-ed6bca08a485
+# github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/backend/inmemory
 github.com/gravitational/satellite/agent/cache

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/gravitational/etcd-backup/lib/etcd
 github.com/gravitational/go-udev
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922
+# github.com/gravitational/satellite v0.0.9-0.20200922035717-72df43de52a1
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/backend/inmemory
 github.com/gravitational/satellite/agent/cache

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/gravitational/etcd-backup/lib/etcd
 github.com/gravitational/go-udev
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200915185602-5f78daf69e77
+# github.com/gravitational/satellite v0.0.9-0.20200922030426-b4cdbbd13922
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/backend/inmemory
 github.com/gravitational/satellite/agent/cache
@@ -165,6 +165,7 @@ github.com/gravitational/satellite/lib/history
 github.com/gravitational/satellite/lib/history/sqlite
 github.com/gravitational/satellite/lib/kubernetes
 github.com/gravitational/satellite/lib/membership
+github.com/gravitational/satellite/lib/nethealth
 github.com/gravitational/satellite/lib/rpc
 github.com/gravitational/satellite/lib/rpc/client
 github.com/gravitational/satellite/monitoring
@@ -371,6 +372,7 @@ golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
+golang.org/x/net/icmp
 golang.org/x/net/idna
 golang.org/x/net/internal/iana
 golang.org/x/net/internal/socket


### PR DESCRIPTION
1. Tunes the kubernetes api-server to allow 5x the default inflight requests. We were hitting limits when scaling the cluster. I don't believe I've ever witnessed us hitting these limits on a small cluster where having a smaller limit is important. The implication is an authenticated client may be able to resource starve the apiserver on small master nodes (which is already the case really). Newer versions of kubernetes have a priority queuing mechanism, that would help avoid being able to starve this out.

2. System pods checker only runs on master nodes. 