### PR TITLE
[7.0.x] Update system pods check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "bernard/7.0.x/system-pods"
   digest = "1:6431d8417c06afed8394a2ec98732d59d8f4272dbdc6966076602b57d3efcbf1"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -452,7 +451,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "3863af1f53f0158b0cf81317e9719654e8ed7a68"
+  revision = "853c9e775c27c30c8eee3c2fbd683daf0bcf6548"
+  version = "7.0.23"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0dbb12f9a0c4799557ee61fa5d07b8ad4db674c0b54904f7d17f5390ae71e79a"
+  branch = "bernard/7.0.x/system-pods"
+  digest = "1:6431d8417c06afed8394a2ec98732d59d8f4272dbdc6966076602b57d3efcbf1"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -451,8 +452,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "df447e4093bc3920f4e8121a54a516e07acb89df"
-  version = "7.0.22"
+  revision = "3863af1f53f0158b0cf81317e9719654e8ed7a68"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,8 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.22"
+  # version = "=7.0.22"
+  branch = "bernard/7.0.x/system-pods"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,8 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  # version = "=7.0.22"
-  branch = "bernard/7.0.x/system-pods"
+  version = "=7.0.23"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/lib/monitoring/checkers.go
+++ b/lib/monitoring/checkers.go
@@ -77,6 +77,8 @@ type Config struct {
 	ServiceGID string
 	// HTTPTimeout specifies the HTTP timeout for checks
 	HTTPTimeout time.Duration
+	// CriticalNamespaces lists the namespaces of critical system pods.
+	CriticalNamespaces []string
 }
 
 // CheckAndSetDefaults validates monitoring configuration
@@ -310,6 +312,7 @@ func addToMaster(node agent.Agent, config *Config, etcdConfig *monitoring.ETCDCo
 	systemPodsChecker, err := monitoring.NewSystemPodsChecker(
 		monitoring.SystemPodsConfig{
 			KubeConfig: &kubeConfig,
+			Namespaces: config.CriticalNamespaces,
 		},
 	)
 	if err != nil {

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -259,6 +259,9 @@ const (
 	// EnvPlanetSELinux is an environment variable that indicates whether
 	// SELinux support has been requested
 	EnvPlanetSELinux = "PLANET_SELINUX"
+	// EnvCriticalNamespaces lists the Kubernetes namespaces to search for
+	// critical system pods.
+	EnvCriticalNamespaces = "PLANET_CRITICAL_NAMESPACES"
 
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
@@ -422,6 +425,10 @@ const (
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"
+
+	// DefaultCriticalNamespaces is the default list of critical namespaces
+	DefaultCriticalNamespaces = "kube-system,monitoring"
+
 	// DNSEnvFile specifies the file location to write information about the overlay network
 	// in use to be picked up by scripts
 	DNSEnvFile = "/run/dns.env"

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -261,7 +261,7 @@ const (
 	EnvPlanetSELinux = "PLANET_SELINUX"
 	// EnvCriticalNamespaces lists the Kubernetes namespaces to search for
 	// critical system pods.
-	EnvCriticalNamespaces = "PLANET_CRITICAL_NAMESPACES"
+	EnvCriticalNamespaces = "PLANET_MONITORED_NAMESPACES"
 
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
@@ -426,7 +426,7 @@ const (
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"
 
-	// DefaultCriticalNamespaces is the default list of critical namespaces
+	// DefaultCriticalNamespaces is the default list of namespaces to monitor for pod health.
 	DefaultCriticalNamespaces = "kube-system,monitoring"
 
 	// DNSEnvFile specifies the file location to write information about the overlay network

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -173,6 +173,7 @@ func run() error {
 		cagentTimelineDir            = cagent.Flag("timeline-dir", "Directory to be used for timeline storage").Default("/tmp/timeline").String()
 		cagentRetention              = cagent.Flag("retention", "Window to retain timeline as a Go duration").Duration()
 		cagentServiceCIDR            = cidrFlag(cagent.Flag("service-subnet", "IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.").Default(DefaultServiceSubnet).Envar(EnvServiceSubnet))
+		cagentCriticalNamespaces     = List(cagent.Flag("critical-namespaces", "List of Kubernetes namespaces to search for critical system pods").Default(DefaultCriticalNamespaces).OverrideDefaultFromEnvar(EnvCriticalNamespaces))
 
 		// stop a running container
 		cstop        = app.Command("stop", "Stop planet container")
@@ -348,6 +349,7 @@ func run() error {
 				ServiceGID:            *cagentServiceGID,
 				NodeName:              *cagentNodeName,
 				HTTPTimeout:           *cagentHTTPTimeout,
+				CriticalNamespaces:    *cagentCriticalNamespaces,
 			},
 			leader: &LeaderConfig{
 				PublicIP:        cagentPublicIP.String(),

--- a/vendor/github.com/gravitational/satellite/lib/kubernetes/constants.go
+++ b/vendor/github.com/gravitational/satellite/lib/kubernetes/constants.go
@@ -16,5 +16,7 @@ limitations under the License.
 
 package kubernetes
 
-// AllNamespaces can be used to query pods in all namespaces.
-const AllNamespaces = ""
+const (
+	// AllNamespaces can be used to query pods in all namespaces.
+	AllNamespaces = ""
+)

--- a/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
@@ -171,7 +171,7 @@ func (c Config) New() (*Server, error) {
 		promPeerRequest: promPeerRequest,
 		selector:        labelSelector,
 		triggerResync:   make(chan bool, 1),
-		rxMessage:       make(chan messageWrapper, 100),
+		rxMessage:       make(chan messageWrapper, RxQueueSize),
 		peers:           make(map[string]*peer),
 		addrToPeer:      make(map[string]string),
 	}, nil

--- a/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/system_pods.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	"github.com/gravitational/satellite/lib/kubernetes"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/trace"
@@ -35,6 +34,8 @@ import (
 type SystemPodsConfig struct {
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
+	// Namespaces specifies the list of namespaces to query for critical pods.
+	Namespaces []string
 }
 
 // checkAndSetDefaults validates that this configuration is correct and sets
@@ -98,16 +99,20 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 
 // getPods returns a list of the local pods that have the
 // `gravitational.io/critical-pod` label.
-func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
+func (r *systemPodsChecker) getPods() (pods []corev1.Pod, err error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
 	}
-	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
-	if err != nil {
-		return nil, utils.ConvertError(err)
+
+	for _, namespace := range r.Namespaces {
+		podList, err := r.Client.CoreV1().Pods(namespace).List(opts)
+		if err != nil {
+			return pods, utils.ConvertError(err)
+		}
+		pods = append(pods, podList.Items...)
 	}
 
-	return pods.Items, nil
+	return pods, nil
 }
 
 // verifyPods verifies the pods are in a valid state. Reports a failed probe for


### PR DESCRIPTION
## Description
Update system pods check. This patch will help reduce the load on etcd if there are a large number of pods in user namespaces. System pods check will only search the `kube-system` and `monitoring` namespaces for system pods.

## Linked tickets and PRs
* Requires gravitational/satellite#281
* Ports https://github.com/gravitational/planet/pull/772