### PR TITLE
Allow flannel backend override

### DIFF
--- a/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
+++ b/build.assets/docker/os-rootfs/etc/planet/orbit.manifest.json
@@ -507,6 +507,14 @@
                 "cli": {
                     "name": "high-availability"
                 }
+            },
+            {
+                "type": "String",
+                "name": "flannel-backend",
+                "env": "FLANNEL_BACKEND",
+                "cli": {
+                    "name": "flannel-backend"
+                }
             }
         ]
     }

--- a/tool/planet/cfg.go
+++ b/tool/planet/cfg.go
@@ -140,6 +140,8 @@ type Config struct {
 	// HighAvailability enables kubernetes high availability mode. If enabled,
 	// control plane components will be enabled on all master nodes.
 	HighAvailability bool
+	// FlannelBackend specifies the backend to pair with flannel.
+	FlannelBackend string
 }
 
 // DNS describes DNS server configuration

--- a/tool/planet/constants.go
+++ b/tool/planet/constants.go
@@ -271,6 +271,9 @@ const (
 	// availability mode.
 	EnvHighAvailability = "KUBE_HIGH_AVAILABILITY"
 
+	// EnvFlannelBackend specifies the flannel backend.
+	EnvFlannelBackend = "FLANNEL_BACKEND"
+
 	// DefaultDNSListenAddr is the default IP address CoreDNS will listen on
 	DefaultDNSListenAddr = "127.0.0.2"
 

--- a/tool/planet/main.go
+++ b/tool/planet/main.go
@@ -139,6 +139,7 @@ func run() error {
 		cstartAllowPrivileged  = cstart.Flag("allow-privileged", "Allow privileged containers").OverrideDefaultFromEnvar(EnvPlanetAllowPrivileged).Bool()
 		cstartSELinux          = cstart.Flag("selinux", "Run with SELinux support").Envar(EnvPlanetSELinux).Bool()
 		cstartHighAvailability = cstart.Flag("high-availability", "Boolean flag to enable/disable kubernetes high availability mode.").OverrideDefaultFromEnvar(EnvHighAvailability).Bool()
+		cstartFlannelBackend   = cstart.Flag("flannel-backend", "Flannel backend: 'aws-vpc', 'gce', or 'vxlan'").Envar(EnvFlannelBackend).String()
 
 		// start the planet agent
 		cagent                 = app.Command("agent", "Start Planet Agent")
@@ -464,6 +465,7 @@ func run() error {
 			AllowPrivileged:  *cstartAllowPrivileged,
 			SELinux:          *cstartSELinux,
 			HighAvailability: *cstartHighAvailability,
+			FlannelBackend:   *cstartFlannelBackend,
 		}
 		err = startAndWait(config)
 


### PR DESCRIPTION
## Description
Planet automatically selects a flannel backend based on the cloud provider it is running on. This PR adds the `flannel-backend` flag to allow the user to specify the flannel backend.

The changes will only allow overriding backend to `aws-vpc`, `gce`, and `vxlan`.

These changes are required to implement geo-diversity for Teleport Cloud https://github.com/gravitational/cloud/pull/747