### PR TITLE
 [6.1.x] Remove CONFIG_NF_NAT_IPV4 check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,7 +385,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:527ab6baa75def81e50bdd7ae8bf30d560d966b0accd15bb26e7583481d0c8c1"
+  digest = "1:965ad9f73f91f25d74f1fb2f13e75e1fb630b2f7e7b177d0978e6f417a5bca7e"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -406,8 +406,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "065d18f5cc6d6dfa2ccdd73fcf02979465efa430"
-  version = "6.1.18"
+  revision = "336a276099236ea802e0dfe722acabab8ce9560a"
+  version = "6.1.19"
 
 [[projects]]
   digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,7 +90,7 @@ ignored = ["github.com/Sirupsen/logrus", "github.com/gravitational/planet/build/
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.18"
+  version = "=6.1.19"
 
 [[constraint]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
@@ -114,12 +114,6 @@ func DefaultBootConfigParams() health.Checker {
 		BootConfigParam{Name: "CONFIG_VETH"},
 		BootConfigParam{Name: "CONFIG_BRIDGE"},
 		BootConfigParam{Name: "CONFIG_BRIDGE_NETFILTER"},
-		BootConfigParam{
-			// https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV4.html
-			// CONFIG_NF_NAT_IPV4 has been removed as of kernel 5.1
-			Name:             "CONFIG_NF_NAT_IPV4",
-			KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 5, Major: 1}),
-		},
 		BootConfigParam{Name: "CONFIG_IP_NF_FILTER"},
 		BootConfigParam{Name: "CONFIG_IP_NF_TARGET_MASQUERADE"},
 		BootConfigParam{Name: "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"},


### PR DESCRIPTION
## Description

Removes the CONFIG_NF_NAT_IPV4 check from Satellite.  This allows install on CentOS/RHEL 8.3.

## Linked tickets and PRs
 
* Depends on https://github.com/gravitational/satellite/pull/288
* Contributes to https://github.com/gravitational/gravity/issues/2331

## TODO

- [x] Update the branch to a tagged version once the Satellite PR merges
- [x] Self review the change