### PR TITLE
Implement Kubernetes HA mode

### DIFF
--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -499,6 +499,14 @@
                 "cli": {
                     "name": "feature-gates"
                 }
+            },
+            {
+                "type": "Bool",
+                "name": "high-availability",
+                "env": "KUBE_HIGH_AVAILABILITY",
+                "cli": {
+                    "name": "high-availability"
+                }
             }
         ]
     }

--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -25,7 +25,6 @@ ExecStart=/usr/bin/kube-apiserver \
         --authorization-mode=Node,RBAC \
         --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true \
         --allow-privileged=${PLANET_ALLOW_PRIVILEGED} \
-        --apiserver-count=1 \
         --tls-cert-file=/var/state/apiserver.cert \
         --tls-private-key-file=/var/state/apiserver.key \
         --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384 \

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -77,6 +77,8 @@ type LeaderConfig struct {
 	// APIServerDNS is a name of the API server entry to lookup
 	// for the currently active API server
 	APIServerDNS string
+	// HighAvailability enables kubernetes high availability mode.
+	HighAvailability bool
 }
 
 // String returns string representation of the agent leader configuration

--- a/tool/planet/agent.go
+++ b/tool/planet/agent.go
@@ -175,16 +175,17 @@ func manageParticipation(client *leader.Client, config agentConfig, errorC chan 
 			ctx, cancelVoter = context.WithCancel(context.TODO())
 			err := client.AddVoter(ctx, config.leader.LeaderKey, config.leader.PublicIP, config.leader.Term)
 			if err != nil {
-				log.Errorf("failed to add voter for %v: %v", config.leader.PublicIP, trace.DebugReport(err))
+				log.WithError(err).Errorf("Failed to add voter for %v.", config.leader.PublicIP)
+				cancelVoter()
 				errorC <- err
 			}
 
 			// While running with HA enabled, start units when election is re-enabled
 			if config.leader.HighAvailability {
-				if err := startUnits(context.TODO()); err != nil {
+				if err := startUnits(ctx); err != nil {
 					log.WithError(err).Warn("Failed to start units.")
 				}
-				if err := validateKubernetesService(context.TODO(), config.serviceCIDR); err != nil {
+				if err := validateKubernetesService(ctx, config.serviceCIDR); err != nil {
 					log.WithError(err).Warn("Failed to validate kubernetes service.")
 				}
 			}

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -137,6 +137,9 @@ type Config struct {
 	AllowPrivileged bool
 	// SELinux turns on SELinux support
 	SELinux bool
+	// HighAvailability enables kubernetes high availability mode. If enabled,
+	// control plane components will be enabled on all master nodes.
+	HighAvailability bool
 }
 
 // DNS describes DNS server configuration

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -267,6 +267,10 @@ const (
 	// critical system pods.
 	EnvCriticalNamespaces = "PLANET_CRITICAL_NAMESPACES"
 
+	// EnvHighAvailability is a bool flag to enable/disable kubernetes high
+	// availability mode.
+	EnvHighAvailability = "KUBE_HIGH_AVAILABILITY"
+
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
 

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -165,6 +165,7 @@ func start(config *Config) (*runtimeContext, error) {
 		box.EnvPair{Name: EnvPlanetAllowPrivileged, Val: strconv.FormatBool(config.AllowPrivileged)},
 		box.EnvPair{Name: EnvServiceUID, Val: config.ServiceUser.UID},
 		box.EnvPair{Name: EnvServiceGID, Val: config.ServiceUser.GID},
+		box.EnvPair{Name: EnvHighAvailability, Val: strconv.FormatBool(config.HighAvailability)},
 	)
 
 	// Setup http_proxy / no_proxy environment configuration

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -534,6 +534,12 @@ func addComponentOptions(config *Config) error {
 		config.Env.Append(EnvAPIServerOptions,
 			fmt.Sprintf("--service-node-port-range=%v", config.ServiceNodePortRange))
 	}
+	if config.HighAvailability {
+		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--endpoint-reconciler-type=lease"))
+	} else {
+		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--endpoint-reconciler-type=master-count"))
+		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--apiserver-count=1"))
+	}
 	if config.ProxyPortRange != "" {
 		config.Env.Append(EnvKubeProxyOptions,
 			fmt.Sprintf("--proxy-port-range=%v", config.ProxyPortRange))

--- a/tool/planet/start.go
+++ b/tool/planet/start.go
@@ -535,10 +535,10 @@ func addComponentOptions(config *Config) error {
 			fmt.Sprintf("--service-node-port-range=%v", config.ServiceNodePortRange))
 	}
 	if config.HighAvailability {
-		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--endpoint-reconciler-type=lease"))
+		config.Env.Append(EnvAPIServerOptions, "--endpoint-reconciler-type=lease")
 	} else {
-		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--endpoint-reconciler-type=master-count"))
-		config.Env.Append(EnvAPIServerOptions, fmt.Sprintf("--apiserver-count=1"))
+		config.Env.Append(EnvAPIServerOptions, "--endpoint-reconciler-type=master-count")
+		config.Env.Append(EnvAPIServerOptions, "--apiserver-count=1")
 	}
 	if config.ProxyPortRange != "" {
 		config.Env.Append(EnvKubeProxyOptions,


### PR DESCRIPTION
## Description
This PR enables Kubernetes HA mode. 

A `--high-availability` boolean flag has been added to the planet `start` and `agent` commands. Default value will be read from container-environment variable `KUBE_HIGH_AVAILABILITY`.

If planet is running in HA mode, Kubernetes control plane components(`apiserver`, `controller-manager`, `scheduler`) will run on all master nodes vs running only on the elected leader.