### PR TITLE
update tiller repo

### DIFF
--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -97,7 +97,7 @@ RUN curl -L https://github.com/containerd/containerd/releases/download/v1.2.10/c
     cp /tmp/containerd/bin/containerd /tmp/containerd/bin/containerd-shim /tmp/containerd/bin/ctr /usr/bin/ && \
     rm -rf /tmp/containerd
 
-RUN curl https://ghcr.io/helm//helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
+RUN curl https://ghcr.io/helm/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
     mkdir -p /tmp/helm && tar -xvzf /tmp/helm-$HELM_VER.tar.gz -C /tmp/helm && \
     cp /tmp/helm/linux-amd64/helm /usr/bin && \
     rm -rf /tmp/helm*

--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -97,7 +97,7 @@ RUN curl -L https://github.com/containerd/containerd/releases/download/v1.2.10/c
     cp /tmp/containerd/bin/containerd /tmp/containerd/bin/containerd-shim /tmp/containerd/bin/ctr /usr/bin/ && \
     rm -rf /tmp/containerd
 
-RUN curl https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
+RUN curl https://ghcr.io/helm//helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
     mkdir -p /tmp/helm && tar -xvzf /tmp/helm-$HELM_VER.tar.gz -C /tmp/helm && \
     cp /tmp/helm/linux-amd64/helm /usr/bin && \
     rm -rf /tmp/helm*

--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -97,7 +97,7 @@ RUN curl -L https://github.com/containerd/containerd/releases/download/v1.2.10/c
     cp /tmp/containerd/bin/containerd /tmp/containerd/bin/containerd-shim /tmp/containerd/bin/ctr /usr/bin/ && \
     rm -rf /tmp/containerd
 
-RUN curl https://ghcr.io/helm/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
+RUN curl https://get.helm.sh/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
     mkdir -p /tmp/helm && tar -xvzf /tmp/helm-$HELM_VER.tar.gz -C /tmp/helm && \
     cp /tmp/helm/linux-amd64/helm /usr/bin && \
     rm -rf /tmp/helm*


### PR DESCRIPTION
## Description
Per https://helm.sh/docs/faq/troubleshooting/#tiller-installations-stopped-working-and-access-is-denied

    The legacy Tiller image location began the removal of images in August 2021. We have made these images available at the GitHub Container Registry location. For example, to download version v2.17.0, replace:

    https://storage.googleapis.com/kubernetes-helm/helm-v2.17.0-linux-amd64.tar.gz

    with:

    https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz


