### PR TITLE
[8.0.x] Bump go to 1.17.5 (#871)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,11 +248,8 @@ RUN --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache
 FROM gobase AS serf-builder
 ARG SERF_VER
 RUN set -ex && \
-	mkdir -p /go/src/github.com/hashicorp && \
-	cd /go/src/github.com/hashicorp && \
-	git clone https://github.com/hashicorp/serf -b ${SERF_VER} --depth 1 && \
-	cd /go/src/github.com/hashicorp/serf && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /serf ./cmd/serf
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install github.com/hashicorp/serf/cmd/serf@${SERF_VER} && \
+	cp ${GOPATH}/bin/serf /serf
 
 FROM downloader AS cni-downloader
 ARG CNI_VER

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ ARG SERF_VER=v0.8.5
 ARG IPTABLES_VER=v1.8.5
 ARG PLANET_UID=980665
 ARG PLANET_GID=980665
-ARG GO_VERSION=1.16.3
+ARG GO_VERSION=1.17.5
 ARG ALPINE_VERSION=3.12
 ARG DEBIAN_IMAGE=quay.io/gravitational/debian-mirror@sha256:4b6ec644c29e4964a6f74543a5bf8c12bed6dec3d479e039936e4a37a8af9116
-ARG GO_BUILDER_VERSION=go1.13.8-stretch
+ARG GO_BUILDER_VERSION=go1.17.5-stretch
 # TODO(dima): update to 2.7.2 release once available
 # ARG DISTRIBUTION_VER=release/2.7
 ARG DISTRIBUTION_VER=v2.7.1-gravitational
@@ -70,7 +70,7 @@ RUN set -ex && \
 ARG GO_BUILDER_VERSION
 FROM quay.io/gravitational/debian-venti:${GO_BUILDER_VERSION} AS planet-builder-base
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev && mkdir -p /tmp && \
-	GO111MODULE=on go install github.com/gravitational/version/cmd/linkflags
+	GO111MODULE=on go install github.com/gravitational/version/cmd/linkflags@0.0.2
 
 FROM planet-builder-base AS planet-builder
 ENV PATH="$PATH:/gopath/bin"

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.12.17
+ARG GOVERSION=1.17.5
 
 # TODO: currently defaulting to stretch explicitly to work around
 # a breaking change in buster (with GLIBC 2.28) w.r.t fcntl() implementation.
@@ -10,7 +10,8 @@ ENV GOCACHE ${GOPATH}/.gocache-${GOVERSION}
 
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev
 
-RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE};go get github.com/tools/godep
-RUN go get github.com/gravitational/version/cmd/linkflags
+RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE}
+RUN GO111MODULE=off go get github.com/tools/godep
+RUN GO111MODULE=off go get github.com/gravitational/version/cmd/linkflags
 RUN chmod a+w $GOPATH -R
 RUN chmod a+w $GOROOT -R

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,6 +1,5 @@
 .PHONY: all
 
-REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
 OUT := $(ASSETDIR)/serf-$(SERF_VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
 
@@ -8,11 +7,8 @@ all: agent.mk planet-agent.service $(OUT) $(BINARIES)
 
 $(OUT):
 	@echo "\n---> Building Serf:\n"
-	mkdir -p $(GOPATH)/src/github.com/hashicorp
-	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(SERF_VER) --depth 1
-	cd $(REPODIR) && \
-	go get -t -d ./... && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install github.com/hashicorp/serf/cmd/serf@$(SERF_VER)
+	cp $(GOPATH)/bin/serf $@
 
 $(BINARIES): serf.service planet-agent.service
 	@echo "\n---> Installing services for Serf/Planet agent:\n"

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -34,7 +34,7 @@ $(BINARIES):
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(DISTRIBUTION_VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
+	GO111MODULE=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
 
 install: registry.mk $(BINARIES)
 	@echo "\n---> Installing docker registry:\n"

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -34,5 +34,5 @@ $(ASSETDIR)/docker-import:
 
 .PHONY: flags
 flags:
-	go install github.com/gravitational/version/cmd/linkflags
+	go install github.com/gravitational/version/cmd/linkflags@0.0.2
 	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")

--- a/versions.mk
+++ b/versions.mk
@@ -3,16 +3,16 @@ KUBE_VER ?= v1.19.15
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 20.10.7
 # we currently use our own flannel fork: gravitational/flannel
-FLANNEL_VER ?= v0.10.5-gravitational
-HELM_VER ?= 2.16.12
-HELM3_VER ?= 3.3.4
-COREDNS_VER ?= 1.7.0
-NODE_PROBLEM_DETECTOR_VER ?= v0.6.4
-CNI_VER ?= 0.8.6
+FLANNEL_VER := v0.10.5-gravitational
+HELM_VER := 2.16.12
+HELM3_VER := 3.3.4
+COREDNS_VER := 1.7.0
+NODE_PROBLEM_DETECTOR_VER := v0.6.4
+CNI_VER := 0.8.6
 SERF_VER ?= v0.8.5
-IPTABLES_VER ?= v1.8.5
-BUILDBOX_GO_VER ?= 1.13.8
-DISTRIBUTION_VER ?= v2.7.1-gravitational
+IPTABLES_VER := v1.8.5
+BUILDBOX_GO_VER ?= 1.17.5
+DISTRIBUTION_VER=v2.7.1-gravitational
 
 # planet user to use inside the rootfs tarball. This serves as a placeholder
 # and the files will be owned by the actual planet user after extraction

--- a/versions.mk
+++ b/versions.mk
@@ -3,16 +3,16 @@ KUBE_VER ?= v1.19.15
 SECCOMP_VER ?= 2.3.1-2.1+deb9u1
 DOCKER_VER ?= 20.10.7
 # we currently use our own flannel fork: gravitational/flannel
-FLANNEL_VER := v0.10.5-gravitational
-HELM_VER := 2.16.12
-HELM3_VER := 3.3.4
-COREDNS_VER := 1.7.0
-NODE_PROBLEM_DETECTOR_VER := v0.6.4
-CNI_VER := 0.8.6
+FLANNEL_VER ?= v0.10.5-gravitational
+HELM_VER ?= 2.16.12
+HELM3_VER ?= 3.3.4
+COREDNS_VER ?= 1.7.0
+NODE_PROBLEM_DETECTOR_VER ?= v0.6.4
+CNI_VER ?= 0.8.6
 SERF_VER ?= v0.8.5
-IPTABLES_VER := v1.8.5
+IPTABLES_VER ?= v1.8.5
 BUILDBOX_GO_VER ?= 1.17.5
-DISTRIBUTION_VER=v2.7.1-gravitational
+DISTRIBUTION_VER ?= v2.7.1-gravitational
 
 # planet user to use inside the rootfs tarball. This serves as a placeholder
 # and the files will be owned by the actual planet user after extraction


### PR DESCRIPTION
## Description
Bump go version to `1.17.5`.
Applied some changes that were required due to [module changes in Go 1.16](https://go.dev/blog/go116-module-changes).
- `go install` now requires a version suffix.
- Go defaults to `GO111MODULE=on`. We need to set `GO111MODULE=off` in places we want to continue using GOPATH mode.


## Linked tickets and PRs
- Ports https://github.com/gravitational/planet/pull/871
- Refs https://github.com/gravitational/gravity/issues/2693