### PR TITLE
[7.0] add feature to set google metadata within hosts when running on gce 

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"syscall"
 	"unicode"
 
@@ -31,6 +33,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // WriteHosts formats entries in hosts file format to writer
@@ -153,4 +156,37 @@ func hasJSONPrefix(buf []byte) bool {
 func hasPrefix(buf []byte, prefix []byte) bool {
 	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
 	return bytes.HasPrefix(trim, prefix)
+}
+
+// OnGCEVM returns true if it finds a local GCE VM.
+// Looks at a product file that is an undocumented API.
+// Based on https://github.com/kubernetes/kubernetes/blob/09f4baed35865d410febb3220811ca5c2fe1cf42/pkg/credentialprovider/gcp/metadata.go#L117-L142
+// Copyright the Kubernetes Authors: https://github.com/kubernetes/kubernetes/blob/09f4baed35865d410febb3220811ca5c2fe1cf42/pkg/credentialprovider/gcp/metadata.go#L1-L15
+func OnGCEVM() bool {
+	var name string
+
+	if runtime.GOOS == "windows" {
+		data, err := exec.Command("wmic", "computersystem", "get", "model").Output()
+		if err != nil {
+			return false
+		}
+
+		fields := strings.Split(strings.TrimSpace(string(data)), "\r\n")
+
+		if len(fields) != 2 {
+			logrus.Infof("Received unexpected value retrieving system model: %q", string(data))
+			return false
+		}
+
+		name = fields[1]
+	} else {
+		data, err := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+		if err != nil {
+			logrus.Infof("Error while reading product_name: %v", err)
+			return false
+		}
+		name = strings.TrimSpace(string(data))
+	}
+
+	return name == "Google" || name == "Google Compute Engine"
 }

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -245,10 +245,7 @@ func start(config *Config) (*runtimeContext, error) {
 	}
 	mountSecrets(config)
 
-	err = setHosts(config, []utils.HostEntry{
-		{IP: "127.0.0.1", Hostnames: "localhost localhost.localdomain localhost4 localhost4.localdomain4"},
-		{IP: "::1", Hostnames: "localhost localhost.localdomain localhost6 localhost6.localdomain6"},
-	})
+	err = setHosts(config, generateHosts())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -789,6 +786,22 @@ func copyResolvFile(cfg utils.DNSConfig, destination string, upstreamNameservers
 	}
 
 	return nil
+}
+
+func generateHosts() []utils.HostEntry {
+	hosts := []utils.HostEntry{
+		{IP: "127.0.0.1", Hostnames: "localhost localhost.localdomain localhost4 localhost4.localdomain4"},
+		{IP: "::1", Hostnames: "localhost localhost.localdomain localhost6 localhost6.localdomain6"},
+	}
+
+	if utils.OnGCEVM() {
+		hosts = append(hosts, utils.HostEntry{
+			IP:        "169.254.169.254",
+			Hostnames: "metadata.google.internal metadata",
+		})
+	}
+
+	return hosts
 }
 
 func setHosts(config *Config, entries []utils.HostEntry) error {


### PR DESCRIPTION
Backport #817
Updates https://github.com/gravitational/gravity/issues/2391

* add feature to set google metadata within hosts when running on gce

* address review feedback

(cherry picked from commit aeaefb20fb93d4ec1426455a173feb636914e426)