### PR TITLE
Bump Kubernetes to 1.21.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BUILDDIR ?= $(PWD)/build
 BUILDDIR := $(shell realpath $(BUILDDIR))
 OUTPUTDIR := $(BUILDDIR)/planet
 
-KUBE_VER ?= v1.19.8
+KUBE_VER ?= v1.21.0
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 19.03.12
 # we currently use our own flannel fork: gravitational/flannel

--- a/build.assets/makefiles/master/k8s-master/kube-apiserver.service
+++ b/build.assets/makefiles/master/k8s-master/kube-apiserver.service
@@ -14,7 +14,6 @@ EnvironmentFile=/etc/container-environment
 ExecStartPre=/usr/bin/scripts/wait-for-etcd.sh
 ExecStartPre=/bin/systemctl is-active etcd.service
 ExecStart=/usr/bin/kube-apiserver \
-        --insecure-port=0 \
         --service-account-key-file=/var/state/apiserver.key \
         --service-account-lookup=true \
         --service-account-signing-key-file=/var/state/apiserver.key \
@@ -23,13 +22,12 @@ ExecStart=/usr/bin/kube-apiserver \
         --enable-admission-plugins=${KUBE_ADMISSION_PLUGINS} \
         --admission-control-config-file=/etc/kubernetes/admission-control/control-config.yaml \
         --authorization-mode=Node,RBAC \
-        --runtime-config=api/v1,extensions/v1beta1,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true,flowcontrol.apiserver.k8s.io/v1alpha1=true,storage.k8s.io/v1alpha1 \
+        --runtime-config=api/v1,extensions/v1beta1,rbac.authorization.k8s.io/v1beta1,extensions/v1beta1/podsecuritypolicy,apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true,flowcontrol.apiserver.k8s.io/v1alpha1=true,storage.k8s.io/v1alpha1 \
         --allow-privileged=${PLANET_ALLOW_PRIVILEGED} \
         --tls-cert-file=/var/state/apiserver.cert \
         --tls-private-key-file=/var/state/apiserver.key \
         --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384 \
         --tls-min-version=VersionTLS12 \
-        --kubelet-https=true \
         --kubelet-certificate-authority=/var/state/root.cert \
         --kubelet-client-certificate=/var/state/apiserver-kubelet-client.cert \
         --kubelet-client-key=/var/state/apiserver-kubelet-client.key \

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -434,7 +434,7 @@ const (
 	DefaultVxlanPort = 8472
 
 	// DefaultFeatureGates is the default set of component feature gates
-	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIMigration=false,KubeletPodResources=false,IPv6DualStack=false,RemoveSelfLink=false,StorageVersionAPI=false"
+	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,StorageVersionAPI=false"
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -434,7 +434,7 @@ const (
 	DefaultVxlanPort = 8472
 
 	// DefaultFeatureGates is the default set of component feature gates
-	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIMigration=false,KubeletPodResources=false,IPv6DualStack=false,RemoveSelfLink=false"
+	DefaultFeatureGates = "AllAlpha=true,APIResponseCompression=false,BoundServiceAccountTokenVolume=false,CSIMigration=false,KubeletPodResources=false,IPv6DualStack=false,RemoveSelfLink=false,StorageVersionAPI=false"
 
 	// DefaultServiceNodePortRange defines the default IP range for services with NodePort visibility
 	DefaultServiceNodePortRange = "30000-32767"


### PR DESCRIPTION
## Description
Bump Kubernetes from `v1.19.8` -> `v1.21.0`. Kubernetes changelogs [v1.20](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md), [v1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md)

The `--kubelet-https` flag seems to have been deprecated a while ago, so the flag has been removed.

The ability to serve on an insecure port has been removed in v1.20, so the flag `--insecure-port` has been removed.
> The kube-apiserver ability to serve on an insecure port, deprecated since v1.10, has been removed. The insecure address flags --address and --insecure-bind-address have no effect in kube-apiserver and will be removed in v1.24. The insecure port flags --port and --insecure-port may only be set to 0 and will be removed in v1.24.


v1.20 introduced a new StorageVersionAPI alpha feature gate. Planet has all alpha features enabled by default, but this feature was causing kube-apiserver to crash with the current config. So I've disabled it for now.
> Add a StorageVersionAPI feature gate that makes API server update storageversions before serving certain write requests. This feature allows the storage migrator to manage storage migration for built-in resources. Enabling internal.apiserver.k8s.io/v1alpha1 API and APIServerIdentity feature gate are required to use this feature.

In v1.21, the `batch/v2alpha1` API group has been disabled. CronJobs have been promoted to `batch/v1` API group.
> The batch/v2alpha1 CronJob type definitions and clients are deprecated and removed. Promote CronJobs to batch/v1 

## Note
Kubernetes v1.20+ is needed to support our custom load balancer for Teleport Cloud https://github.com/gravitational/aws-global-accelerator-controller/issues/4