### PR TITLE
Workaround PidsLimit config of systemd scope

### DIFF
--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -388,7 +388,7 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 				AllowedDevices:   configs.DefaultAllowedDevices,
 				MemorySwappiness: nil, // nil means "machine-default" and that's what we need because we don't care
 				CpuShares:        2,   // set planet to minimum cpu shares relative to host services
-				PidsLimit:        -1,  // override systemd defaults and set planet scope to unlimited pids
+				PidsLimit:        2000000,  // override systemd defaults and set planet scope to unlimited pids
 			},
 		},
 		Devices:  append(configs.DefaultAutoCreatedDevices, append(loopDevices, disks...)...),


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2444

Workaround for the -1 PidLimit not correctly passed to systemd by libcontainer. Newer runc updates does appear to fix this, however, updating runc in backports tends to be a bit risky so just set some large value we don't expect to see.