### PR TITLE
Add bsdmainutils / columns util

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -52,6 +52,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && set -ex && \
         open-iscsi \
         strace \
         netbase \
+        bsdmainutils \
         && apt-get -y autoclean && apt-get -y clean && apt-get autoremove \
         && rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
Requested by customer M, have `column` unix utility inside planet to help with formatting.

https://man7.org/linux/man-pages/man1/column.1.html

It's pretty small
```
kevin-test1:/$ apt-get install bsdmainutils
Reading package lists... Done
Building dependency tree... Done
The following additional packages will be installed:
  libbsd0
Suggested packages:
  cpp wamerican | wordlist whois vacation
The following NEW packages will be installed:
  bsdmainutils libbsd0
0 upgraded, 2 newly installed, 0 to remove and 18 not upgraded.
Need to get 269 kB of archives.
After this operation, 746 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://deb.debian.org/debian stretch/main amd64 libbsd0 amd64 0.8.3-1 [83.0 kB]
Get:2 http://deb.debian.org/debian stretch/main amd64 bsdmainutils amd64 9.0.12+nmu1 [186 kB]
Fetched 269 kB in 0s (2,449 kB/s)
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 2.)
debconf: falling back to frontend: Readline
Selecting previously unselected package libbsd0:amd64.
(Reading database ... 16337 files and directories currently installed.)
Preparing to unpack .../libbsd0_0.8.3-1_amd64.deb ...
Unpacking libbsd0:amd64 (0.8.3-1) ...
Selecting previously unselected package bsdmainutils.
Preparing to unpack .../bsdmainutils_9.0.12+nmu1_amd64.deb ...
Unpacking bsdmainutils (9.0.12+nmu1) ...
Setting up libbsd0:amd64 (0.8.3-1) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Setting up bsdmainutils (9.0.12+nmu1) ...
update-alternatives: using /usr/bin/bsd-write to provide /usr/bin/write (write) in auto mode
update-alternatives: using /usr/bin/bsd-from to provide /usr/bin/from (from) in auto mode
```