### PR TITLE
[6.1.x] Update system pods check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,7 +385,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/6.1.x/system-pods"
   digest = "1:527ab6baa75def81e50bdd7ae8bf30d560d966b0accd15bb26e7583481d0c8c1"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -407,7 +406,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "1e169458e886642cc487955d384bf7f7b8002cd6"
+  revision = "065d18f5cc6d6dfa2ccdd73fcf02979465efa430"
+  version = "6.1.18"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,7 +385,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:554a173359d02ee6b34576f5fdf7a6c03d9da2180ad53126dbea3f4e202a36a5"
+  branch = "bernard/6.1.x/system-pods"
+  digest = "1:527ab6baa75def81e50bdd7ae8bf30d560d966b0accd15bb26e7583481d0c8c1"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -406,8 +407,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "59fb383cc5792e9c597e44f413b30722c57fc19b"
-  version = "6.1.17"
+  revision = "1e169458e886642cc487955d384bf7f7b8002cd6"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,7 +90,8 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.17"
+  # version = "=6.1.17"
+  branch = "bernard/6.1.x/system-pods"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,8 +90,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=6.1.17"
-  branch = "bernard/6.1.x/system-pods"
+  version = "=6.1.18"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -74,6 +74,8 @@ type Config struct {
 	ServiceUID string
 	// ServiceGID is the GID of the service (planet) user.
 	ServiceGID string
+	// CriticalNamespaces lists the namespaces of critical system pods.
+	CriticalNamespaces []string
 }
 
 // LocalTransport returns http transport that is set up with local certificate authority
@@ -275,6 +277,7 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 	systemPodsChecker, err := monitoring.NewSystemPodsChecker(
 		monitoring.SystemPodsConfig{
 			KubeConfig: &kubeConfig,
+			Namespaces: config.CriticalNamespaces,
 		},
 	)
 	if err != nil {

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -255,6 +255,9 @@ const (
 
 	// EnvPlanetServiceSubnet specifies the service subnet
 	EnvPlanetServiceSubnet = "PLANET_SERVICE_SUBNET"
+	// EnvCriticalNamespaces lists the Kubernetes namespaces to search for
+	// critical system pods.
+	EnvCriticalNamespaces = "PLANET_CRITICAL_NAMESPACES"
 
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
@@ -420,6 +423,10 @@ const (
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"
+
+	// DefaultCriticalNamespaces is the default list of critical namespaces
+	DefaultCriticalNamespaces = "kube-system,monitoring"
+
 	// DNSEnvFile specifies the file location to write information about the overlay network
 	// in use to be picked up by scripts
 	DNSEnvFile = "/run/dns.env"

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -174,6 +174,7 @@ func run() error {
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
 		cagentServiceCIDR            = cidrFlag(cagent.Flag("service-subnet", "IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.").Default(DefaultServiceSubnet).Envar(EnvServiceSubnet))
+		cagentCriticalNamespaces     = List(cagent.Flag("critical-namespaces", "List of Kubernetes namespaces to search for critical system pods").Default(DefaultCriticalNamespaces).OverrideDefaultFromEnvar(EnvCriticalNamespaces))
 
 		// stop a running container
 		cstop = app.Command("stop", "Stop planet container")
@@ -349,6 +350,7 @@ func run() error {
 				ServiceUID:            *cagentServiceUID,
 				ServiceGID:            *cagentServiceGID,
 				NodeName:              *cagentNodeName,
+				CriticalNamespaces:    *cagentCriticalNamespaces,
 			},
 			leader: &LeaderConfig{
 				PublicIP:        cagentPublicIP.String(),

--- a/vendor/github.com/gravitational/satellite/lib/kubernetes/constants.go
+++ b/vendor/github.com/gravitational/satellite/lib/kubernetes/constants.go
@@ -16,5 +16,7 @@ limitations under the License.
 
 package kubernetes
 
-// AllNamespaces can be used to query pods in all namespaces.
-const AllNamespaces = ""
+const (
+	// AllNamespaces can be used to query pods in all namespaces.
+	AllNamespaces = ""
+)

--- a/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
@@ -171,7 +171,7 @@ func (c Config) New() (*Server, error) {
 		promPeerRequest: promPeerRequest,
 		selector:        labelSelector,
 		triggerResync:   make(chan bool, 1),
-		rxMessage:       make(chan messageWrapper, 100),
+		rxMessage:       make(chan messageWrapper, RxQueueSize),
 		peers:           make(map[string]*peer),
 		addrToPeer:      make(map[string]string),
 	}, nil

--- a/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	"github.com/gravitational/satellite/lib/kubernetes"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/trace"
@@ -35,6 +34,8 @@ import (
 type SystemPodsConfig struct {
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
+	// Namespaces specifies the list of namespaces to query for critical pods.
+	Namespaces []string
 }
 
 // checkAndSetDefaults validates that this configuration is correct and sets
@@ -98,16 +99,20 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 
 // getPods returns a list of the local pods that have the
 // `gravitational.io/critical-pod` label.
-func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
+func (r *systemPodsChecker) getPods() (pods []corev1.Pod, err error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
 	}
-	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
-	if err != nil {
-		return nil, utils.ConvertError(err)
+
+	for _, namespace := range r.Namespaces {
+		podList, err := r.Client.CoreV1().Pods(namespace).List(opts)
+		if err != nil {
+			return pods, utils.ConvertError(err)
+		}
+		pods = append(pods, podList.Items...)
 	}
 
-	return pods.Items, nil
+	return pods, nil
 }
 
 // verifyPods verifies the pods are in a valid state. Reports a failed probe for


### PR DESCRIPTION
## Description
Update system pods check. This patch will help reduce the load on etcd if there are a large number of pods in user namespaces. System pods check will only search the `kube-system` and `monitoring` namespaces for system pods.

## Linked tickets and PRs
* Requires gravitational/satellite#280
* Ports https://github.com/gravitational/planet/pull/772