### PR TITLE
Enable EventRateLimit admission control

### DIFF
--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -18,7 +18,8 @@ ExecStart=/usr/bin/kube-apiserver \
         --service-account-lookup=true \
         --service-account-signing-key-file=/var/state/apiserver.key \
         --service-account-issuer=api \
-        --enable-admission-plugins=PodSecurityPolicy,NodeRestriction,AlwaysPullImages \
+        --enable-admission-plugins=PodSecurityPolicy,NodeRestriction,AlwaysPullImages,EventRateLimit \
+        --admission-control-config-file=/etc/kubernetes/admission-control/control-config.yaml \
         --authorization-mode=Node,RBAC \
         --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true \
         --allow-privileged=${PLANET_ALLOW_PRIVILEGED} \

--- a/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/control-config.yaml
+++ b/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/control-config.yaml
@@ -1,0 +1,8 @@
+# Admission Control Configuration
+# Documentation: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers
+
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: EventRateLimit
+  path: event-config.yaml

--- a/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/event-config.yaml
+++ b/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/event-config.yaml
@@ -6,7 +6,7 @@ kind: Configuration
 limits:
 - type: Server
   qps: 1000
-  busrt: 10000
+  burst: 10000
 - type: Namespace
   qps: 100
   burst: 1000

--- a/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/event-config.yaml
+++ b/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/admission-control/event-config.yaml
@@ -1,0 +1,12 @@
+# EventRateLimit Configuration
+# Documentation: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#eventratelimit
+
+apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+kind: Configuration
+limits:
+- type: Server
+  qps: 1000
+  busrt: 10000
+- type: Namespace
+  qps: 100
+  burst: 1000


### PR DESCRIPTION
## Description
This PR enables the EventRateLimit admission controller. 

Admission control configuration is defined in `/etc/kubernetes/admission-control/control-config.yaml`. Additional admission controllers should be plugged in here.

EventRateLimit admission controller is configured in `/etc/kubernetes/admission-control/event-config.yaml`. The current default is fairly generous and creates limits on the server as a whole and per namespace. Additional limits can be added per user and per source&object. More information can be found in the linked Kubernetes documentation.

## Linked tickets and PRs
* Refs https://github.com/gravitational/gravity/issues/2294