### PR TITLE
Kubernetes 1.19 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.17.9
+KUBE_VER ?= v1.19.8
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 19.03.12
 # we currently use our own flannel fork: gravitational/flannel

--- a/build.assets/makefiles/master/k8s-master/containers/pause.mk
+++ b/build.assets/makefiles/master/k8s-master/containers/pause.mk
@@ -1,6 +1,6 @@
 .PHONY: all pull-from-internet
 
-IMAGE:=gcr.io/google_containers/pause:3.0
+IMAGE:=gcr.io/google_containers/pause:3.2
 # OUTDIR defines the output directory for the resulting tarball
 # (set in the parent makefile)
 override OUT:=$(OUTDIR)/pause.tar.gz

--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/kube-apiserver \
         --enable-admission-plugins=${KUBE_ADMISSION_PLUGINS} \
         --admission-control-config-file=/etc/kubernetes/admission-control/control-config.yaml \
         --authorization-mode=Node,RBAC \
-        --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true \
+        --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true,flowcontrol.apiserver.k8s.io/v1alpha1=true,storage.k8s.io/v1alpha1 \
         --allow-privileged=${PLANET_ALLOW_PRIVILEGED} \
         --tls-cert-file=/var/state/apiserver.cert \
         --tls-private-key-file=/var/state/apiserver.key \

--- a/build.assets/makefiles/master/k8s-master/kube-kubelet.service
+++ b/build.assets/makefiles/master/k8s-master/kube-kubelet.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/kubelet \
         --root-dir=/var/lib/kubelet \
         --hostname-override=${KUBE_NODE_NAME} \
         --logtostderr=true \
-        --pod-infra-container-image=${KUBE_APISERVER}:5000/gcr.io/google_containers/pause:3.0 \
+        --pod-infra-container-image=${KUBE_APISERVER}:5000/gcr.io/google_containers/pause:3.2 \
         --kubeconfig=/etc/kubernetes/kubelet.kubeconfig \
         --register-with-taints=${PLANET_NODE_TAINTS} \
         --node-labels=${PLANET_NODE_LABELS} \
@@ -23,7 +23,6 @@ ExecStart=/usr/bin/kubelet \
         --cgroup-root=${KUBE_CGROUP_ROOT} \
         --config=/etc/kubernetes/kubelet.yaml \
         --image-pull-progress-deadline=15m \
-        --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384 \
         --tls-min-version=VersionTLS12 \
         $KUBE_KUBELET_FLAGS \
         $KUBE_CLOUD_FLAGS \

--- a/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/audit-policy.yaml
+++ b/build.assets/makefiles/master/k8s-master/rootfs/etc/kubernetes/audit-policy.yaml
@@ -8,8 +8,10 @@ rules:
   # so drop them.
   - level: None
     users: ["system:kube-proxy"]
-    verbs: ["watch"]
+    verbs: ["get", "list", "watch"]
     resources:
+      - group: "discovery.k8s.io"
+        resources: ["endpointslices"]
       - group: "" # core
         resources: ["endpoints", "services", "services/status"]
   - level: None

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -434,7 +434,7 @@ const (
 	DefaultVxlanPort = 8472
 
 	// DefaultFeatureGates is the default set of component feature gates
-	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIMigration=false,KubeletPodResources=false,EndpointSlice=false,IPv6DualStack=false,RemoveSelfLink=false"
+	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIMigration=false,KubeletPodResources=false,IPv6DualStack=false,RemoveSelfLink=false"
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"
@@ -574,6 +574,16 @@ var KubeletConfigOverrides = kubeletconfig.KubeletConfiguration{
 	Authorization: kubeletconfig.KubeletAuthorization{
 		Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 	},
+	TLSCipherSuites: []string{
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_RSA_WITH_AES_256_GCM_SHA384",
+	},
+	TLSMinVersion: "VersionTLS12",
 }
 
 // KubeletTypeMeta defines the type meta block of the kubelet configuration resource


### PR DESCRIPTION
## Description
This PR supersedes https://github.com/gravitational/planet/pull/811, and bumps the Kubernetes version to 1.19.8. 

This PR only includes the minimum required changes to upgrade the Kubernetes service components. It does not bump Kubernetes client package versions. We will eventually want to upgrade client packages, but this will require larger changes and will be implemented in a separate batch of PRs.