### PR TITLE
[7.0] Remove CONFIG_NF_NAT_IPV4 check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6431d8417c06afed8394a2ec98732d59d8f4272dbdc6966076602b57d3efcbf1"
+  branch = "walt/7.0-nf-nat-ipv4"
+  digest = "1:de5b3032c10ac9cd09e54d90b9affbd807481cb5809638756a6741e395f2e3e3"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -451,8 +452,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "853c9e775c27c30c8eee3c2fbd683daf0bcf6548"
-  version = "7.0.23"
+  revision = "2e2407185f8448b415e4df7c9b1074a115be4dc7"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "walt/7.0-nf-nat-ipv4"
   digest = "1:de5b3032c10ac9cd09e54d90b9affbd807481cb5809638756a6741e395f2e3e3"
   name = "github.com/gravitational/satellite"
   packages = [
@@ -452,7 +451,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "2e2407185f8448b415e4df7c9b1074a115be4dc7"
+  revision = "aef8c3a377eb8e09f0fb06f7ba4ee7a63b61a617"
+  version = "7.0.24"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  branch = "walt/7.0-nf-nat-ipv4"
+  version = "=7.0.24"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.23"
+  branch = "walt/7.0-nf-nat-ipv4"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
@@ -113,12 +113,6 @@ func DefaultBootConfigParams() health.Checker {
 		BootConfigParam{Name: "CONFIG_VETH"},
 		BootConfigParam{Name: "CONFIG_BRIDGE"},
 		BootConfigParam{Name: "CONFIG_BRIDGE_NETFILTER"},
-		BootConfigParam{
-			// https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV4.html
-			// CONFIG_NF_NAT_IPV4 has been removed as of kernel 5.1
-			Name:             "CONFIG_NF_NAT_IPV4",
-			KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 5, Major: 1}),
-		},
 		BootConfigParam{Name: "CONFIG_IP_NF_FILTER"},
 		BootConfigParam{Name: "CONFIG_IP_NF_TARGET_MASQUERADE"},
 		BootConfigParam{Name: "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"},


### PR DESCRIPTION
## Description

Removes the CONFIG_NF_NAT_IPV4 check from Satellite.

## Linked tickets and PRs
 
Requires https://github.com/gravitational/satellite/pull/286

## TODO

- [x] Update the branch to a tagged version once the Satellite PR merges
- [x] Self review the change