### PR TITLE
[7.0] Workaround PidsLimit config of systemd scop (#833)

### DIFF
--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -388,7 +388,7 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 				AllowedDevices:   configs.DefaultAllowedDevices,
 				MemorySwappiness: nil, // nil means "machine-default" and that's what we need because we don't care
 				CpuShares:        2,   // set planet to minimum cpu shares relative to host services
-				PidsLimit:        -1,  // override systemd defaults and set planet scope to unlimited pids
+				PidsLimit:        2000000,  // override systemd defaults and set planet scope to unlimited pids
 			},
 		},
 		Devices:  append(configs.DefaultAutoCreatedDevices, append(loopDevices, disks...)...),


### PR DESCRIPTION
Backport #833 

(cherry picked from commit 066329a5250b490da93db8a3bebac9267972df0f)