### PR TITLE
[5.5] Backport Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,55 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
+kind: signature
+hmac: b38e0d956bc9dc2abee7fb1418a05b7233ade75516da22cdfaceb01fb253ffce
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -118,8 +118,74 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: dev-publish
+
+trigger:
+  event:
+  - custom
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish to s3
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_DEFAULT_REGION: us-east-1
+    commands:
+      - apk add --no-cache make aws-cli
+      - make dev-deploy
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
 ---
 kind: signature
-hmac: 16ff6331fc38270a5038e000f3687835b826ff6d2bb14d51c6702a6889b9342d
+hmac: 89b749595d4aac174eb23a4f8a4678b67241f2a05ada27ed6d02fea92a5acaae
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,8 +48,78 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish
+
+trigger:
+  event:
+  - tag
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make buildbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build tarball
+    image: docker:git
+    commands:
+      - apk add --no-cache make fakeroot
+      - make production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      REGISTRY_USERNAME:
+        from_secret: quay_username
+      REGISTRY_PASSWORD:
+        from_secret: quay_password
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_DEFAULT_REGION: us-east-1
+    commands:
+      - apk add --no-cache make aws-cli
+      - docker login -u="$REGISTRY_USERNAME" -p="$REGISTRY_PASSWORD" quay.io
+      - make deploy
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 ---
 kind: signature
-hmac: b38e0d956bc9dc2abee7fb1418a05b7233ade75516da22cdfaceb01fb253ffce
+hmac: 16ff6331fc38270a5038e000f3687835b826ff6d2bb14d51c6702a6889b9342d
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 # Quick Start
 # -----------
 # make production:
-#     CD/CD build of Planet. This is what's used by Jenkins builds and this
-#     is what gets released to customers.
+#     Used by CI builds and what is released to customers.
 #
 # make:
 #     builds your changes and updates planet binary in

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@
 #
 .DEFAULT_GOAL := all
 
-SHELL := /bin/bash
 PWD := $(shell pwd)
 ASSETS := $(PWD)/build.assets
 BUILD_ASSETS := $(PWD)/build/assets

--- a/build.assets/makefiles/buildbox.mk
+++ b/build.assets/makefiles/buildbox.mk
@@ -1,5 +1,4 @@
 # This makefile is used inside the buildbox container
-SHELL := /bin/bash
 TARGETDIR ?= $(BUILDDIR)/planet
 ASSETDIR ?= $(BUILDDIR)/assets
 ROOTFS ?= $(TARGETDIR)/rootfs
@@ -90,11 +89,11 @@ $(ROOTFS)/bin/bash: clean-rootfs
 .PHONY: clean-rootfs
 clean-rootfs:
 # umount tmps volume for rootfs:
-	if [[ $$(mount | grep $(ROOTFS)) ]]; then \
+	if mount | grep $(ROOTFS); then \
 		sudo umount -f $(ROOTFS) 2>/dev/null ;\
 	fi
 # delete docker container we've used to create rootfs:
-	if [[ $$(docker ps -a | grep $(CONTAINERNAME)) ]]; then \
+	if docker ps -a | grep $(CONTAINERNAME); then \
 		docker rm -f $(CONTAINERNAME) ;\
 	fi
 


### PR DESCRIPTION
This is the 5.5 backport of https://github.com/gravitational/planet/pull/812 and https://github.com/gravitational/planet/pull/813.  The changes are verbatim.

## Testing Done
The PR build is sufficient for the PR pipeline.  I did not test publishing specific to 5.5, but I did test it in https://github.com/gravitational/planet/pull/813.  The jenkins job uses the same logic for all branches, so I'm not concerned that something 5.5 specific will break.

## TODO
 - [x] Finish discussion on https://github.com/gravitational/planet/pull/813, include any changes
 - [x] Address PR feedback