### PR TITLE
[5.5.x] Remove CONFIG_NF_NAT_IPV4 check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,7 +363,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0cd2bc7530276353a9e4f87ff983a5d3f9330bb456ee18d186221d5c7cdab7f7"
+  digest = "1:0ee0c2258e11bf47ec670c9de69e8fb49328422ff8be9b8ea1eb276888853236"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -385,8 +385,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "698d2c8e4a9047a14daca8692fde570c1225dfbc"
-  version = "5.5.26"
+  revision = "358a7e6759cdb924a5e33e6d4f957452c51484a2"
+  version = "5.5.27"
 
 [[projects]]
   digest = "1:488b046f7e099afaa97b0596967f96c54a0c8f85bb02d155931982fed2275851"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ name = "golang.org/x/net"
 
 [[constraint]]
 name = "github.com/gravitational/satellite"
-version = "=5.5.26"
+version = "=5.5.27"
 
 [[constraint]]
 name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults_linux.go
@@ -110,12 +110,6 @@ func DefaultBootConfigParams() health.Checker {
 		BootConfigParam{Name: "CONFIG_VETH"},
 		BootConfigParam{Name: "CONFIG_BRIDGE"},
 		BootConfigParam{Name: "CONFIG_BRIDGE_NETFILTER"},
-		BootConfigParam{
-			// https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV4.html
-			// CONFIG_NF_NAT_IPV4 has been removed as of kernel 5.1
-			Name:             "CONFIG_NF_NAT_IPV4",
-			KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 5, Major: 1}),
-		},
 		BootConfigParam{Name: "CONFIG_IP_NF_FILTER"},
 		BootConfigParam{Name: "CONFIG_IP_NF_TARGET_MASQUERADE"},
 		BootConfigParam{Name: "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"},


### PR DESCRIPTION
## Description

Removes the CONFIG_NF_NAT_IPV4 check from Satellite.  This allows install on CentOS/RHEL 8.3.

## Linked tickets and PRs
 
* Depends on https://github.com/gravitational/satellite/pull/287
* Contributes to https://github.com/gravitational/gravity/issues/2331

## TODO

- [x] Update the branch to a tagged version once the Satellite PR merges
- [x] Self review the change