### PR TITLE
add feature to set google metadata within hosts when running on gce

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -30,10 +30,10 @@ import (
 	"unicode"
 
 	"github.com/gravitational/planet/lib/constants"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // WriteHosts formats entries in hosts file format to writer

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -24,10 +24,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"syscall"
 	"unicode"
 
 	"github.com/gravitational/planet/lib/constants"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
@@ -153,4 +156,37 @@ func hasJSONPrefix(buf []byte) bool {
 func hasPrefix(buf []byte, prefix []byte) bool {
 	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
 	return bytes.HasPrefix(trim, prefix)
+}
+
+// OnGCEVM returns true if it finds a local GCE VM.
+// Looks at a product file that is an undocumented API.
+// Based on https://github.com/kubernetes/kubernetes/blob/09f4baed35865d410febb3220811ca5c2fe1cf42/pkg/credentialprovider/gcp/metadata.go#L117-L142
+// Copyright the Kubernetes Authors: https://github.com/kubernetes/kubernetes/blob/09f4baed35865d410febb3220811ca5c2fe1cf42/pkg/credentialprovider/gcp/metadata.go#L1-L15
+func OnGCEVM() bool {
+	var name string
+
+	if runtime.GOOS == "windows" {
+		data, err := exec.Command("wmic", "computersystem", "get", "model").Output()
+		if err != nil {
+			return false
+		}
+
+		fields := strings.Split(strings.TrimSpace(string(data)), "\r\n")
+
+		if len(fields) != 2 {
+			logrus.Infof("Received unexpected value retrieving system model: %q", string(data))
+			return false
+		}
+
+		name = fields[1]
+	} else {
+		data, err := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+		if err != nil {
+			logrus.Infof("Error while reading product_name: %v", err)
+			return false
+		}
+		name = strings.TrimSpace(string(data))
+	}
+
+	return name == "Google" || name == "Google Compute Engine"
 }

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -245,10 +245,7 @@ func start(config *Config) (*runtimeContext, error) {
 	}
 	mountSecrets(config)
 
-	err = setHosts(config, []utils.HostEntry{
-		{IP: "127.0.0.1", Hostnames: "localhost localhost.localdomain localhost4 localhost4.localdomain4"},
-		{IP: "::1", Hostnames: "localhost localhost.localdomain localhost6 localhost6.localdomain6"},
-	})
+	err = setHosts(config, generateHosts())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -789,6 +786,22 @@ func copyResolvFile(cfg utils.DNSConfig, destination string, upstreamNameservers
 	}
 
 	return nil
+}
+
+func generateHosts() []utils.HostEntry {
+	hosts := []utils.HostEntry{
+		{IP: "127.0.0.1", Hostnames: "localhost localhost.localdomain localhost4 localhost4.localdomain4"},
+		{IP: "::1", Hostnames: "localhost localhost.localdomain localhost6 localhost6.localdomain6"},
+	}
+
+	if utils.OnGCEVM() {
+		hosts = append(hosts, utils.HostEntry{
+			IP:        "169.254.169.254",
+			Hostnames: "metadata.google.internal metadata",
+		})
+	}
+
+	return hosts
 }
 
 func setHosts(config *Config, entries []utils.HostEntry) error {


### PR DESCRIPTION
Adds a feature to planet to hardcode the google metadata server into the planet hosts file when detected as running on a gcloud VM. This is a workaround for a kubelet problem where it will always try and contact the metadata server even when configured without cloud integrations. 

https://github.com/kubernetes/kubernetes/issues/30195
https://github.com/kubernetes/kubernetes/issues/86245
And probably others.

Updates https://github.com/gravitational/gravity/issues/2391