### PR TITLE
Add Drone CI pull request config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,55 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
+kind: signature
+hmac: b38e0d956bc9dc2abee7fb1418a05b7233ade75516da22cdfaceb01fb253ffce
+
+...

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 # Quick Start
 # -----------
 # make production:
-#     CD/CD build of Planet. This is what's used by Jenkins builds and this
-#     is what gets released to customers.
+#     Used by CI builds and what is released to customers.
 #
 # make:
 #     builds your changes and updates planet binary in

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@
 #
 .DEFAULT_GOAL := all
 
-SHELL := /bin/bash
 PWD := $(shell pwd)
 ASSETS := $(PWD)/build.assets
 BUILD_ASSETS := $(PWD)/build/assets

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -1,5 +1,4 @@
 # This makefile is used inside the buildbox container
-SHELL := /bin/bash
 TARGETDIR ?= $(BUILDDIR)/planet
 ASSETDIR ?= $(BUILDDIR)/assets
 ROOTFS ?= $(TARGETDIR)/rootfs
@@ -114,11 +113,11 @@ $(ROOTFS)/bin/bash: clean-rootfs
 .PHONY: clean-rootfs
 clean-rootfs:
 # umount tmps volume for rootfs:
-	if [[ $$(mount | grep $(ROOTFS)) ]]; then \
+	if mount | grep $(ROOTFS); then \
 		sudo umount -f $(ROOTFS) 2>/dev/null ;\
 	fi
 # delete docker container we've used to create rootfs:
-	if [[ $$(docker ps -a | grep $(CONTAINERNAME)) ]]; then \
+	if docker ps -a | grep $(CONTAINERNAME); then \
 		docker rm -f $(CONTAINERNAME) ;\
 	fi
 


### PR DESCRIPTION
This adds a Drone CI pull request configuration consistent with https://jenkins.gravitational.io/job/Planet/.

The Makefile changes remove bash-isms in the Makefile and replace them with generic POSIX shell logic.  This saves us from needing bash in the container running make -- allowing us to run in alpine more easily.

## Testing Done
See the PR build. https://drone.gravitational.io/gravitational/planet/4

## TODO
 - [x] Address review feedback
 - [x] Sign the yaml

I'm working on separate PRs that build off of the work here to replace the planet-deploy and planet-dev-deploy jenkins jobs.