### PR TITLE
Prepare the planet repo for archive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,3 @@
 # Contributing
 
-Planet is an open source project.
-
-It is the work of tens of contributors. We appreciate your help!
-
-We follow a [code of conduct](./CODE_OF_CONDUCT.md).
-
-## Filing an Issue
-
-Security issues should be reported directly to security@goteleport.com.
-
-Planet uses [Gravity's issue tracker]((https://github.com/gravitational/gravity/issues).
-
-If you are unsure if you've found a bug, search the tracker first.
-
-Once you know you have a issue, fill out all sections of the
-one of the templates at https://github.com/gravitational/gravity/issues/new/choose.
-
-Gravity contributors will triage the issue.
-
-## Contributing A Patch
-
-If you're working on an existing issue, respond to the issue and express
-interest in working on it. This helps other people know that the issue is
-active, and hopefully prevents duplicated efforts.
-
-If you want to work on a new idea of relatively small scope:
-
-1. Submit an issue describing the proposed change and the implementation.
-2. The repo owners will respond to your issue promptly.
-3. Write your code, test your changes and _communicate_ with us as you're
-moving forward.
-4. Submit a pull request from your fork.
-
+Planet is not currently accepting contributions.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Planet
 
+> **Warning**
+> Planet was archived 2023-07-01.
+>
+> Please see the [Gravity](https://github.com/gravitational/gravity) README.md for more information.
+
 Planet is a containerized [Kubernetes](https://kubernetes.io/) environment. It is a self-containerizing Debian image with
 Kubernetes services running inside. [Gravity](https://github.com/gravitational/gravity) is the
 recommended way to deploy planet containers.
-
-Compared to [official ways](https://kubernetes.io/docs/setup/) to install and manage a Kubernetes cluster, `planet` is different because:
-
-* Planet creates a "bubble of consistency" for every cluster.
-* Planet packages services running under/alongside Kubernetes.
-* Planet facilitates easier remote updating of itself and Kubernetes.
 
 ## Installation
 
@@ -68,11 +67,6 @@ Commands:
   leader view --leader-key=LEADER-KEY
     Display the IP address of the active master
 ```
-
-## Hacking on Planet
-
-We follow a [Code of Conduct](./CODE_OF_CONDUCT.md). We also have [contributing guidelines](./CONTRIBUTING.md)
-with information about filing bugs and submitting patches.
 
 ### Building (installing from source)
 


### PR DESCRIPTION
The entire gravity project is being shut down at the top of July.

I'm editing the README's of some of the more popular components (planet, satellite) but I probably wont go much further than that.

See https://github.com/gravitational/gravity/pull/2775