### PR TITLE
Add publishing to Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -118,8 +118,74 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: dev-publish
+
+trigger:
+  event:
+  - custom
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish to s3
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_DEFAULT_REGION: us-east-1
+    commands:
+      - apk add --no-cache make aws-cli
+      - make dev-deploy
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
 ---
 kind: signature
-hmac: 16ff6331fc38270a5038e000f3687835b826ff6d2bb14d51c6702a6889b9342d
+hmac: 89b749595d4aac174eb23a4f8a4678b67241f2a05ada27ed6d02fea92a5acaae
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,8 +48,78 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish
+
+trigger:
+  event:
+  - tag
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      REGISTRY_USERNAME:
+        from_secret: quay_username
+      REGISTRY_PASSWORD:
+        from_secret: quay_password
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_DEFAULT_REGION: us-east-1
+    commands:
+      - apk add --no-cache make aws-cli
+      - docker login -u="$REGISTRY_USERNAME" -p="$REGISTRY_PASSWORD" quay.io
+      - make deploy
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 ---
 kind: signature
-hmac: b38e0d956bc9dc2abee7fb1418a05b7233ade75516da22cdfaceb01fb253ffce
+hmac: 16ff6331fc38270a5038e000f3687835b826ff6d2bb14d51c6702a6889b9342d
 
 ...


### PR DESCRIPTION
## Summary
This changeset adds two further drone pipelines covering our two planet publishing scenarios.

Replacing https://jenkins.gravitational.io/job/Planet-dev-deploy/, the `trigger: event: custom` pipeline performs a dev deploy to s3 when manually invoked with a command like the following:

```
drone build create gravitational/planet --branch walt/drone-publish
```

**There is no way to trigger a dev deploy via the Drone UI**

Replacing https://jenkins.gravitational.io/job/Planet-Deploy-Artifacts/, the "trigger: event: tag" pipeline will publish to both s3 and quay every time a tag is pushed.

**Again, there is no way to trigger a full deploy via the Drone UI.**  It "just happens" when a tag is pushed.

## Testing Done

I pushed the `7.1.22-11709-test` tag to test the publishing job. Find the build logs and artifacts below:


https://drone.gravitational.io/gravitational/planet/7
https://quay.io/repository/gravitational/planet?tab=tags
https://s3.console.aws.amazon.com/s3/buckets/clientbuilds.gravitational.io?region=us-east-1&prefix=planet/7.1.22-11709-test/&showversions=false

I used the following drone command to test the dev publishing:

```
drone build create gravitational/planet --branch walt/drone-publish 
```

Resulting in:

https://drone.gravitational.io/gravitational/planet/10
https://s3.console.aws.amazon.com/s3/buckets/clientbuilds.gravitational.io?region=us-east-1&prefix=planet/7.1.22-11709-4-g591e4fd1/&showversions=false

## Notes
The AWS credentials are limited to s3 read write on the `clientbuilds.gravitational.io/planet` bucket/path.  They are managed in code, provisioned in https://github.com/gravitational/cloud-terraform/pull/109. The quay credentials are artisanally hand provisioned, and can be found under `gravitational+drone_planet_publish` here:

https://quay.io/organization/gravitational?tab=robots

## TODO
 - [x] Address PR feedback
 - [x] Write transition docs, send email to dev team
 - [x] Backport to 7.0
 - [x] Backport to 6.1
 - [x] Backport to 5.5
 - [x] Turn off Jenkins jobs
 - [x] Delete 7.1.22-11709-test  in quay
 - [x] Delete 7.1.22-11709-test  in github
 - [x] Delete 7.1.22-11709-test  in s3