### PR TITLE
[7.0.x] Revert go upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ETCD_VER := v3.3.12 v3.3.15 v3.3.20 v3.3.22 v3.4.3 v3.4.7 v3.4.9
 #   - Modify build.go and run the etcd upgrade integration test (go run mage.go ci:testEtcdUpgrade)
 ETCD_LATEST_VER := v3.4.9
 
-BUILDBOX_GO_VER ?= 1.17.5
+BUILDBOX_GO_VER ?= 1.12.9
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)
@@ -101,7 +101,7 @@ build: $(BUILD_ASSETS)/planet $(BUILDDIR)/planet.tar.gz
 
 .PHONY: planet-bin
 planet-bin:
-	GO111MODULE=off go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
+	go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
 .PHONY: dev-deploy

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.17.5
+ARG GOVERSION=1.12.17
 
 # TODO: currently defaulting to stretch explicitly to work around
 # a breaking change in buster (with GLIBC 2.28) w.r.t fcntl() implementation.
@@ -10,8 +10,7 @@ ENV GOCACHE ${GOPATH}/.gocache-${GOVERSION}
 
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev
 
-RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE}
-RUN GO111MODULE=off go get github.com/tools/godep
-RUN GO111MODULE=off go get github.com/gravitational/version/cmd/linkflags
+RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE};go get github.com/tools/godep
+RUN go get github.com/gravitational/version/cmd/linkflags
 RUN chmod a+w $GOPATH -R
 RUN chmod a+w $GOROOT -R

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,5 +1,6 @@
 .PHONY: all
 
+REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
 OUT := $(ASSETDIR)/serf-$(SERF_VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
 
@@ -7,8 +8,11 @@ all: agent.mk $(OUT) $(BINARIES)
 
 $(OUT):
 	@echo "\n---> Building Serf:\n"
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install github.com/hashicorp/serf/cmd/serf@$(SERF_VER)
-	cp $(GOPATH)/bin/serf $@
+	mkdir -p $(GOPATH)/src/github.com/hashicorp
+	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(SERF_VER) --depth 1
+	cd $(REPODIR) && \
+	go get -t -d ./... && \
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf
 
 $(BINARIES): serf.service planet-agent.service
 	@echo "\n---> Installing services for Serf/Planet agent:\n"

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -35,7 +35,7 @@ $(BINARIES):
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
-	GO111MODULE=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
 
 install: registry.mk $(BINARIES)
 	@echo "\n---> Installing docker registry:\n"

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -23,13 +23,13 @@ $(ASSETDIR)/planet: flags
 # Add to ldflags to compile a completely static version of the planet binary (w/o the glibc dependency)
 # -ldflags '-extldflags "-static"'
 	CGO_LDFLAGS_ALLOW=".*" \
-	GO111MODULE=off GOOS=linux GOARCH=amd64 \
+	GOOS=linux GOARCH=amd64 \
 		go build -ldflags $(PLANET_LINKFLAGS) $(PLANET_BUILDFLAGS) -o $@ github.com/gravitational/planet/tool/planet
 
 $(ASSETDIR)/docker-import:
-	GO111MODULE=off GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
 
 .PHONY: flags
 flags:
-	go install github.com/gravitational/version/cmd/linkflags@0.0.2
+	go install github.com/gravitational/version/cmd/linkflags
 	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/planet/vendor/github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")


### PR DESCRIPTION
This reverts commit d96f1e9456b15da9f65d0f97e2dd1981f7fe2ed2. The Go upgrade resulted in volumes being unable to be mounted on Google Cloud https://github.com/gravitational/gravity/issues/2727. We'll revert the Go version to v1.12 until we can resolve the issue.