### PR TITLE
[7.0.x] Update go-udev

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -554,6 +554,14 @@
   version = "v0.3.6"
 
 [[projects]]
+  branch = "master"
+  digest = "1:96e2e68cc63ed2010448ebbad799e16d25bcdc997a23dc7722bb5fb70d950be6"
+  name = "github.com/jkeiser/iter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c8aa0ae784d15ad3cb2a1f1579768e46f6e87fe5"
+
+[[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
@@ -570,6 +578,14 @@
   pruneopts = "UT"
   revision = "d161d7a76b5661016ad0b085869f77fd410f3e6a"
   version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4b57f0f5cbfc1d9ea2bce2f32eff6137fe19d14182732e395dfca7f85494ce83"
+  name = "github.com/jochenvg/go-udev"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d6b62d56d37b941d93a199f9cb6f0250636fd4ab"
 
 [[projects]]
   digest = "1:35f49695a600c368ad7811a672d583b3e004b44fe883a0a1eb2a6c0d75eaeb1b"
@@ -1523,6 +1539,7 @@
     "github.com/gravitational/version",
     "github.com/hashicorp/serf/client",
     "github.com/imdario/mergo",
+    "github.com/jochenvg/go-udev",
     "github.com/kylelemons/godebug/diff",
     "github.com/magefile/mage/mage",
     "github.com/magefile/mage/mg",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,7 +90,7 @@ ignored = ["github.com/gravitational/planet/build/*"]
 
 [[constraint]]
   branch = "master"
-  name = "github.com/gravitational/go-udev"
+  name = "github.com/jochenvg/go-udev"
 
 [[constraint]]
   name = "github.com/gravitational/satellite"

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ETCD_VER := v3.3.12 v3.3.15 v3.3.20 v3.3.22 v3.4.3 v3.4.7 v3.4.9
 #   - Modify build.go and run the etcd upgrade integration test (go run mage.go ci:testEtcdUpgrade)
 ETCD_LATEST_VER := v3.4.9
 
-BUILDBOX_GO_VER ?= 1.12.9
+BUILDBOX_GO_VER ?= 1.17.5
 PLANET_BUILD_TAG ?= $(shell git describe --tags)
 PLANET_IMAGE_NAME ?= planet/base
 PLANET_IMAGE ?= $(PLANET_IMAGE_NAME):$(PLANET_BUILD_TAG)
@@ -101,7 +101,7 @@ build: $(BUILD_ASSETS)/planet $(BUILDDIR)/planet.tar.gz
 
 .PHONY: planet-bin
 planet-bin:
-	go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
+	GO111MODULE=off go build -o $(BUILDDIR)/planet github.com/gravitational/planet/tool/planet
 
 # Deploys the build artifacts to Amazon S3
 .PHONY: dev-deploy

--- a/build.assets/docker/buildbox.dockerfile
+++ b/build.assets/docker/buildbox.dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.12.17
+ARG GOVERSION=1.17.5
 
 # TODO: currently defaulting to stretch explicitly to work around
 # a breaking change in buster (with GLIBC 2.28) w.r.t fcntl() implementation.
@@ -10,7 +10,8 @@ ENV GOCACHE ${GOPATH}/.gocache-${GOVERSION}
 
 RUN apt-get update && apt-get install -y libc6-dev libudev-dev
 
-RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE};go get github.com/tools/godep
-RUN go get github.com/gravitational/version/cmd/linkflags
+RUN mkdir -p $GOPATH/src $GOPATH/bin ${GOCACHE}
+RUN GO111MODULE=off go get github.com/tools/godep
+RUN GO111MODULE=off go get github.com/gravitational/version/cmd/linkflags
 RUN chmod a+w $GOPATH -R
 RUN chmod a+w $GOROOT -R

--- a/build.assets/makefiles/base/agent/agent.mk
+++ b/build.assets/makefiles/base/agent/agent.mk
@@ -1,6 +1,5 @@
 .PHONY: all
 
-REPODIR := $(GOPATH)/src/github.com/hashicorp/serf
 OUT := $(ASSETDIR)/serf-$(SERF_VER)
 BINARIES := $(ROOTFS)/usr/bin/serf
 
@@ -8,11 +7,8 @@ all: agent.mk $(OUT) $(BINARIES)
 
 $(OUT):
 	@echo "\n---> Building Serf:\n"
-	mkdir -p $(GOPATH)/src/github.com/hashicorp
-	cd $(GOPATH)/src/github.com/hashicorp && git clone https://github.com/hashicorp/serf -b $(SERF_VER) --depth 1
-	cd $(REPODIR) && \
-	go get -t -d ./... && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o $@ ./cmd/serf
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install github.com/hashicorp/serf/cmd/serf@$(SERF_VER)
+	cp $(GOPATH)/bin/serf $@
 
 $(BINARIES): serf.service planet-agent.service
 	@echo "\n---> Installing services for Serf/Planet agent:\n"

--- a/build.assets/makefiles/base/docker/registry.mk
+++ b/build.assets/makefiles/base/docker/registry.mk
@@ -35,7 +35,7 @@ $(BINARIES):
 	cd $(REPODIR) && git clone https://github.com/gravitational/distribution -b $(VER) --depth 1
 	cd $(REPODIR)/distribution && \
 	echo "$$VERSION_PACKAGE" > version/version.go && \
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
+	GO111MODULE=off GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags "$(DOCKER_BUILDTAGS)" -a -installsuffix cgo -o $@ $(GO_LDFLAGS) ./cmd/registry
 
 install: registry.mk $(BINARIES)
 	@echo "\n---> Installing docker registry:\n"

--- a/build.assets/makefiles/common-docker.mk
+++ b/build.assets/makefiles/common-docker.mk
@@ -23,13 +23,13 @@ $(ASSETDIR)/planet: flags
 # Add to ldflags to compile a completely static version of the planet binary (w/o the glibc dependency)
 # -ldflags '-extldflags "-static"'
 	CGO_LDFLAGS_ALLOW=".*" \
-	GOOS=linux GOARCH=amd64 \
+	GO111MODULE=off GOOS=linux GOARCH=amd64 \
 		go build -ldflags $(PLANET_LINKFLAGS) $(PLANET_BUILDFLAGS) -o $@ github.com/gravitational/planet/tool/planet
 
 $(ASSETDIR)/docker-import:
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
+	GO111MODULE=off GOOS=linux GOARCH=amd64 go build -ldflags "$(PLANET_GO_LDFLAGS)" -o $@ github.com/gravitational/planet/tool/docker-import
 
 .PHONY: flags
 flags:
-	go install github.com/gravitational/version/cmd/linkflags
+	go install github.com/gravitational/version/cmd/linkflags@0.0.2
 	$(eval PLANET_LINKFLAGS := "$(shell linkflags -pkg=$(PLANET_PKG_PATH) -verpkg=github.com/gravitational/planet/vendor/github.com/gravitational/version) $(PLANET_GO_LDFLAGS)")

--- a/lib/box/srv.go
+++ b/lib/box/srv.go
@@ -33,8 +33,8 @@ import (
 	"github.com/gravitational/planet/lib/constants"
 	"github.com/gravitational/planet/lib/defaults"
 
-	"github.com/gravitational/go-udev"
 	"github.com/gravitational/trace"
+	"github.com/jochenvg/go-udev"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -386,9 +386,9 @@ func getLibcontainerConfig(containerID, rootfs string, cfg Config) (*configs.Con
 			Resources: &configs.Resources{
 				AllowAllDevices:  &allowAllDevices,
 				AllowedDevices:   configs.DefaultAllowedDevices,
-				MemorySwappiness: nil, // nil means "machine-default" and that's what we need because we don't care
-				CpuShares:        2,   // set planet to minimum cpu shares relative to host services
-				PidsLimit:        2000000,  // override systemd defaults and set planet scope to unlimited pids
+				MemorySwappiness: nil,     // nil means "machine-default" and that's what we need because we don't care
+				CpuShares:        2,       // set planet to minimum cpu shares relative to host services
+				PidsLimit:        2000000, // override systemd defaults and set planet scope to unlimited pids
 			},
 		},
 		Devices:  append(configs.DefaultAutoCreatedDevices, append(loopDevices, disks...)...),

--- a/vendor/github.com/jkeiser/iter/LICENSE
+++ b/vendor/github.com/jkeiser/iter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 John Keiser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jkeiser/iter/channel.go
+++ b/vendor/github.com/jkeiser/iter/channel.go
@@ -1,0 +1,125 @@
+package iter
+
+import "log"
+
+// A result from a iterator.Go() channel.
+type ChannelItem struct {
+	Value interface{}
+	Error error
+}
+
+// Runs the iterator in a goroutine, sending to a channel.
+//
+// The returned items channel will send ChannelItems to you, which can indicate
+// either a value or an error.  If item.Error is set, iteration is ready
+// to terminate.  Otherwise item.Value is the next value of the iteration.
+//
+// When you are done iterating, you must close the done channel. Even if iteration
+// was terminated early, this will ensure that the goroutine and channel are
+// properly cleaned up.
+//
+//   channel, done := iter.Go(iterator)
+//   defer close(done) // if early return or panic happens, this will clean up the goroutine
+//   for item := range channel {
+//     if item.Error != nil {
+//       // Iteration failed; handle the error and exit the loop
+//       ...
+//     }
+//     value := item.Value
+//     ...
+//   }
+func (iterator Iterator) Go() (items <-chan ChannelItem, done chan<- bool) {
+	itemsChannel := make(chan ChannelItem)
+	doneChannel := make(chan bool)
+	go iterator.IterateToChannel(itemsChannel, doneChannel)
+	return itemsChannel, doneChannel
+}
+
+// Iterates all items and sends them to the given channel.  Runs on the current
+// goroutine (call go iterator.IterateToChannel to set it up on a new goroutine).
+// This will close the items channel when done.  If the done channel is closed,
+// iteration will terminate.
+func (iterator Iterator) IterateToChannel(items chan<- ChannelItem, done <-chan bool) {
+	defer close(items)
+	err := iterator.EachWithError(func(result interface{}) error {
+		select {
+		case items <- ChannelItem{Value: result}:
+			return nil
+		case _, _ = <-done:
+			// If we are told we're done early, we finish quietly.
+			return FINISHED
+		}
+	})
+	if err != nil {
+		items <- ChannelItem{Error: err}
+	}
+}
+
+// Iterate over the channels from a Go(), calling a user-defined function for each value.
+// This function handles all anomalous conditions including errors, early
+// termination and safe cleanup of the goroutine and channels.
+func EachFromChannel(items <-chan ChannelItem, done chan<- bool, processor func(interface{}) error) error {
+	defer close(done) // if early return or panic happens, this will clean up the goroutine
+	for item := range items {
+		if item.Error != nil {
+			return item.Error
+		}
+		err := processor(item.Value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Perform the iteration in the background concurrently with the Each() statement.
+// Useful when the iterator or iteratee will be doing blocking work.
+//
+// The bufferSize parameter lets you set how far ahead the background goroutine can
+// get.
+//
+//   iterator.BackgroundEach(100, func(item interface{}) { ... })
+func (iterator Iterator) BackgroundEach(bufferSize int, processor func(interface{}) error) error {
+	itemsChannel := make(chan ChannelItem, bufferSize)
+	doneChannel := make(chan bool)
+	go iterator.IterateToChannel(itemsChannel, doneChannel)
+	return EachFromChannel(itemsChannel, doneChannel, processor)
+}
+
+// Iterate to a channel in the background.
+//
+//   for value := range iter.GoSimple(iterator) {
+//     ...
+//   }
+//
+// With this method, two undesirable things can happen:
+// - if the iteration stops early due to an error, you will not be able to handle
+//   it (the goroutine will log and panic, and the program will exit).
+// - if callers panic or exit early without retrieving all values from the channel,
+//   the goroutine is blocked forever and leaks.
+//
+// The Go() routine allows you to handle both of these issues, at a small cost to
+// caller complexity.  BackgroundEach() provides a simple way to use Go(), as
+// well.
+//
+// That said, if you can make guarantees about no panics or don't care, this
+// method can make calling code easier to read.
+func (iterator Iterator) GoSimple() (values <-chan interface{}) {
+	mainChannel := make(chan interface{})
+	go iterator.IterateToChannelSimple(mainChannel)
+	return mainChannel
+}
+
+// Iterates all items and sends them to the given channel.  Runs on the current
+// goroutine (call go iterator.IterateToChannelSimple() to set it up on a new goroutine).
+// This will close the values channel when done.  See warnings about GoSimple()
+// vs. Go() in the GoSimple() method.
+func (iterator Iterator) IterateToChannelSimple(values chan<- interface{}) {
+	defer close(values)
+	err := iterator.Each(func(item interface{}) {
+		values <- item
+	})
+	if err != nil {
+		log.Fatalf("Iterator returned an error in GoSimple: %v", err)
+	}
+}

--- a/vendor/github.com/jkeiser/iter/doc.go
+++ b/vendor/github.com/jkeiser/iter/doc.go
@@ -1,0 +1,125 @@
+/*
+Generic forward-only iterator that is safe and leak-free.
+
+This package is intended to support forward-only iteration in a variety of use
+cases while avoiding the normal errors and leaks that can happen with iterators
+in Go. It provides mechanisms for map/select filtering, background iteration
+through a goroutine, and error handling throughout.
+
+The type of the iterator is interface{}, so it can store anything, at the cost
+that you have to cast it back out when you use it. This package can be used as
+is, or used as an example for creating your own forward-only iterators of more
+specific types.
+
+  sum := 0
+  iterator.Each(func(item interface{}) {
+    sum = sum + item.(int)
+  })
+
+Motivation
+
+With the lack of generics and a builtin iterator pattern, iterators have been
+the topic of much discussion in Go. Here are the discussions that inspired this:
+
+http://ewencp.org/blog/golang-iterators/: Ewan Cheslack-Postava's
+discussion of the major iteration patterns. Herein we have chosen the closure
+pattern for iterator implementation, and given the choice of callback and
+channel patterns for iteration callers.
+
+http://blog.golang.org/pipelines: A March 2014 discussion of pipelines
+on the go blog presents some of the pitfalls of channel iteration, suggesting
+the "done" channel implementation to compensate.
+
+Creating Iterators
+
+Simple error- and cleanup-free iterators can be easily created:
+
+  // Create a simple iterator from a function
+  val := 1
+  iterator := iter.NewSimple(func() interface{} {
+    val = val * 2;
+    return val > 2000 ? val : nil // nil terminates iteration
+  })
+
+Typically you will create iterators in packages ("please iterate over this
+complicated thing").  You will often handle errors and have cleanup to do.
+iter supports both of these. You can create a fully-functional iterator thusly:
+
+  // Create a normal iterator parsing a file, close when done
+  func ParseStream(reader io.ReadCloser) iter.Iterator {
+    return iter.Iterator{
+      Next: func() (iterator{}, error) {
+        item, err := Parse()
+        if item == nil && err == nil {
+          return nil, iter.FINISHED
+        }
+        return item, err
+      },
+      Close: func() {
+        reader.Close()
+      }
+    }
+  }
+
+Iterating
+
+Callback iteration looks like this and handles any bookkeeping automatically:
+
+  // Iterate over all values
+  err := iterator.Each(func(item interface{}) {
+    fmt.Println(item)
+  })
+
+Sometimes you need to handle errors:
+
+  // Iterate over all values, terminating if processing has a problem
+  var files []*File
+  err := iterator.EachWithError(func(item interface{}) error {
+    file, err = os.Open(item.(string))
+    if err == nil {
+      files = append(files, file)
+    }
+    return err
+  })
+
+Raw iteration looks like this:
+
+  defer iterator.Close() // allow the iterator to clean itself up
+  item, err := iterator.Next()
+  for err == nil {
+    ... // do stuff with value
+    item, err = iterator.Next()
+  }
+  if err != iter.FINISHED {
+    ... // handle error
+  }
+
+Background goroutine iteration (using channels) deserves special mention:
+
+  // Produce the values in a goroutine, cleaning up safely afterwards.
+  // This allows background iteration to continue at its own pace while we
+  // perform blocking operations in the foreground.
+  var responses []http.Response
+  err := iterator.BackgroundEach(1000, func(item interface{}) error {
+    response, err := http.Get(item.(string))
+    if err == nil {
+      responses = append(list, response)
+    }
+    return err
+  })
+
+Utilities
+
+There are several useful functions provided to work with iterators:
+
+  // Square the ints
+  squaredIterator, err := iterator.Map(func(item interface{}) interface{} { item.int() * 2 })
+
+  // Select non-nil values
+  nonNilIterator, err := iterator.Select(func(item interface{}) bool) { item != nil })
+
+  // Produce a list
+  list, err := iterator.ToList()
+
+*/
+package iter

--- a/vendor/github.com/jkeiser/iter/iterator.go
+++ b/vendor/github.com/jkeiser/iter/iterator.go
@@ -1,0 +1,140 @@
+package iter
+
+import "errors"
+
+// Error returned from Iterator.Next() when iteration is done.
+var FINISHED = errors.New("FINISHED")
+
+// Iterator letting you specify just two functions defining iteration. All
+// helper functions utilize this.
+//
+// Iterator is designed to avoid common pitfalls and to allow common Go patterns:
+// - errors can be yielded all the way up the chain to the caller
+// - safe iteration in background channels
+// - iterators are nil-clean (you can send nil values through the iterator)
+// - allows for cleanup when iteration ends early
+type Iterator struct {
+	// Get the next value (or error).
+	// nil, iter.FINISHED indicates iteration is complete.
+	Next func() (interface{}, error)
+	// Close out resources in case iteration terminates early. Callers are *not*
+	// required to call this if iteration completes cleanly (but they may).
+	Close func()
+}
+
+// Use to create an iterator from a single closure.  retun nil to stop iteration.
+//
+//   iter.NewSimple(func() interface{} { return x*2 })
+func NewSimple(f func() interface{}) Iterator {
+	return Iterator{
+		Next: func() (interface{}, error) {
+			val := f()
+			if val == nil {
+				return nil, FINISHED
+			} else {
+				return f, nil
+			}
+		},
+		Close: func() {},
+	}
+}
+
+// Transform values in the input.
+//   iterator.Map(func(item interface{}) interface{} { item.(int) * 2 })
+func (iterator Iterator) Map(mapper func(interface{}) interface{}) Iterator {
+	return Iterator{
+		Next: func() (interface{}, error) {
+			item, err := iterator.Next()
+			if err != nil {
+				return nil, err
+			}
+			return mapper(item), nil
+		},
+		Close: func() { iterator.Close() },
+	}
+}
+
+// Filter values from the input.
+//   iterator.Select(func(item interface{}) bool { item.(int) > 10 })
+func (iterator Iterator) Select(selector func(interface{}) bool) Iterator {
+	return Iterator{
+		Next: func() (interface{}, error) {
+			for {
+				item, err := iterator.Next()
+				if err != nil {
+					return nil, err
+				}
+				if selector(item) {
+					return item, nil
+				}
+			}
+		},
+		Close: func() { iterator.Close() },
+	}
+}
+
+// Concatenate multiple iterators together in one.
+//   d := iter.Concat(a, b, c)
+func Concat(iterators ...Iterator) Iterator {
+	i := 0
+	return Iterator{
+		Next: func() (interface{}, error) {
+			if i >= len(iterators) {
+				return nil, FINISHED
+			}
+			item, err := iterators[i].Next()
+			if err == FINISHED {
+				i++
+				return nil, err
+			} else if err != nil {
+				i = len(iterators)
+				return nil, err
+			}
+			return item, nil
+		},
+		Close: func() {
+			// Close out remaining iterators
+			for ; i < len(iterators); i++ {
+				iterators[i].Close()
+			}
+		},
+	}
+}
+
+// Iterate over all values, calling a user-defined function for each one.
+//   iterator.Each(func(item interface{}) { fmt.Println(item) })
+func (iterator Iterator) Each(processor func(interface{})) error {
+	defer iterator.Close()
+	item, err := iterator.Next()
+	for err == nil {
+		processor(item)
+		item, err = iterator.Next()
+	}
+	return err
+}
+
+// Iterate over all values, calling a user-defined function for each one.
+// If an error is returned from the function, iteration terminates early
+// and the EachWithError function returns the error.
+//   iterator.EachWithError(func(item interface{}) error { return http.Get(item.(string)) })
+func (iterator Iterator) EachWithError(processor func(interface{}) error) error {
+	defer iterator.Close()
+	item, err := iterator.Next()
+	for err == nil {
+		err = processor(item)
+		if err == nil {
+			item, err = iterator.Next()
+		}
+	}
+	return err
+}
+
+// Convert the iteration directly to a slice.
+//   var list []interface{}
+//   list, err := iterator.ToSlice()
+func (iterator Iterator) ToSlice() (list []interface{}, err error) {
+	err = iterator.Each(func(item interface{}) {
+		list = append(list, item)
+	})
+	return list, err
+}

--- a/vendor/github.com/jochenvg/go-udev/.gitignore
+++ b/vendor/github.com/jochenvg/go-udev/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/jochenvg/go-udev/LICENSE
+++ b/vendor/github.com/jochenvg/go-udev/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/jochenvg/go-udev/README.md
+++ b/vendor/github.com/jochenvg/go-udev/README.md
@@ -1,0 +1,6 @@
+# go-udev
+Go bindings for libudev
+
+## Documentation
+Documentation is on Godoc.
+[![GoDoc](https://godoc.org/github.com/jochenvg/go-udev?status.svg)](https://godoc.org/github.com/jochenvg/go-udev)

--- a/vendor/github.com/jochenvg/go-udev/device.go
+++ b/vendor/github.com/jochenvg/go-udev/device.go
@@ -1,0 +1,353 @@
+// +build linux,cgo
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+*/
+import "C"
+import "errors"
+import "github.com/jkeiser/iter"
+
+// Device wraps a libudev device object
+type Device struct {
+	ptr *C.struct_udev_device
+	u   *Udev
+}
+
+// Lock the udev context
+func (d *Device) lock() {
+	d.u.m.Lock()
+}
+
+// Unlock the udev context
+func (d *Device) unlock() {
+	d.u.m.Unlock()
+}
+
+func deviceUnref(d *Device) {
+	C.udev_device_unref(d.ptr)
+}
+
+// Parent returns the parent Device, or nil if the receiver has no parent Device
+func (d *Device) Parent() *Device {
+	d.lock()
+	defer d.unlock()
+	ptr := C.udev_device_get_parent(d.ptr)
+	if ptr != nil {
+		C.udev_device_ref(ptr)
+	}
+	return d.u.newDevice(ptr)
+}
+
+// ParentWithSubsystemDevtype returns the parent Device with the given subsystem and devtype,
+// or nil if the receiver has no such parent device
+func (d *Device) ParentWithSubsystemDevtype(subsystem, devtype string) *Device {
+	d.lock()
+	defer d.unlock()
+	ss, dt := C.CString(subsystem), C.CString(devtype)
+	defer freeCharPtr(ss)
+	defer freeCharPtr(dt)
+	ptr := C.udev_device_get_parent_with_subsystem_devtype(d.ptr, ss, dt)
+	if ptr != nil {
+		C.udev_device_ref(ptr)
+	}
+	return d.u.newDevice(ptr)
+}
+
+// Devpath returns the kernel devpath value of the udev device.
+// The path does not contain the sys mount point, and starts with a '/'.
+func (d *Device) Devpath() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_devpath(d.ptr))
+}
+
+// Subsystem returns the subsystem string of the udev device.
+// The string does not contain any "/".
+func (d *Device) Subsystem() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_subsystem(d.ptr))
+}
+
+// Devtype returns the devtype string of the udev device.
+func (d *Device) Devtype() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_devtype(d.ptr))
+}
+
+// Sysname returns the sysname of the udev device (e.g. ttyS3, sda1...).
+func (d *Device) Sysname() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_sysname(d.ptr))
+}
+
+// Syspath returns the sys path of the udev device.
+// The path is an absolute path and starts with the sys mount point.
+func (d *Device) Syspath() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_syspath(d.ptr))
+}
+
+// Sysnum returns the trailing number of of the device name
+func (d *Device) Sysnum() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_sysnum(d.ptr))
+}
+
+// Devnode returns the device node file name belonging to the udev device.
+// The path is an absolute path, and starts with the device directory.
+func (d *Device) Devnode() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_devnode(d.ptr))
+}
+
+// IsInitialized checks if udev has already handled the device and has set up
+// device node permissions and context, or has renamed a network device.
+//
+// This is only implemented for devices with a device node or network interfaces.
+// All other devices return 1 here.
+func (d *Device) IsInitialized() bool {
+	d.lock()
+	defer d.unlock()
+	return C.udev_device_get_is_initialized(d.ptr) != 0
+}
+
+// Devlinks retrieves the map of device links pointing to the device file of the udev device.
+// The path is an absolute path, and starts with the device directory.
+func (d *Device) Devlinks() (r map[string]struct{}) {
+	d.lock()
+	defer d.unlock()
+	r = make(map[string]struct{})
+	for l := C.udev_device_get_devlinks_list_entry(d.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+		r[C.GoString(C.udev_list_entry_get_name(l))] = struct{}{}
+	}
+	return
+}
+
+// DevlinkIterator returns an Iterator over the device links pointing to the device file of the udev device.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to string.
+func (d *Device) DevlinkIterator() iter.Iterator {
+	d.lock()
+	defer d.unlock()
+	l := C.udev_device_get_devlinks_list_entry(d.ptr)
+	return iter.Iterator{
+		Next: func() (item interface{}, err error) {
+			d.lock()
+			defer d.unlock()
+			if l != nil {
+				item = C.GoString(C.udev_list_entry_get_name(l))
+				l = C.udev_list_entry_get_next(l)
+			} else {
+				err = iter.FINISHED
+			}
+			return
+		},
+		Close: func() {
+		},
+	}
+}
+
+// Properties retrieves a map[string]string of key/value device properties of the udev device.
+func (d *Device) Properties() (r map[string]string) {
+	d.lock()
+	defer d.unlock()
+	r = make(map[string]string)
+	for l := C.udev_device_get_properties_list_entry(d.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+		r[C.GoString(C.udev_list_entry_get_name(l))] = C.GoString(C.udev_list_entry_get_value(l))
+	}
+	return
+}
+
+// PropertyIterator returns an Iterator over the key/value device properties of the udev device.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to []string,
+// which will have length 2 and represent a Key/Value pair.
+func (d *Device) PropertyIterator() iter.Iterator {
+	d.lock()
+	defer d.unlock()
+	l := C.udev_device_get_properties_list_entry(d.ptr)
+	return iter.Iterator{
+		Next: func() (item interface{}, err error) {
+			d.lock()
+			defer d.unlock()
+			if l != nil {
+				item = []string{
+					C.GoString(C.udev_list_entry_get_name(l)),
+					C.GoString(C.udev_list_entry_get_value(l)),
+				}
+				l = C.udev_list_entry_get_next(l)
+			} else {
+				err = iter.FINISHED
+			}
+			return
+		},
+		Close: func() {
+		},
+	}
+}
+
+// Tags retrieves the Set of tags attached to the udev device.
+func (d *Device) Tags() (r map[string]struct{}) {
+	d.lock()
+	defer d.unlock()
+	r = make(map[string]struct{})
+	for l := C.udev_device_get_tags_list_entry(d.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+		r[C.GoString(C.udev_list_entry_get_name(l))] = struct{}{}
+	}
+	return
+}
+
+// TagIterator returns an Iterator over the tags attached to the udev device.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to string.
+func (d *Device) TagIterator() iter.Iterator {
+	d.lock()
+	defer d.unlock()
+	l := C.udev_device_get_tags_list_entry(d.ptr)
+	return iter.Iterator{
+		Next: func() (item interface{}, err error) {
+			d.lock()
+			defer d.unlock()
+			if l != nil {
+				item = C.GoString(C.udev_list_entry_get_name(l))
+				l = C.udev_list_entry_get_next(l)
+			} else {
+				err = iter.FINISHED
+			}
+			return
+		},
+		Close: func() {
+		},
+	}
+}
+
+// Sysattrs returns a Set with the systems attributes of the udev device.
+func (d *Device) Sysattrs() (r map[string]struct{}) {
+	d.lock()
+	defer d.unlock()
+	r = make(map[string]struct{})
+	for l := C.udev_device_get_sysattr_list_entry(d.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+		r[C.GoString(C.udev_list_entry_get_name(l))] = struct{}{}
+	}
+	return
+}
+
+// SysattrIterator returns an Iterator over the systems attributes of the udev device.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to string.
+func (d *Device) SysattrIterator() iter.Iterator {
+	d.lock()
+	defer d.unlock()
+	l := C.udev_device_get_sysattr_list_entry(d.ptr)
+	return iter.Iterator{
+		Next: func() (item interface{}, err error) {
+			d.lock()
+			defer d.unlock()
+			if l != nil {
+				item = C.GoString(C.udev_list_entry_get_name(l))
+				l = C.udev_list_entry_get_next(l)
+			} else {
+				err = iter.FINISHED
+			}
+			return
+		},
+		Close: func() {
+		},
+	}
+}
+
+// PropertyValue retrieves the value of a device property
+func (d *Device) PropertyValue(key string) string {
+	d.lock()
+	defer d.unlock()
+	k := C.CString(key)
+	defer freeCharPtr(k)
+	return C.GoString(C.udev_device_get_property_value(d.ptr, k))
+}
+
+// Driver returns the driver for the receiver
+func (d *Device) Driver() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_driver(d.ptr))
+}
+
+// Devnum returns the device major/minor number.
+func (d *Device) Devnum() Devnum {
+	d.lock()
+	defer d.unlock()
+	return Devnum{C.udev_device_get_devnum(d.ptr)}
+}
+
+// Action returns the action for the event.
+// This is only valid if the device was received through a monitor.
+// Devices read from sys do not have an action string.
+// Usual actions are: add, remove, change, online, offline.
+func (d *Device) Action() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_action(d.ptr))
+}
+
+// Seqnum returns the sequence number of the event.
+// This is only valid if the device was received through a monitor.
+// Devices read from sys do not have a sequence number.
+func (d *Device) Seqnum() uint64 {
+	d.lock()
+	defer d.unlock()
+	return uint64(C.udev_device_get_seqnum(d.ptr))
+}
+
+// UsecSinceInitialized returns the number of microseconds passed since udev set up the device for the first time.
+// This is only implemented for devices with need to store properties in the udev database.
+// All other devices return 0 here.
+func (d *Device) UsecSinceInitialized() uint64 {
+	d.lock()
+	defer d.unlock()
+	return uint64(C.udev_device_get_usec_since_initialized(d.ptr))
+}
+
+// SysattrValue retrieves the content of a sys attribute file, and returns an empty string if there is no sys attribute value.
+// The retrieved value is cached in the device.
+// Repeated calls will return the same value and not open the attribute again.
+func (d *Device) SysattrValue(sysattr string) string {
+	d.lock()
+	defer d.unlock()
+	s := C.CString(sysattr)
+	defer freeCharPtr(s)
+	return C.GoString(C.udev_device_get_sysattr_value(d.ptr, s))
+}
+
+// SetSysattrValue sets the content of a sys attribute file, and returns an error if this fails.
+func (d *Device) SetSysattrValue(sysattr, value string) (err error) {
+	d.lock()
+	defer d.unlock()
+	sa, val := C.CString(sysattr), C.CString(value)
+	defer freeCharPtr(sa)
+	defer freeCharPtr(val)
+	if C.udev_device_set_sysattr_value(d.ptr, sa, val) < 0 {
+		err = errors.New("udev: udev_device_set_sysattr_value failed")
+	}
+	return
+}
+
+// HasTag checks if the udev device has the tag specified
+func (d *Device) HasTag(tag string) bool {
+	d.lock()
+	defer d.unlock()
+	t := C.CString(tag)
+	defer freeCharPtr(t)
+	return C.udev_device_has_tag(d.ptr, t) != 0
+}

--- a/vendor/github.com/jochenvg/go-udev/devnum.go
+++ b/vendor/github.com/jochenvg/go-udev/devnum.go
@@ -1,0 +1,42 @@
+// +build linux,cgo
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+
+  int go_udev_major(dev_t d) {
+    return MAJOR(d);
+  }
+  int go_udev_minor(dev_t d) {
+    return MINOR(d);
+  }
+  dev_t go_udev_mkdev(int major, int minor) {
+    return MKDEV(major, minor);
+  }
+*/
+import "C"
+
+// Devnum is a kernel device number
+type Devnum struct {
+	d C.dev_t
+}
+
+// Major returns the major part of a Devnum
+func (d Devnum) Major() int {
+	return int(C.go_udev_major(d.d))
+}
+
+// Minor returns the minor part of a Devnum
+func (d Devnum) Minor() int {
+	return int(C.go_udev_minor(d.d))
+}
+
+// MkDev creates a Devnum from a major and minor number
+func MkDev(major, minor int) Devnum {
+	return Devnum{C.go_udev_mkdev((C.int)(major), (C.int)(minor))}
+}

--- a/vendor/github.com/jochenvg/go-udev/enumerate.go
+++ b/vendor/github.com/jochenvg/go-udev/enumerate.go
@@ -1,0 +1,296 @@
+// +build linux,cgo
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+*/
+import "C"
+
+import (
+	"errors"
+
+	"github.com/jkeiser/iter"
+)
+
+// Enumerate is an opaque struct wrapping a udev enumerate object.
+type Enumerate struct {
+	ptr *C.struct_udev_enumerate
+	u   *Udev
+}
+
+// Lock the udev context
+func (e *Enumerate) lock() {
+	e.u.m.Lock()
+}
+
+// Unlock the udev context
+func (e *Enumerate) unlock() {
+	e.u.m.Unlock()
+}
+
+// Unref the Enumerate object
+func enumerateUnref(e *Enumerate) {
+	C.udev_enumerate_unref(e.ptr)
+}
+
+// AddMatchSubsystem adds a filter for a subsystem of the device to include in the list.
+func (e *Enumerate) AddMatchSubsystem(subsystem string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s := C.CString(subsystem)
+	defer freeCharPtr(s)
+	if C.udev_enumerate_add_match_subsystem(e.ptr, s) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_subsystem failed")
+	}
+	return
+}
+
+// AddNomatchSubsystem adds a filter for a subsystem of the device to exclude from the list.
+func (e *Enumerate) AddNomatchSubsystem(subsystem string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s := C.CString(subsystem)
+	defer freeCharPtr(s)
+	if C.udev_enumerate_add_nomatch_subsystem(e.ptr, s) != 0 {
+		err = errors.New("udev: udev_enumerate_add_nomatch_subsystem failed")
+	}
+	return
+}
+
+// AddMatchSysattr adds a filter for a sys attribute at the device to include in the list.
+func (e *Enumerate) AddMatchSysattr(sysattr, value string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s, v := C.CString(sysattr), C.CString(value)
+	defer freeCharPtr(s)
+	defer freeCharPtr(v)
+	if C.udev_enumerate_add_match_sysattr(e.ptr, s, v) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_sysattr failed")
+	}
+	return
+}
+
+// AddNomatchSysattr adds a filter for a sys attribute at the device to exclude from the list.
+func (e *Enumerate) AddNomatchSysattr(sysattr, value string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s, v := C.CString(sysattr), C.CString(value)
+	defer freeCharPtr(s)
+	defer freeCharPtr(v)
+	if C.udev_enumerate_add_nomatch_sysattr(e.ptr, s, v) != 0 {
+		err = errors.New("udev: udev_enumerate_add_nomatch_sysattr failed")
+	}
+	return
+}
+
+// AddMatchProperty adds a filter for a property of the device to include in the list.
+func (e *Enumerate) AddMatchProperty(property, value string) (err error) {
+	e.lock()
+	defer e.unlock()
+	p, v := C.CString(property), C.CString(value)
+	defer freeCharPtr(p)
+	defer freeCharPtr(v)
+	if C.udev_enumerate_add_match_property(e.ptr, p, v) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_property failed")
+	}
+	return
+}
+
+// AddMatchSysname adds a filter for the name of the device to include in the list.
+func (e *Enumerate) AddMatchSysname(sysname string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s := C.CString(sysname)
+	defer freeCharPtr(s)
+	if C.udev_enumerate_add_match_sysname(e.ptr, s) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_sysname failed")
+	}
+	return
+}
+
+// AddMatchTag adds a filter for a tag of the device to include in the list.
+func (e *Enumerate) AddMatchTag(tag string) (err error) {
+	e.lock()
+	defer e.unlock()
+	t := C.CString(tag)
+	defer freeCharPtr(t)
+	if C.udev_enumerate_add_match_tag(e.ptr, t) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_tag failed")
+	}
+	return
+}
+
+// AddMatchParent adds a filter for a parent Device to include in the list.
+func (e *Enumerate) AddMatchParent(parent *Device) (err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_add_match_parent(e.ptr, parent.ptr) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_parent failed")
+	}
+	return
+}
+
+// AddMatchIsInitialized adds a filter matching only devices which udev has set up already.
+// This makes sure, that the device node permissions and context are properly set and that network devices are fully renamed.
+// Usually, devices which are found in the kernel but not already handled by udev, have still pending events.
+// Services should subscribe to monitor events and wait for these devices to become ready, instead of using uninitialized devices.
+// For now, this will not affect devices which do not have a device node and are not network interfaces.
+func (e *Enumerate) AddMatchIsInitialized() (err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_add_match_is_initialized(e.ptr) != 0 {
+		err = errors.New("udev: udev_enumerate_add_match_is_initialized failed")
+	}
+	return
+}
+
+// AddSyspath adds a device to the list of enumerated devices, to retrieve it back sorted in dependency order.
+func (e *Enumerate) AddSyspath(syspath string) (err error) {
+	e.lock()
+	defer e.unlock()
+	s := C.CString(syspath)
+	defer freeCharPtr(s)
+	if C.udev_enumerate_add_syspath(e.ptr, s) != 0 {
+		err = errors.New("udev: udev_enumerate_add_syspath failed")
+	}
+	return
+}
+
+// DeviceSyspaths retrieves a list of device syspaths matching the filter, sorted in dependency order.
+func (e *Enumerate) DeviceSyspaths() (s []string, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_devices(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_devices failed")
+	} else {
+		s = make([]string, 0)
+		for l := C.udev_enumerate_get_list_entry(e.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+			s = append(s, C.GoString(C.udev_list_entry_get_name(l)))
+		}
+	}
+	return
+}
+
+// DeviceSyspathIterator returns an Iterator over the device syspaths matching the filter, sorted in dependency order.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to string.
+func (e *Enumerate) DeviceSyspathIterator() (it iter.Iterator, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_devices(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_devices failed")
+	} else {
+		l := C.udev_enumerate_get_list_entry(e.ptr)
+		it = iter.Iterator{
+			Next: func() (item interface{}, err error) {
+				e.lock()
+				defer e.unlock()
+				if l != nil {
+					item = C.GoString(C.udev_list_entry_get_name(l))
+					l = C.udev_list_entry_get_next(l)
+				} else {
+					err = iter.FINISHED
+				}
+				return
+			},
+			Close: func() {
+			},
+		}
+	}
+	return
+}
+
+// SubsystemSyspaths retrieves a list of subsystem syspaths matching the filter, sorted in dependency order.
+func (e *Enumerate) SubsystemSyspaths() (s []string, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_subsystems(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_subsystems failed")
+	} else {
+		s = make([]string, 0)
+		for l := C.udev_enumerate_get_list_entry(e.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+			s = append(s, C.GoString(C.udev_list_entry_get_name(l)))
+		}
+	}
+	return
+}
+
+// DeviceSubsystemIterator returns an Iterator over the subsystem syspaths matching the filter, sorted in dependency order.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to string.
+func (e *Enumerate) DeviceSubsystemIterator() (it iter.Iterator, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_subsystems(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_devices failed")
+	} else {
+		l := C.udev_enumerate_get_list_entry(e.ptr)
+		it = iter.Iterator{
+			Next: func() (item interface{}, err error) {
+				e.lock()
+				defer e.unlock()
+				if l != nil {
+					item = C.GoString(C.udev_list_entry_get_name(l))
+					l = C.udev_list_entry_get_next(l)
+				} else {
+					err = iter.FINISHED
+				}
+				return
+			},
+			Close: func() {
+			},
+		}
+	}
+	return
+}
+
+// Devices retrieves a list of Devices matching the filter, sorted in dependency order.
+func (e *Enumerate) Devices() (m []*Device, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_devices(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_devices failed")
+	} else {
+		m = make([]*Device, 0)
+		for l := C.udev_enumerate_get_list_entry(e.ptr); l != nil; l = C.udev_list_entry_get_next(l) {
+			s := C.udev_list_entry_get_name(l)
+			m = append(m, e.u.newDevice(C.udev_device_new_from_syspath(e.u.ptr, s)))
+		}
+	}
+	return
+}
+
+// DeviceIterator returns an Iterator over the Devices matching the filter, sorted in dependency order.
+// The Iterator is using the github.com/jkeiser/iter package.
+// Values are returned as an interface{} and should be cast to *Device.
+func (e *Enumerate) DeviceIterator() (it iter.Iterator, err error) {
+	e.lock()
+	defer e.unlock()
+	if C.udev_enumerate_scan_devices(e.ptr) < 0 {
+		err = errors.New("udev: udev_enumerate_scan_devices failed")
+	} else {
+		l := C.udev_enumerate_get_list_entry(e.ptr)
+		it = iter.Iterator{
+			Next: func() (item interface{}, err error) {
+				e.lock()
+				defer e.unlock()
+				if l != nil {
+					s := C.udev_list_entry_get_name(l)
+					item = e.u.newDevice(C.udev_device_new_from_syspath(e.u.ptr, s))
+					l = C.udev_list_entry_get_next(l)
+				} else {
+					err = iter.FINISHED
+				}
+				return
+			},
+			Close: func() {
+			},
+		}
+	}
+	return
+}

--- a/vendor/github.com/jochenvg/go-udev/monitor.go
+++ b/vendor/github.com/jochenvg/go-udev/monitor.go
@@ -1,0 +1,208 @@
+// +build linux,cgo
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+*/
+import "C"
+import (
+	"context"
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Monitor is an opaque object handling an event source
+type Monitor struct {
+	ptr *C.struct_udev_monitor
+	u   *Udev
+}
+
+const (
+	maxEpollEvents = 32
+	epollTimeout   = 1000
+)
+
+// Lock the udev context
+func (m *Monitor) lock() {
+	m.u.m.Lock()
+}
+
+// Unlock the udev context
+func (m *Monitor) unlock() {
+	m.u.m.Unlock()
+}
+
+// Unref the monitor
+func monitorUnref(m *Monitor) {
+	C.udev_monitor_unref(m.ptr)
+}
+
+// SetReceiveBufferSize sets the size of the kernel socket buffer.
+// This call needs the appropriate privileges to succeed.
+func (m *Monitor) SetReceiveBufferSize(size int) (err error) {
+	m.lock()
+	defer m.unlock()
+	if C.udev_monitor_set_receive_buffer_size(m.ptr, (C.int)(size)) != 0 {
+		err = errors.New("udev: udev_monitor_set_receive_buffer_size failed")
+	}
+	return
+}
+
+// FilterAddMatchSubsystem adds a filter matching the device against a subsystem.
+// This filter is efficiently executed inside the kernel, and libudev subscribers will usually not be woken up for devices which do not match.
+// The filter must be installed before the monitor is switched to listening mode with the DeviceChan function.
+func (m *Monitor) FilterAddMatchSubsystem(subsystem string) (err error) {
+	m.lock()
+	defer m.unlock()
+	s := C.CString(subsystem)
+	defer freeCharPtr(s)
+	if C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, s, nil) != 0 {
+		err = errors.New("udev: udev_monitor_filter_add_match_subsystem_devtype failed")
+	}
+	return
+}
+
+// FilterAddMatchSubsystemDevtype adds a filter matching the device against a subsystem and device type.
+// This filter is efficiently executed inside the kernel, and libudev subscribers will usually not be woken up for devices which do not match.
+// The filter must be installed before the monitor is switched to listening mode with the DeviceChan function.
+func (m *Monitor) FilterAddMatchSubsystemDevtype(subsystem, devtype string) (err error) {
+	m.lock()
+	defer m.unlock()
+	s, d := C.CString(subsystem), C.CString(devtype)
+	defer freeCharPtr(s)
+	defer freeCharPtr(d)
+	if C.udev_monitor_filter_add_match_subsystem_devtype(m.ptr, s, d) != 0 {
+		err = errors.New("udev: udev_monitor_filter_add_match_subsystem_devtype failed")
+	}
+	return
+}
+
+// FilterAddMatchTag adds a filter matching the device against a tag.
+// This filter is efficiently executed inside the kernel, and libudev subscribers will usually not be woken up for devices which do not match.
+// The filter must be installed before the monitor is switched to listening mode.
+func (m *Monitor) FilterAddMatchTag(tag string) (err error) {
+	m.lock()
+	defer m.unlock()
+	t := C.CString(tag)
+	defer freeCharPtr(t)
+	if C.udev_monitor_filter_add_match_tag(m.ptr, t) != 0 {
+		err = errors.New("udev: udev_monitor_filter_add_match_tag failed")
+	}
+	return
+}
+
+// FilterUpdate updates the installed socket filter.
+// This is only needed, if the filter was removed or changed.
+func (m *Monitor) FilterUpdate() (err error) {
+	m.lock()
+	defer m.unlock()
+	if C.udev_monitor_filter_update(m.ptr) != 0 {
+		err = errors.New("udev: udev_monitor_filter_update failed")
+	}
+	return
+}
+
+// FilterRemove removes all filter from the Monitor.
+func (m *Monitor) FilterRemove() (err error) {
+	m.lock()
+	defer m.unlock()
+	if C.udev_monitor_filter_remove(m.ptr) != 0 {
+		err = errors.New("udev: udev_monitor_filter_remove failed")
+	}
+	return
+}
+
+// receiveDevice is a helper function receiving a device while the Mutex is locked
+func (m *Monitor) receiveDevice() (d *Device) {
+	m.lock()
+	defer m.unlock()
+	return m.u.newDevice(C.udev_monitor_receive_device(m.ptr))
+}
+
+// DeviceChan binds the udev_monitor socket to the event source and spawns a
+// goroutine. The goroutine efficiently waits on the monitor socket using epoll.
+// Data is received from the udev monitor socket and a new Device is created
+// with the data received. Pointers to the device are sent on the returned
+// channel. The function takes a context as argument, which when done will stop
+// the goroutine and close the device channel. Only socket connections with
+// uid=0 are accepted.
+func (m *Monitor) DeviceChan(ctx context.Context) (<-chan *Device, error) {
+
+	var event unix.EpollEvent
+	var events [maxEpollEvents]unix.EpollEvent
+
+	// Lock the context
+	m.lock()
+	defer m.unlock()
+
+	// Enable receiving
+	if C.udev_monitor_enable_receiving(m.ptr) != 0 {
+		return nil, errors.New("udev: udev_monitor_enable_receiving failed")
+	}
+
+	// Set the fd to non-blocking
+	fd := C.udev_monitor_get_fd(m.ptr)
+	if e := unix.SetNonblock(int(fd), true); e != nil {
+		return nil, errors.New("udev: unix.SetNonblock failed")
+	}
+
+	// Create an epoll fd
+	epfd, e := unix.EpollCreate1(0)
+	if e != nil {
+		return nil, errors.New("udev: unix.EpollCreate1 failed")
+	}
+
+	// Add the fd to the epoll fd
+	event.Events = unix.EPOLLIN | unix.EPOLLET
+	event.Fd = int32(fd)
+	if e = unix.EpollCtl(epfd, unix.EPOLL_CTL_ADD, int(fd), &event); e != nil {
+		return nil, errors.New("udev: unix.EpollCtl failed")
+	}
+
+	// Create the channel
+	ch := make(chan *Device)
+
+	// Create goroutine to epoll the fd
+	go func(fd int32) {
+		// Close the epoll fd when goroutine exits
+		defer unix.Close(epfd)
+		// Close the channel when goroutine exits
+		defer close(ch)
+		// Loop forever
+		for {
+			// Poll the file descriptor
+			nevents, e := unix.EpollWait(epfd, events[:], epollTimeout)
+			// Ignore the EINTR error case since cancelation is performed with the
+			// context's Done() channel
+			errno, isErrno := e.(syscall.Errno)
+			if (e != nil && !isErrno) || (isErrno && errno != syscall.EINTR) {
+				return
+			}
+			// Check for done signal
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			// Process events
+			for ev := 0; ev < nevents; ev++ {
+				if events[ev].Fd == fd {
+					if (events[ev].Events & unix.EPOLLIN) != 0 {
+						for d := m.receiveDevice(); d != nil; d = m.receiveDevice() {
+							ch <- d
+						}
+					}
+				}
+			}
+		}
+	}(int32(fd))
+
+	return ch, nil
+}

--- a/vendor/github.com/jochenvg/go-udev/udev.go
+++ b/vendor/github.com/jochenvg/go-udev/udev.go
@@ -1,0 +1,168 @@
+// +build linux,cgo
+
+// Package udev provides a cgo wrapper around the libudev C library
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+*/
+import "C"
+import (
+	"runtime"
+	"sync"
+)
+
+// Udev is an opaque struct wraping a udev library context
+type Udev struct {
+	// A pointer to the C struct udev context
+	ptr *C.struct_udev
+	// Mutex for thread sync as libudev is not thread safe when called with the same struct udev
+	m    sync.Mutex
+	once sync.Once
+}
+
+func udevUnref(u *Udev) {
+	C.udev_unref(u.ptr)
+}
+
+// Lock locks a udev context
+func (u *Udev) lock() {
+	u.once.Do(func() {
+		u.ptr = C.udev_new()
+		runtime.SetFinalizer(u, udevUnref)
+	})
+	u.m.Lock()
+}
+
+// Unlock unlocks a udev context
+func (u *Udev) unlock() {
+	u.m.Unlock()
+}
+
+// newDevice is a private helper function and returns a pointer to a new device.
+// The device is also added t the devices map in the udev context.
+// The agrument ptr is a pointer to the underlying C udev_device structure.
+// The function returns nil if the pointer passed is NULL.
+func (u *Udev) newDevice(ptr *C.struct_udev_device) (d *Device) {
+	// If passed a NULL pointer, return nil
+	if ptr == nil {
+		return nil
+	}
+	// Create a new device object
+	d = &Device{
+		ptr: ptr,
+		u:   u,
+	}
+	runtime.SetFinalizer(d, deviceUnref)
+	// Return the device object
+	return
+}
+
+// newMonitor is a private helper function and returns a pointer to a new monitor.
+// The monitor is also added t the monitors map in the udev context.
+// The agrument ptr is a pointer to the underlying C udev_monitor structure.
+// The function returns nil if the pointer passed is NULL.
+func (u *Udev) newMonitor(ptr *C.struct_udev_monitor) (m *Monitor) {
+	// If passed a NULL pointer, return nil
+	if ptr == nil {
+		return nil
+	}
+	// Create a new device object
+	m = &Monitor{
+		ptr: ptr,
+		u:   u,
+	}
+	runtime.SetFinalizer(m, monitorUnref)
+	// Return the device object
+	return
+}
+
+func (u *Udev) newEnumerate(ptr *C.struct_udev_enumerate) (e *Enumerate) {
+	// If passed a NULL pointer, return nil
+	if ptr == nil {
+		return nil
+	}
+	// Create a new device object
+	e = &Enumerate{
+		ptr: ptr,
+		u:   u,
+	}
+	runtime.SetFinalizer(e, enumerateUnref)
+	// Return the device object
+	return
+}
+
+// NewDeviceFromSyspath returns a pointer to a new device identified by its syspath, and nil on error
+// The device is identified by the syspath argument
+func (u *Udev) NewDeviceFromSyspath(syspath string) *Device {
+	// Lock the udev context
+	u.lock()
+	defer u.unlock()
+	// Convert Go strings to C strings for passing
+	s := C.CString(syspath)
+	defer freeCharPtr(s)
+	// Return a new device
+	return u.newDevice(C.udev_device_new_from_syspath(u.ptr, s))
+}
+
+// NewDeviceFromDevnum returns a pointer to a new device identified by its Devnum, and nil on error
+// deviceType is 'c' for a character device and 'b' for a block device
+func (u *Udev) NewDeviceFromDevnum(deviceType uint8, n Devnum) *Device {
+	u.lock()
+	defer u.unlock()
+	return u.newDevice(C.udev_device_new_from_devnum(u.ptr, C.char(deviceType), n.d))
+}
+
+// NewDeviceFromSubsystemSysname returns a pointer to a new device identified by its subystem and sysname, and nil on error
+func (u *Udev) NewDeviceFromSubsystemSysname(subsystem, sysname string) *Device {
+	u.lock()
+	defer u.unlock()
+	ss, sn := C.CString(subsystem), C.CString(sysname)
+	defer freeCharPtr(ss)
+	defer freeCharPtr(sn)
+	return u.newDevice(C.udev_device_new_from_subsystem_sysname(u.ptr, ss, sn))
+}
+
+// NewDeviceFromDeviceID returns a pointer to a new device identified by its device id, and nil on error
+func (u *Udev) NewDeviceFromDeviceID(id string) *Device {
+	u.lock()
+	defer u.unlock()
+	i := C.CString(id)
+	defer freeCharPtr(i)
+	return u.newDevice(C.udev_device_new_from_device_id(u.ptr, i))
+}
+
+// NewEnumerate returns a pointer to a new enumerate, and nil on error
+func (u *Udev) NewEnumerate() *Enumerate {
+	u.lock()
+	defer u.unlock()
+	return u.newEnumerate(C.udev_enumerate_new(u.ptr))
+}
+
+// NewMonitorFromNetlink returns a pointer to a new monitor listening to a NetLink socket, and nil on error
+// The name argument is either "kernel" or "udev".
+// When passing "kernel" the events are received before they are processed by udev.
+// When passing "udev" the events are received after udev has processed the events and created device nodes.
+// In most cases you will want to use "udev".
+func (u *Udev) NewMonitorFromNetlink(name string) *Monitor {
+	u.lock()
+	defer u.unlock()
+	n := C.CString(name)
+	defer freeCharPtr(n)
+	return u.newMonitor(C.udev_monitor_new_from_netlink(u.ptr, n))
+}
+
+/*
+// NewMonitorFromSocket returns a pointer to a new monitor listening to the specified socket, and nil on error
+func (u *Udev) NewMonitorFromSocket(socketPath string) *Monitor {
+	u.lock()
+	defer u.unlock()
+	s := C.CString(socketPath)
+	defer freeCharPtr(s)
+	return u.newMonitor(C.udev_monitor_new_from_socket(u.ptr, s))
+}
+*/

--- a/vendor/github.com/jochenvg/go-udev/util.go
+++ b/vendor/github.com/jochenvg/go-udev/util.go
@@ -1,0 +1,18 @@
+// +build linux,cgo
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+  #include <linux/types.h>
+  #include <stdlib.h>
+	#include <linux/kdev_t.h>
+*/
+import "C"
+
+import "unsafe"
+
+func freeCharPtr(s *C.char) {
+	C.free(unsafe.Pointer(s))
+}


### PR DESCRIPTION
## Description
Use `github.com/jochenvg/go-udev` instead of `github.com/gravitational/go-udev`. The go-udev package has been updated since we created a fork of the repo. 

Preemption implementation was changed in [Go 1.14](https://go.dev/doc/go1.14)

> A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases. This means that programs that use packages like [syscall](https://go.dev/pkg/syscall/) or [golang.org/x/sys/unix](https://godoc.org/golang.org/x/sys/unix) will see more slow system calls fail with EINTR errors. Those programs will have to handle those errors in some way, most likely looping to try the system call again. For more information about this see [man 7 signal](http://man7.org/linux/man-pages/man7/signal.7.html) for Linux systems or similar documentation for other systems.

The latest commit contains https://github.com/jochenvg/go-udev/pull/4. 

> If the program that uses go-udev receives an interruption (SIGINT), go-udev stops monitoring and closes the channel. But this should only be the case when gracefully closed by done. Checking and continuing for EINTR would ensure that monitoring continues without stopping even if the source program receives any signal (usually when EINTR is seen).



I think Go1.14 is when the bug would have been introduced into Planet and the linked `go-udev` PR is the fix.