### PR TITLE
bump kubernetes to 1.21.5 for CVE-2021-25741

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -1,5 +1,5 @@
 
-KUBE_VER ?= v1.21.2
+KUBE_VER ?= v1.21.5
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 20.10.7
 # we currently use our own flannel fork: gravitational/flannel


### PR DESCRIPTION
Bump kubernetes to 1.21.5 to avoid CVE-2021-25741. See https://groups.google.com/g/kubernetes-announce/c/-e9OlTcED5E for more information from the Kubernetes project.