### PR TITLE
[7.0.x] Bump helm version to 2.16.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 19.03.12
 # we currently use our own flannel fork: gravitational/flannel
 FLANNEL_VER := v0.10.3-gravitational
-HELM_VER := 2.15.2
+HELM_VER := 2.16.12
 COREDNS_VER := 1.7.0
 NODE_PROBLEM_DETECTOR_VER := v0.6.4
 CNI_VER := 0.8.6


### PR DESCRIPTION
Required by [gravity #2319](https://github.com/gravitational/gravity/pull/2319)