### PR TITLE
Bump go to 1.17.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ ARG CNI_VER=0.8.6
 ARG IPTABLES_VER=v1.8.5
 ARG PLANET_UID=980665
 ARG PLANET_GID=980665
-ARG GO_VERSION=1.16.3
+ARG GO_VERSION=1.17.5
 ARG ALPINE_VERSION=3.12
 ARG DEBIAN_IMAGE=quay.io/gravitational/debian-mirror@sha256:4b6ec644c29e4964a6f74543a5bf8c12bed6dec3d479e039936e4a37a8af9116
-ARG GO_BUILDER_VERSION=go1.13.8-stretch
+ARG GO_BUILDER_VERSION=go1.17.5-stretch
 ARG AWS_ENCRYPTION_PROVIDER_VER=c4abcb30b4c1ab1961369e1e50a98da2cedb765d
 # TODO(dima): update to 2.7.2 release once available
 # ARG DISTRIBUTION_VER=release/2.7
@@ -70,7 +70,7 @@ RUN set -ex && \
 ARG GO_BUILDER_VERSION
 FROM quay.io/gravitational/debian-venti:${GO_BUILDER_VERSION} AS planet-builder-base
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev && mkdir -p /tmp && \
-	GO111MODULE=on go install github.com/gravitational/version/cmd/linkflags
+	GO111MODULE=on go install github.com/gravitational/version/cmd/linkflags@0.0.2
 
 FROM planet-builder-base AS planet-builder
 ENV PATH="$PATH:/gopath/bin"

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.12.17
+ARG GOVERSION=1.17.5
 
 # TODO: currently defaulting to stretch explicitly to work around
 # a breaking change in buster (with GLIBC 2.28) w.r.t fcntl() implementation.
@@ -10,7 +10,8 @@ ENV GOCACHE ${GOPATH}/.gocache-${GOVERSION}
 
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev
 
-RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE};go get github.com/tools/godep
-RUN go get github.com/gravitational/version/cmd/linkflags
+RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE}
+RUN GO111MODULE=off go get github.com/tools/godep
+RUN GO111MODULE=off go get github.com/gravitational/version/cmd/linkflags
 RUN chmod a+w $GOPATH -R
 RUN chmod a+w $GOROOT -R

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -34,7 +34,7 @@ $(BINARIES):
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(DISTRIBUTION_VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
+	GO111MODULE=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
 
 install: registry.mk $(BINARIES)
 	@echo "\n---> Installing docker registry:\n"

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -34,5 +34,5 @@ $(ASSETDIR)/docker-import:
 
 .PHONY: flags
 flags:
-	go install github.com/gravitational/version/cmd/linkflags
+	go install github.com/gravitational/version/cmd/linkflags@0.0.2
 	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/aws/aws-sdk-go v1.25.41
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/checkpoint-restore/go-criu v0.0.0-20181120144056-17b0214f6c48 // indirect
 	github.com/cilium/ebpf v0.0.0-20200224172853-0b019ed01187 // indirect

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ COREDNS_VER := 1.7.0
 NODE_PROBLEM_DETECTOR_VER := v0.6.4
 CNI_VER := 0.8.6
 IPTABLES_VER := v1.8.5
-BUILDBOX_GO_VER ?= 1.13.8
+BUILDBOX_GO_VER ?= 1.17.5
 DISTRIBUTION_VER=v2.7.1-gravitational
 # aws-encryption-provider repo does not currently provide tagged releases
 AWS_ENCRYPTION_PROVIDER_VER := c4abcb30b4c1ab1961369e1e50a98da2cedb765d


### PR DESCRIPTION
## Description
Bump go version to `1.17.5`.
Applied some changes that were required due to [module changes in Go 1.16](https://go.dev/blog/go116-module-changes).
- `go install` now requires a version suffix.
- Go defaults to `GO111MODULE=on`. We need to set `GO111MODULE=off` in places we want to continue using GOPATH mode.


## Linked tickets and PRs
- Refs https://github.com/gravitational/gravity/issues/2693