### PR TITLE
[6.1] make sure to shutdown services if elections are disabled (#800)

### DIFF
--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -227,6 +227,12 @@ func startLeaderClient(config agentConfig, agent agent.Agent, errorC chan error)
 			// stop election participation
 			cancelVoter()
 			cancelVoter = nil
+
+			log.Info("Shut down services until election has been re-enabled.")
+			// Shut down services if we've been requested to not participate in elections
+			if err := stopUnits(context.TODO()); err != nil {
+				log.WithError(err).Warn("Failed to stop units.")
+			}
 		}
 	})
 	// modify /etc/hosts upon election of a new leader node


### PR DESCRIPTION
Backport #800
Updates https://github.com/gravitational/gravity/issues/2349

(cherry picked from commit 31799d7fe9d0f9dff20e804af212a561447357c4)