### PR TITLE
Update satellite to fix nethealth fd leak

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:de5b3032c10ac9cd09e54d90b9affbd807481cb5809638756a6741e395f2e3e3"
+  digest = "1:6e6cf48f5c01f76822140c446dc88282eb5418a39a6e87ba3360b171a8131ab2"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -451,8 +451,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "aef8c3a377eb8e09f0fb06f7ba4ee7a63b61a617"
-  version = "7.0.24"
+  revision = "321d645d9f7113f776c8a64f2e952651e823dd21"
+  version = "7.0.25"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.24"
+  version = "=7.0.25"
 
 [[override]]
   name = "github.com/gravitational/trace"

--- a/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/lib/nethealth/nethealth.go
@@ -242,6 +242,11 @@ func (s *Server) Start() error {
 	mux := http.ServeMux{}
 	mux.Handle("/metrics", promhttp.Handler())
 	s.httpServer = &http.Server{Addr: fmt.Sprint(":", s.config.PrometheusPort), Handler: &mux}
+
+	// Workaround for https://github.com/gravitational/gravity/issues/2320
+	// Disable keep-alives to avoid the client/server hanging unix domain sockets that don't get cleaned up.
+	s.httpServer.SetKeepAlivesEnabled(false)
+
 	go func() {
 		if err := s.httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			s.Fatalf("ListenAndServe(): %s", err)

--- a/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/nethealth.go
@@ -306,6 +306,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		},
 		Timeout: time.Second,
 	}
+
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
 	// Example metrics received from nethealth may look something like the output below:
@@ -325,11 +326,16 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 
 	req = req.WithContext(ctx)
 
+	req.Close = true
+
 	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
It is a backport to fix nethealth fd leak
Refs: 
 - gravitational/gravity#2320
 - gravitational/satellite#291
