### PR TITLE
[7.0.x] fix rootfs executable lookup for SELinux

### DIFF
--- a/lib/box/selinux.go
+++ b/lib/box/selinux.go
@@ -38,9 +38,10 @@ func getSELinuxProcLabel(rootfs, cmd string) (label string) {
 	if !filepath.IsAbs(cmd) {
 		abspath, err := getAbsPathForCommand(rootfs, cmd)
 		if err != nil {
-			log.WithError(err).Warn("Failed to find absolute path to command in rootfs.")
+			logger.WithError(err).Warn("Failed to find absolute path to command in rootfs.")
 		} else {
 			cmd = abspath
+			logger = logger.WithField("abspath", cmd)
 		}
 	}
 	label, err := getProcLabel(filepath.Join(rootfs, cmd))

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -116,4 +116,14 @@ var (
 		Minor:   0,
 		Patch:   1127,
 	}
+
+	// ContainerEnvPath defines the default container PATH
+	ContainerEnvPath = []string{
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/usr/sbin",
+		"/bin",
+		"/sbin",
+	}
 )

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/planet/lib/constants"
 	"github.com/gravitational/planet/lib/utils"
 
 	"github.com/syndtr/gocapability/capability"
@@ -269,10 +270,6 @@ const (
 	// DNSPort is the default DNS port
 	DNSPort = 53
 
-	// DefaultEnvPath defines the default value for PATH environment variable
-	// when executing commands inside the container
-	DefaultEnvPath = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
-
 	// PlanetRoleMaster specifies the value of the node role to be master.
 	// A master node runs additional runtime tests as well as additional
 	// set of services
@@ -472,6 +469,10 @@ const (
 	// See https://github.com/kubernetes/kubernetes/blob/v1.17.9/pkg/master/controller.go#L44
 	KubernetesServiceName = "kubernetes"
 )
+
+// DefaultEnvPath defines the default value for PATH environment variable
+// when executing commands inside the container
+var DefaultEnvPath = strings.Join(constants.ContainerEnvPath, ":")
 
 // DefaultDNSAddress is the default listen address for local DNS server.
 var DefaultDNSAddress = fmt.Sprintf("%v:%v", DefaultDNSListenAddr, DNSPort)


### PR DESCRIPTION
lib/box: fix label selection for executables given without absolute paths.

When 'gravity exec' executed a command without specifying the absolute path to said command, it picked the wrong label since it attempted to match each command directly inside the `rootfs` directory.
Instead, if the command is given without absolute path, match it inside the `rootfs` directory by using the `PATH` value.

Before the change:
```
$ gravity exec systemctl status kube-kubelet
/bin/systemctl: permission denied
```

After the change:
```
$ gravity exec systemctl status kube-kubelet
<output of systemctl status kube-kubelet>
```