### PR TITLE
system checker should not run on workers with recent changes

### DIFF
--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -341,16 +341,6 @@ func addToNode(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDConf
 	}
 	node.AddChecker(nethealthChecker)
 
-	systemPodsChecker, err := monitoring.NewSystemPodsChecker(
-		monitoring.SystemPodsConfig{
-			KubeConfig: &nodeConfig,
-		},
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	node.AddChecker(systemPodsChecker)
-
 	return nil
 }
 


### PR DESCRIPTION
Broken backport to 6.1, where the system pod checker is running on each node. With satellite changes to reduce query load, it's only expected to run on masters.