### PR TITLE
[master] make sure to shutdown services if elections are disabled

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -227,6 +227,12 @@ func startLeaderClient(config agentConfig, agent agent.Agent, errorC chan error)
 			// stop election participation
 			cancelVoter()
 			cancelVoter = nil
+
+			log.Info("Shut down services until election has been re-enabled.")
+			// Shut down services if we've been requested to not participate in elections
+			if err := stopUnits(context.TODO()); err != nil {
+				log.WithError(err).Warn("Failed to stop units.")
+			}
 		}
 	})
 	// modify /etc/hosts upon election of a new leader node


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2349

When a controller has elections disabled, shutdown the control plane immediately, instead of waiting for another node to take over the election key. This is needed for uninstall, where the node may be removed from etcd ahead of the leadership change event, and as such the node will miss the leadership change event.