### PR TITLE
[5.5.x] Bump go to 1.17.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ETCD_VER := v2.3.8 v3.3.4 v3.3.9 v3.3.11 v3.3.20 v3.3.22
 # This is the version of etcd we should upgrade to (from the version list)
 ETCD_LATEST_VER := v3.3.22
 
-BUILDBOX_GO_VER ?= 1.12.9
+BUILDBOX_GO_VER ?= 1.17.5
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)
@@ -79,7 +79,7 @@ build: $(BUILD_ASSETS)/planet $(BUILDDIR)/planet.tar.gz
 
 .PHONY: planet-bin
 planet-bin:
-	go build -o $(OUTPUTDIR)/planet github.com/gravitational/planet/tool/planet
+	GO111MODULE=off go build -o $(OUTPUTDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
 .PHONY: dev-deploy

--- a/build.assets/docker/base.dockerfile
+++ b/build.assets/docker/base.dockerfile
@@ -89,7 +89,7 @@ RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_V
     cp /tmp/docker/* /usr/bin && \
     rm -rf /tmp/docker*
 
-RUN curl https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
+RUN curl https://get.helm.sh/helm-$HELM_VER-linux-amd64.tar.gz -o /tmp/helm-$HELM_VER.tar.gz && \
     mkdir -p /tmp/helm && tar -xvzf /tmp/helm-$HELM_VER.tar.gz -C /tmp/helm && \
     cp /tmp/helm/linux-amd64/helm /usr/bin && \
     # make symlink for helm for backward compatibility

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -1,7 +1,7 @@
 ARG PLANET_BASE_IMAGE=planet/base:latest
 FROM $PLANET_BASE_IMAGE
 
-ARG GOVERSION=go1.10.7
+ARG GOVERSION=go1.17.5
 
 ENV GOPATH /gopath
 ENV GOROOT /opt/go
@@ -15,7 +15,8 @@ COPY passwd /etc/passwd
 RUN apt-get update && apt-get -t stretch-backports install -y libc6-dev libudev-dev && \
 	apt-get install -y curl make git gcc tar gzip vim screen dumb-init
 RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar xz
-RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOVERSION};go get github.com/tools/godep
-RUN go get github.com/gravitational/version/cmd/linkflags
+RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOVERSION}
+RUN GO111MODULE=off go get github.com/tools/godep
+RUN GO111MODULE=off go get github.com/gravitational/version/cmd/linkflags
 RUN chmod a+w $GOPATH -R
 RUN chmod a+w $GOROOT -R

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,18 +1,13 @@
 .PHONY: all
 
-REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
 OUT := $(ASSETDIR)/serf-$(SERF_VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
 
 all: agent.mk $(OUT) $(BINARIES)
 
 $(OUT):
-	@echo "\n---> Building Serf:\n"
-	mkdir -p $(GOPATH)/src/github.com/hashicorp
-	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(SERF_VER) --depth 1
-	cd $(REPODIR) && \
-	go get -t -d ./... && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install github.com/hashicorp/serf/cmd/serf@$(SERF_VER)
+	cp $(GOPATH)/bin/serf $@
 
 $(BINARIES): serf.service planet-agent.service
 	@echo "\n---> Installing services for Serf/Planet agent:\n"

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -35,7 +35,7 @@ $(BINARIES):
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
+	GO111MODULE=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
 
 install: registry.mk $(BINARIES)
 	@echo "\n---> Installing docker registry:\n"

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -20,12 +20,12 @@ all: common-docker.mk $(ASSETDIR)/planet $(ASSETDIR)/docker-import
 $(ASSETDIR)/planet: flags
 # Add to ldflags to compile a completely static version of the planet binary (w/o the glibc dependency)
 # -ldflags '-extldflags "-static"'
-	GOOS=linux GOARCH=amd64 go build -ldflags $(PLANET_LINKFLAGS) -o $@ github.com/gravitational/planet/tool/planet
+	GO111MODULE=off GOOS=linux GOARCH=amd64 go build -ldflags $(PLANET_LINKFLAGS) -o $@ github.com/gravitational/planet/tool/planet
 
 $(ASSETDIR)/docker-import:
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
+	GO111MODULE=off GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
 
 .PHONY: flags
 flags:
-	go install github.com/gravitational/version/cmd/linkflags
+	go install github.com/gravitational/version/cmd/linkflags@0.0.2
 	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/planet/vendor/github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")


### PR DESCRIPTION
## Description
Bump go version to `1.17.5`.
Applied some changes that were required due to [module changes in Go 1.16](https://go.dev/blog/go116-module-changes).
- `go install` now requires a version suffix.
- Go defaults to `GO111MODULE=on`. We need to set `GO111MODULE=off` in places we want to continue using GOPATH mode.

## Linked tickets and PRs
- Ports https://github.com/gravitational/planet/pull/871
- Refs https://github.com/gravitational/gravity/issues/2693